### PR TITLE
Make UnitsMenuPage class

### DIFF
--- a/src/vario/buttons.cpp
+++ b/src/vario/buttons.cpp
@@ -10,6 +10,7 @@
 #include "buttons.h"
 #include "power.h"
 #include "display.h"
+#include "pages.h"
 #include "speaker.h"
 #include "settings.h"
 #include "page_menu_units.h"
@@ -49,7 +50,8 @@ void buttons_update(void) {
   uint8_t which_button = buttons_check();
 //  uint8_t button_state = buttons_get_state();  //TODO: delete this line probably
   if (display_getPage() == page_menu_units) {
-    page_menu_units_doButton(which_button, buttons_get_state(), buttons_get_hold_count());
+    bool draw_now = units_page.button_event(which_button, buttons_get_state(), buttons_get_hold_count());
+    if (draw_now) display_update();
   } else if (display_getPage() == page_charging) {
     switch (which_button) {
       case CENTER:

--- a/src/vario/display.cpp
+++ b/src/vario/display.cpp
@@ -9,7 +9,7 @@
 #include "display.h"
 #include "display_tests.h"
 #include "fonts.h"
-#include "page_menu_units.h"
+#include "pages.h"
 
 #include "Leaf_SPI.h"
 #include "gps.h"
@@ -111,7 +111,7 @@ void display_update() {
       display_page_charging();
       break;
     case page_menu_units:
-      display_page_menu_units();
+      units_page.draw();
       break;
   }  
 }

--- a/src/vario/menu_page.h
+++ b/src/vario/menu_page.h
@@ -1,0 +1,17 @@
+#ifndef MENU_PAGE_H
+#define MENU_PAGE_H
+
+class MenuPage {
+  public:
+    // Called whenever a button event occurs
+    //   button: Button to which the event pertains (TODO: change to enum)
+    //   state: New state of button (TODO: change to enum)
+    //   count: (TODO: document)
+    virtual bool button_event(uint8_t button, uint8_t state, uint8_t count) = 0;
+
+    // Called to draw the menu page.
+    // Assumes(?) the screen is already clear.
+    virtual void draw() = 0;
+};
+
+#endif

--- a/src/vario/page_menu_units.cpp
+++ b/src/vario/page_menu_units.cpp
@@ -5,25 +5,15 @@
 #include "fonts.h"
 #include "settings.h"
 
-char label_back[] = "Back";
-char label_alt[] = "Alt:";
-char label_climb[] = "Climb:";
-char label_speed[] = "Speed:";
-char label_dist[] = "Dist:";
-char label_heading[] = "Head:";
-char label_temp[] = "Temp:";
-char label_hours[] = "Time:";
-
-
 char * labels[] = {
-  label_back,
-  label_alt,
-  label_climb,
-  label_speed,
-  label_dist,
-  label_heading,
-  label_temp,
-  label_hours
+  "Back",
+  "Alt:",
+  "Climb:",
+  "Speed:",
+  "Dist:",
+  "Head:",
+  "Temp:",
+  "Time:"
 };
 
 enum units_menu_items { 
@@ -42,7 +32,7 @@ int8_t cursor_position = 0;   // 0 means nothing selected
 uint8_t cursor_max = 7;       // the number of items (0-based) in the enum list above
 
 
-void display_page_menu_units() {
+void UnitsMenuPage::draw() {
   u8g2.firstPage();
   do { 
     // Title(s) 
@@ -148,7 +138,7 @@ void setting_change(int8_t dir) {
   }
 }
 
-void page_menu_units_doButton(uint8_t button, uint8_t state, uint8_t count) {    
+bool UnitsMenuPage::button_event(uint8_t button, uint8_t state, uint8_t count) {    
   switch (button) {
     case UP:
       if (state == RELEASED) cursor_prev();
@@ -166,7 +156,7 @@ void page_menu_units_doButton(uint8_t button, uint8_t state, uint8_t count) {
       if (state == RELEASED) setting_change(0);
       break;    
   }    
-  display_update();   //update display after button push so that the UI reflects any changes immediately
+  return true;   //update display after button push so that the UI reflects any changes immediately
 }
 
 

--- a/src/vario/page_menu_units.h
+++ b/src/vario/page_menu_units.h
@@ -1,12 +1,14 @@
 #ifndef page_menu_units_h
 #define page_menu_units_h
 
+#include <Arduino.h>
+#include "menu_page.h"
 
-
-void display_page_menu_units(void);
-void page_menu_units_doButton(uint8_t button, uint8_t state, uint8_t count);
-
-
+class UnitsMenuPage : public MenuPage {
+  public:
+    bool button_event(uint8_t button, uint8_t state, uint8_t count);
+    void draw();
+};
 
 
 #endif

--- a/src/vario/pages.cpp
+++ b/src/vario/pages.cpp
@@ -1,0 +1,3 @@
+#include "pages.h"
+
+UnitsMenuPage units_page;

--- a/src/vario/pages.h
+++ b/src/vario/pages.h
@@ -1,0 +1,8 @@
+#ifndef PAGES_H
+#define PAGES_H
+
+#include "page_menu_units.h"
+
+extern UnitsMenuPage units_page;
+
+#endif


### PR DESCRIPTION
This PR transforms the logic specific to the units page into a class with a structure that can hopefully be reused.  The page *interface* is defined in MenuPage, and then UnitsMenuPage is a concrete class which implements that interface.  Unlike most classes, only one instance of UnitsMenuPage is expected (there is only one units menu page).

In the future, other pages can be encapsulated using the MenuPage interface and the main controller can just handle MenuPage pointers without knowing anything about which menu page is which.