### PR TITLE
Changed button state and buttons to use enum type rather than int8_t

### DIFF
--- a/src/vario/PageMenuAltimeter.cpp
+++ b/src/vario/PageMenuAltimeter.cpp
@@ -78,21 +78,21 @@ void AltimeterMenuPage::draw() {
 }
 
 
-void AltimeterMenuPage::setting_change(int8_t dir, uint8_t state, uint8_t count) {  
+void AltimeterMenuPage::setting_change(buttons button, button_states state, uint8_t count) {  
   switch (cursor_position) {
 		case cursor_altimeter_trackGPSAlt:
       if (state == RELEASED) settings_toggleBoolNeutral(&ALT_SYNC_GPS);
       break;
     case cursor_altimeter_adjust:
-      if (dir == 0 && count == 1 && state == HELD) {  // if center button held for 1 'action time'
+      if (button == NONE && count == 1 && state == HELD) {  // if center button held for 1 'action time'
         if (settings_matchGPSAlt()) { // successful adjustment of altimeter setting to match GPS altitude
           speaker_playSound(fx_enter);  
         } else {                      // unsuccessful 
           speaker_playSound(fx_cancel);
         }
-      } else if (dir != 0) {
+      } else if (button != NONE) {
         if (state == PRESSED || state == HELD || state == HELD_LONG) {
-          baro_adjustAltSetting(dir, count);
+          baro_adjustAltSetting(button, count);
           speaker_playSound(fx_neutral);
         }
       }

--- a/src/vario/PageMenuAltimeter.cpp
+++ b/src/vario/PageMenuAltimeter.cpp
@@ -84,13 +84,13 @@ void AltimeterMenuPage::setting_change(Button button, ButtonState state, uint8_t
       if (state == RELEASED) settings_toggleBoolNeutral(&ALT_SYNC_GPS);
       break;
     case cursor_altimeter_adjust:
-      if (button == NONE && count == 1 && state == HELD) {  // if center button held for 1 'action time'
+      if (button == Button::NONE && count == 1 && state == HELD) {  // if center button held for 1 'action time'
         if (settings_matchGPSAlt()) { // successful adjustment of altimeter setting to match GPS altitude
           speaker_playSound(fx_enter);  
         } else {                      // unsuccessful 
           speaker_playSound(fx_cancel);
         }
-      } else if (button != NONE) {
+      } else if (button != Button::NONE) {
         if (state == PRESSED || state == HELD || state == HELD_LONG) {
           baro_adjustAltSetting(button, count);
           speaker_playSound(fx_neutral);
@@ -115,15 +115,15 @@ void AltimeterMenuPage::setting_change(Button button, ButtonState state, uint8_t
 // helpful switch constructors to copy-paste as needed:
 /*
 switch (button) {
-  case UP:
+  case Button::UP:
     break;
-  case DOWN:
+  case Button::DOWN:
     break;
-  case LEFT:
+  case Button::LEFT:
     break;
-  case RIGHT:
+  case Button::RIGHT:
     break;
-  case CENTER:
+  case Button::CENTER:
     break;
 */
 

--- a/src/vario/PageMenuAltimeter.cpp
+++ b/src/vario/PageMenuAltimeter.cpp
@@ -78,7 +78,7 @@ void AltimeterMenuPage::draw() {
 }
 
 
-void AltimeterMenuPage::setting_change(Button button, button_states state, uint8_t count) {  
+void AltimeterMenuPage::setting_change(Button button, ButtonState state, uint8_t count) {  
   switch (cursor_position) {
 		case cursor_altimeter_trackGPSAlt:
       if (state == RELEASED) settings_toggleBoolNeutral(&ALT_SYNC_GPS);

--- a/src/vario/PageMenuAltimeter.cpp
+++ b/src/vario/PageMenuAltimeter.cpp
@@ -78,7 +78,7 @@ void AltimeterMenuPage::draw() {
 }
 
 
-void AltimeterMenuPage::setting_change(buttons button, button_states state, uint8_t count) {  
+void AltimeterMenuPage::setting_change(Button button, button_states state, uint8_t count) {  
   switch (cursor_position) {
 		case cursor_altimeter_trackGPSAlt:
       if (state == RELEASED) settings_toggleBoolNeutral(&ALT_SYNC_GPS);

--- a/src/vario/PageMenuAltimeter.h
+++ b/src/vario/PageMenuAltimeter.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include "menu_page.h"
+#include "buttons.h"
 
 class AltimeterMenuPage : public SettingsMenuPage {
   public:
@@ -13,7 +14,7 @@ class AltimeterMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(int8_t dir, uint8_t state, uint8_t count);
+    void setting_change(buttons button, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[3] = {

--- a/src/vario/PageMenuAltimeter.h
+++ b/src/vario/PageMenuAltimeter.h
@@ -14,7 +14,7 @@ class AltimeterMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(Button button, button_states state, uint8_t count);
+    void setting_change(Button button, ButtonState state, uint8_t count);
 
   private:
     static constexpr char * labels[3] = {

--- a/src/vario/PageMenuAltimeter.h
+++ b/src/vario/PageMenuAltimeter.h
@@ -14,7 +14,7 @@ class AltimeterMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(buttons button, button_states state, uint8_t count);
+    void setting_change(Button button, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[3] = {

--- a/src/vario/PageMenuDisplay.cpp
+++ b/src/vario/PageMenuDisplay.cpp
@@ -79,7 +79,7 @@ void DisplayMenuPage::draw() {
   } while ( u8g2.nextPage() ); 
 }
 
-void DisplayMenuPage::setting_change(int8_t dir, uint8_t state, uint8_t count) {
+void DisplayMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
   switch (cursor_position) {
     case cursor_display_contrast:
       if (state == RELEASED && dir != 0) settings_adjustContrast(dir);

--- a/src/vario/PageMenuDisplay.cpp
+++ b/src/vario/PageMenuDisplay.cpp
@@ -79,7 +79,7 @@ void DisplayMenuPage::draw() {
   } while ( u8g2.nextPage() ); 
 }
 
-void DisplayMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
+void DisplayMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
   switch (cursor_position) {
     case cursor_display_contrast:
       if (state == RELEASED && dir != 0) settings_adjustContrast(dir);

--- a/src/vario/PageMenuDisplay.cpp
+++ b/src/vario/PageMenuDisplay.cpp
@@ -82,8 +82,8 @@ void DisplayMenuPage::draw() {
 void DisplayMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
   switch (cursor_position) {
     case cursor_display_contrast:
-      if (state == RELEASED && dir != 0) settings_adjustContrast(dir);
-      else if (state == HELD && dir == 0) settings_adjustContrast(dir);
+      if (state == RELEASED && dir != Button::NONE) settings_adjustContrast(dir);
+      else if (state == HELD && dir == Button::NONE) settings_adjustContrast(dir);
       break;
     case cursor_display_AA:
 
@@ -121,15 +121,15 @@ void DisplayMenuPage::setting_change(Button dir, ButtonState state, uint8_t coun
 // helpful switch constructors to copy-paste as needed:
 /*
 switch (button) {
-  case UP:
+  case Button::UP:
     break;
-  case DOWN:
+  case Button::DOWN:
     break;
-  case LEFT:
+  case Button::LEFT:
     break;
-  case RIGHT:
+  case Button::RIGHT:
     break;
-  case CENTER:
+  case Button::CENTER:
     break;
 */
 

--- a/src/vario/PageMenuDisplay.cpp
+++ b/src/vario/PageMenuDisplay.cpp
@@ -79,7 +79,7 @@ void DisplayMenuPage::draw() {
   } while ( u8g2.nextPage() ); 
 }
 
-void DisplayMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
+void DisplayMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
   switch (cursor_position) {
     case cursor_display_contrast:
       if (state == RELEASED && dir != 0) settings_adjustContrast(dir);

--- a/src/vario/PageMenuDisplay.h
+++ b/src/vario/PageMenuDisplay.h
@@ -13,7 +13,7 @@ class DisplayMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(int8_t dir, uint8_t state, uint8_t count);
+    void setting_change(buttons dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuDisplay.h
+++ b/src/vario/PageMenuDisplay.h
@@ -13,7 +13,7 @@ class DisplayMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(Button dir, button_states state, uint8_t count);
+    void setting_change(Button dir, ButtonState state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuDisplay.h
+++ b/src/vario/PageMenuDisplay.h
@@ -13,7 +13,7 @@ class DisplayMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(buttons dir, button_states state, uint8_t count);
+    void setting_change(Button dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuGPS.cpp
+++ b/src/vario/PageMenuGPS.cpp
@@ -73,7 +73,7 @@ void GPSMenuPage::draw() {
 }
 
 
-void GPSMenuPage::setting_change(int8_t dir, uint8_t state, uint8_t count) {
+void GPSMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
   switch (cursor_position) {
     case cursor_gps_update:
 

--- a/src/vario/PageMenuGPS.cpp
+++ b/src/vario/PageMenuGPS.cpp
@@ -73,7 +73,7 @@ void GPSMenuPage::draw() {
 }
 
 
-void GPSMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
+void GPSMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
   switch (cursor_position) {
     case cursor_gps_update:
 

--- a/src/vario/PageMenuGPS.cpp
+++ b/src/vario/PageMenuGPS.cpp
@@ -73,7 +73,7 @@ void GPSMenuPage::draw() {
 }
 
 
-void GPSMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
+void GPSMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
   switch (cursor_position) {
     case cursor_gps_update:
 

--- a/src/vario/PageMenuGPS.cpp
+++ b/src/vario/PageMenuGPS.cpp
@@ -164,15 +164,15 @@ void GPSMenuPage::drawConstellation(uint8_t x, uint8_t y, uint16_t size) {
 // helpful switch constructors to copy-paste as needed:
 /*
 switch (button) {
-  case UP:
+  case Button::UP:
     break;
-  case DOWN:
+  case Button::DOWN:
     break;
-  case LEFT:
+  case Button::LEFT:
     break;
-  case RIGHT:
+  case Button::RIGHT:
     break;
-  case CENTER:
+  case Button::CENTER:
     break;
 */
 

--- a/src/vario/PageMenuGPS.h
+++ b/src/vario/PageMenuGPS.h
@@ -15,7 +15,7 @@ class GPSMenuPage : public SettingsMenuPage {
     void drawConstellation(uint8_t x, uint8_t y, uint16_t size);
 
   protected:
-    void setting_change(int8_t dir, uint8_t state, uint8_t count);
+    void setting_change(buttons dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[4] = {

--- a/src/vario/PageMenuGPS.h
+++ b/src/vario/PageMenuGPS.h
@@ -15,7 +15,7 @@ class GPSMenuPage : public SettingsMenuPage {
     void drawConstellation(uint8_t x, uint8_t y, uint16_t size);
 
   protected:
-    void setting_change(Button dir, button_states state, uint8_t count);
+    void setting_change(Button dir, ButtonState state, uint8_t count);
 
   private:
     static constexpr char * labels[4] = {

--- a/src/vario/PageMenuGPS.h
+++ b/src/vario/PageMenuGPS.h
@@ -15,7 +15,7 @@ class GPSMenuPage : public SettingsMenuPage {
     void drawConstellation(uint8_t x, uint8_t y, uint16_t size);
 
   protected:
-    void setting_change(buttons dir, button_states state, uint8_t count);
+    void setting_change(Button dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[4] = {

--- a/src/vario/PageMenuLog.cpp
+++ b/src/vario/PageMenuLog.cpp
@@ -94,7 +94,7 @@ void LogMenuPage::draw() {
 }
 
 
-void LogMenuPage::setting_change(int8_t dir, uint8_t state, uint8_t count) {
+void LogMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
   switch (cursor_position) {
     case cursor_log_format:
 

--- a/src/vario/PageMenuLog.cpp
+++ b/src/vario/PageMenuLog.cpp
@@ -94,7 +94,7 @@ void LogMenuPage::draw() {
 }
 
 
-void LogMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
+void LogMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
   switch (cursor_position) {
     case cursor_log_format:
 

--- a/src/vario/PageMenuLog.cpp
+++ b/src/vario/PageMenuLog.cpp
@@ -115,7 +115,7 @@ void LogMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
 
       break;
     case cursor_log_timer:
-      if (dir == 0) {
+      if (dir == Button::NONE) {
         if (state == RELEASED) flightTimer_toggle();
         else if (state == HELD) flightTimer_reset();
       }
@@ -137,15 +137,15 @@ void LogMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
 // helpful switch constructors to copy-paste as needed:
 /*
 switch (button) {
-  case UP:
+  case Button::UP:
     break;
-  case DOWN:
+  case Button::DOWN:
     break;
-  case LEFT:
+  case Button::LEFT:
     break;
-  case RIGHT:
+  case Button::RIGHT:
     break;
-  case CENTER:
+  case Button::CENTER:
     break;
 */
 

--- a/src/vario/PageMenuLog.cpp
+++ b/src/vario/PageMenuLog.cpp
@@ -94,7 +94,7 @@ void LogMenuPage::draw() {
 }
 
 
-void LogMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
+void LogMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
   switch (cursor_position) {
     case cursor_log_format:
 

--- a/src/vario/PageMenuLog.h
+++ b/src/vario/PageMenuLog.h
@@ -13,7 +13,7 @@ class LogMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(int8_t dir, uint8_t state, uint8_t count);
+    void setting_change(buttons dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuLog.h
+++ b/src/vario/PageMenuLog.h
@@ -13,7 +13,7 @@ class LogMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(Button dir, button_states state, uint8_t count);
+    void setting_change(Button dir, ButtonState state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuLog.h
+++ b/src/vario/PageMenuLog.h
@@ -13,7 +13,7 @@ class LogMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(buttons dir, button_states state, uint8_t count);
+    void setting_change(Button dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuMain.cpp
+++ b/src/vario/PageMenuMain.cpp
@@ -164,7 +164,7 @@ void MainMenuPage::menu_item_action(int8_t button) {
   }
 }
 
-bool MainMenuPage::mainMenuButtonEvent(uint8_t button, uint8_t state, uint8_t count) {
+bool MainMenuPage::mainMenuButtonEvent(buttons button, button_states state, uint8_t count) {
   bool redraw = false; // only redraw screen if a UI input changes something
   switch (button) {
     case UP:
@@ -192,7 +192,7 @@ bool MainMenuPage::mainMenuButtonEvent(uint8_t button, uint8_t state, uint8_t co
 }
 
 
-bool MainMenuPage::button_event(uint8_t button, uint8_t state, uint8_t count) {    
+bool MainMenuPage::button_event(buttons button, button_states state, uint8_t count) {    
   bool redraw = false; // only redraw screen if a UI input changes something
   switch (menu_page) {
     case page_menu_main:

--- a/src/vario/PageMenuMain.cpp
+++ b/src/vario/PageMenuMain.cpp
@@ -116,48 +116,48 @@ void MainMenuPage::draw_main_menu() {
 }
 
 
-void MainMenuPage::menu_item_action(int8_t button) {
+void MainMenuPage::menu_item_action(Button button) {
   switch (cursor_position) {    
     case cursor_back:
-      if (button == LEFT || button == CENTER) {
+      if (button == Button::LEFT || button == Button::CENTER) {
         display_turnPage(page_back);
         speaker_playSound(fx_exit);  
-      } else if (button == RIGHT) {   
+      } else if (button == Button::RIGHT) {   
         //display_turnPage(page_next);  // maybe stop at menu, don't allow scrolling around back to first page
       }
       break;
     case cursor_altimeter:
-      if (button == RIGHT || button == CENTER) {
+      if (button == Button::RIGHT || button == Button::CENTER) {
         menu_page = page_menu_altimeter;
       }      
       break;
     case cursor_vario:
-      if (button == RIGHT || button == CENTER) {
+      if (button == Button::RIGHT || button == Button::CENTER) {
         menu_page = page_menu_vario;
       }      
       break;
     case cursor_display:
-      if (button == RIGHT || button == CENTER) {
+      if (button == Button::RIGHT || button == Button::CENTER) {
         menu_page = page_menu_display;
       }
       break;
     case cursor_units:
-      if (button == RIGHT || button == CENTER) {        
+      if (button == Button::RIGHT || button == Button::CENTER) {        
         menu_page = page_menu_units;
       }
       break;
     case cursor_gps:
-      if (button == RIGHT || button == CENTER) {
+      if (button == Button::RIGHT || button == Button::CENTER) {
         menu_page = page_menu_gps;
       }      
       break;
     case cursor_log:
-      if (button == RIGHT || button == CENTER) {
+      if (button == Button::RIGHT || button == Button::CENTER) {
         menu_page = page_menu_log;
       }      
       break;
     case cursor_system:      
-      if (button == RIGHT || button == CENTER) {
+      if (button == Button::RIGHT || button == Button::CENTER) {
         menu_page = page_menu_system;
       }      
       break;
@@ -167,21 +167,21 @@ void MainMenuPage::menu_item_action(int8_t button) {
 bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonState state, uint8_t count) {
   bool redraw = false; // only redraw screen if a UI input changes something
   switch (button) {
-    case UP:
+    case Button::UP:
       if (state == RELEASED) {
         cursor_prev();
         redraw = true;
       }
       break;
-    case DOWN:
+    case Button::DOWN:
       if (state == RELEASED) {
         cursor_next();
         redraw = true;
       }
       break;
-    case LEFT:
-    case RIGHT:
-    case CENTER:
+    case Button::LEFT:
+    case Button::RIGHT:
+    case Button::CENTER:
       if (state == RELEASED) {
         menu_item_action(button);
         redraw = true;
@@ -226,15 +226,15 @@ bool MainMenuPage::button_event(Button button, ButtonState state, uint8_t count)
 // helpful switch constructors to copy-paste as needed:
 /*
 switch (button) {
-  case UP:
+  case Button::UP:
     break;
-  case DOWN:
+  case Button::DOWN:
     break;
-  case LEFT:
+  case Button::LEFT:
     break;
-  case RIGHT:
+  case Button::RIGHT:
     break;
-  case CENTER:
+  case Button::CENTER:
     break;
 */
 

--- a/src/vario/PageMenuMain.cpp
+++ b/src/vario/PageMenuMain.cpp
@@ -164,7 +164,7 @@ void MainMenuPage::menu_item_action(int8_t button) {
   }
 }
 
-bool MainMenuPage::mainMenuButtonEvent(Button button, button_states state, uint8_t count) {
+bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonState state, uint8_t count) {
   bool redraw = false; // only redraw screen if a UI input changes something
   switch (button) {
     case UP:
@@ -192,7 +192,7 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, button_states state, uint8
 }
 
 
-bool MainMenuPage::button_event(Button button, button_states state, uint8_t count) {    
+bool MainMenuPage::button_event(Button button, ButtonState state, uint8_t count) {    
   bool redraw = false; // only redraw screen if a UI input changes something
   switch (menu_page) {
     case page_menu_main:

--- a/src/vario/PageMenuMain.cpp
+++ b/src/vario/PageMenuMain.cpp
@@ -164,7 +164,7 @@ void MainMenuPage::menu_item_action(int8_t button) {
   }
 }
 
-bool MainMenuPage::mainMenuButtonEvent(buttons button, button_states state, uint8_t count) {
+bool MainMenuPage::mainMenuButtonEvent(Button button, button_states state, uint8_t count) {
   bool redraw = false; // only redraw screen if a UI input changes something
   switch (button) {
     case UP:
@@ -192,7 +192,7 @@ bool MainMenuPage::mainMenuButtonEvent(buttons button, button_states state, uint
 }
 
 
-bool MainMenuPage::button_event(buttons button, button_states state, uint8_t count) {    
+bool MainMenuPage::button_event(Button button, button_states state, uint8_t count) {    
   bool redraw = false; // only redraw screen if a UI input changes something
   switch (menu_page) {
     case page_menu_main:

--- a/src/vario/PageMenuMain.h
+++ b/src/vario/PageMenuMain.h
@@ -11,14 +11,14 @@ class MainMenuPage : public MenuPage {
       cursor_position = 0;
       cursor_max = 7;
     }
-    bool button_event(uint8_t button, uint8_t state, uint8_t count);
+    bool button_event(buttons button, button_states state, uint8_t count);
     void draw();
     void backToMainMenu();
     void quitMenu();
 
   private:
     void draw_main_menu();
-    bool mainMenuButtonEvent(uint8_t button, uint8_t state, uint8_t count);
+    bool mainMenuButtonEvent(buttons button, button_states state, uint8_t count);
     void menu_item_action(int8_t dir);
     static constexpr char * labels[8] = {
       "Back",

--- a/src/vario/PageMenuMain.h
+++ b/src/vario/PageMenuMain.h
@@ -11,14 +11,14 @@ class MainMenuPage : public MenuPage {
       cursor_position = 0;
       cursor_max = 7;
     }
-    bool button_event(Button button, button_states state, uint8_t count);
+    bool button_event(Button button, ButtonState state, uint8_t count);
     void draw();
     void backToMainMenu();
     void quitMenu();
 
   private:
     void draw_main_menu();
-    bool mainMenuButtonEvent(Button button, button_states state, uint8_t count);
+    bool mainMenuButtonEvent(Button button, ButtonState state, uint8_t count);
     void menu_item_action(int8_t dir);
     static constexpr char * labels[8] = {
       "Back",

--- a/src/vario/PageMenuMain.h
+++ b/src/vario/PageMenuMain.h
@@ -19,7 +19,7 @@ class MainMenuPage : public MenuPage {
   private:
     void draw_main_menu();
     bool mainMenuButtonEvent(Button button, ButtonState state, uint8_t count);
-    void menu_item_action(int8_t dir);
+    void menu_item_action(Button dir);
     static constexpr char * labels[8] = {
       "Back",
       "Altimeter",

--- a/src/vario/PageMenuMain.h
+++ b/src/vario/PageMenuMain.h
@@ -11,14 +11,14 @@ class MainMenuPage : public MenuPage {
       cursor_position = 0;
       cursor_max = 7;
     }
-    bool button_event(buttons button, button_states state, uint8_t count);
+    bool button_event(Button button, button_states state, uint8_t count);
     void draw();
     void backToMainMenu();
     void quitMenu();
 
   private:
     void draw_main_menu();
-    bool mainMenuButtonEvent(buttons button, button_states state, uint8_t count);
+    bool mainMenuButtonEvent(Button button, button_states state, uint8_t count);
     void menu_item_action(int8_t dir);
     static constexpr char * labels[8] = {
       "Back",

--- a/src/vario/PageMenuSystem.cpp
+++ b/src/vario/PageMenuSystem.cpp
@@ -123,7 +123,7 @@ void SystemMenuPage::draw() {
 }
 
 
-void SystemMenuPage::setting_change(int8_t dir, uint8_t state, uint8_t count) {
+void SystemMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
   bool redraw = false;
   switch (cursor_position) {
     case cursor_system_timezone:

--- a/src/vario/PageMenuSystem.cpp
+++ b/src/vario/PageMenuSystem.cpp
@@ -127,11 +127,11 @@ void SystemMenuPage::setting_change(Button dir, ButtonState state, uint8_t count
   bool redraw = false;
   switch (cursor_position) {
     case cursor_system_timezone:
-      if (state == RELEASED && dir != 0) settings_adjustTimeZone(dir);
-      if (state == HELD && dir == 0) settings_adjustTimeZone(dir);
+      if (state == RELEASED && dir != Button::NONE) settings_adjustTimeZone(dir);
+      if (state == HELD && dir == Button::NONE) settings_adjustTimeZone(dir);
       break;
     case cursor_system_volume:
-      if (state == RELEASED && dir != 0) settings_adjustVolumeSystem(dir);
+      if (state == RELEASED && dir != Button::NONE) settings_adjustVolumeSystem(dir);
       break;
     case cursor_system_poweroff:
       if (state == RELEASED) settings_toggleBoolOnOff(&AUTO_OFF);
@@ -172,15 +172,15 @@ void SystemMenuPage::setting_change(Button dir, ButtonState state, uint8_t count
 // helpful switch constructors to copy-paste as needed:
 /*
 switch (button) {
-  case UP:
+  case Button::UP:
     break;
-  case DOWN:
+  case Button::DOWN:
     break;
-  case LEFT:
+  case Button::LEFT:
     break;
-  case RIGHT:
+  case Button::RIGHT:
     break;
-  case CENTER:
+  case Button::CENTER:
     break;
 */
 

--- a/src/vario/PageMenuSystem.cpp
+++ b/src/vario/PageMenuSystem.cpp
@@ -123,7 +123,7 @@ void SystemMenuPage::draw() {
 }
 
 
-void SystemMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
+void SystemMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
   bool redraw = false;
   switch (cursor_position) {
     case cursor_system_timezone:

--- a/src/vario/PageMenuSystem.cpp
+++ b/src/vario/PageMenuSystem.cpp
@@ -123,7 +123,7 @@ void SystemMenuPage::draw() {
 }
 
 
-void SystemMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
+void SystemMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
   bool redraw = false;
   switch (cursor_position) {
     case cursor_system_timezone:

--- a/src/vario/PageMenuSystem.h
+++ b/src/vario/PageMenuSystem.h
@@ -13,7 +13,7 @@ class SystemMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(int8_t dir, uint8_t state, uint8_t count);
+    void setting_change(buttons dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[9] = {

--- a/src/vario/PageMenuSystem.h
+++ b/src/vario/PageMenuSystem.h
@@ -13,7 +13,7 @@ class SystemMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(Button dir, button_states state, uint8_t count);
+    void setting_change(Button dir, ButtonState state, uint8_t count);
 
   private:
     static constexpr char * labels[9] = {

--- a/src/vario/PageMenuSystem.h
+++ b/src/vario/PageMenuSystem.h
@@ -13,7 +13,7 @@ class SystemMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(buttons dir, button_states state, uint8_t count);
+    void setting_change(Button dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[9] = {

--- a/src/vario/PageMenuUnits.cpp
+++ b/src/vario/PageMenuUnits.cpp
@@ -88,7 +88,7 @@ void UnitsMenuPage::draw() {
 }
 
 
-void UnitsMenuPage::setting_change(int8_t dir, uint8_t state, uint8_t count) {
+void UnitsMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
   switch (cursor_position) {
     case cursor_units_alt:
       if (state == RELEASED) settings_toggleBoolNeutral(&UNITS_alt);

--- a/src/vario/PageMenuUnits.cpp
+++ b/src/vario/PageMenuUnits.cpp
@@ -88,7 +88,7 @@ void UnitsMenuPage::draw() {
 }
 
 
-void UnitsMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {
+void UnitsMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
   switch (cursor_position) {
     case cursor_units_alt:
       if (state == RELEASED) settings_toggleBoolNeutral(&UNITS_alt);

--- a/src/vario/PageMenuUnits.cpp
+++ b/src/vario/PageMenuUnits.cpp
@@ -88,7 +88,7 @@ void UnitsMenuPage::draw() {
 }
 
 
-void UnitsMenuPage::setting_change(Button dir, button_states state, uint8_t count) {
+void UnitsMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
   switch (cursor_position) {
     case cursor_units_alt:
       if (state == RELEASED) settings_toggleBoolNeutral(&UNITS_alt);

--- a/src/vario/PageMenuUnits.cpp
+++ b/src/vario/PageMenuUnits.cpp
@@ -129,15 +129,15 @@ void UnitsMenuPage::setting_change(Button dir, ButtonState state, uint8_t count)
 // helpful switch constructors to copy-paste as needed:
 /*
 switch (button) {
-  case UP:
+  case Button::UP:
     break;
-  case DOWN:
+  case Button::DOWN:
     break;
-  case LEFT:
+  case Button::LEFT:
     break;
-  case RIGHT:
+  case Button::RIGHT:
     break;
-  case CENTER:
+  case Button::CENTER:
     break;
 */
 

--- a/src/vario/PageMenuUnits.h
+++ b/src/vario/PageMenuUnits.h
@@ -13,7 +13,7 @@ class UnitsMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(int8_t dir, uint8_t state, uint8_t count);
+    void setting_change(buttons dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuUnits.h
+++ b/src/vario/PageMenuUnits.h
@@ -13,7 +13,7 @@ class UnitsMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(Button dir, button_states state, uint8_t count);
+    void setting_change(Button dir, ButtonState state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuUnits.h
+++ b/src/vario/PageMenuUnits.h
@@ -13,7 +13,7 @@ class UnitsMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(buttons dir, button_states state, uint8_t count);
+    void setting_change(Button dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuVario.cpp
+++ b/src/vario/PageMenuVario.cpp
@@ -88,7 +88,7 @@ void VarioMenuPage::draw() {
 }
 
 
-void VarioMenuPage::setting_change(int8_t dir, uint8_t state, uint8_t count) {  
+void VarioMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {  
   switch (cursor_position) {
     case cursor_vario_volume:
       if (state == RELEASED) settings_adjustVolumeVario(dir);

--- a/src/vario/PageMenuVario.cpp
+++ b/src/vario/PageMenuVario.cpp
@@ -88,7 +88,7 @@ void VarioMenuPage::draw() {
 }
 
 
-void VarioMenuPage::setting_change(buttons dir, button_states state, uint8_t count) {  
+void VarioMenuPage::setting_change(Button dir, button_states state, uint8_t count) {  
   switch (cursor_position) {
     case cursor_vario_volume:
       if (state == RELEASED) settings_adjustVolumeVario(dir);

--- a/src/vario/PageMenuVario.cpp
+++ b/src/vario/PageMenuVario.cpp
@@ -88,7 +88,7 @@ void VarioMenuPage::draw() {
 }
 
 
-void VarioMenuPage::setting_change(Button dir, button_states state, uint8_t count) {  
+void VarioMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {  
   switch (cursor_position) {
     case cursor_vario_volume:
       if (state == RELEASED) settings_adjustVolumeVario(dir);

--- a/src/vario/PageMenuVario.cpp
+++ b/src/vario/PageMenuVario.cpp
@@ -91,7 +91,8 @@ void VarioMenuPage::draw() {
 void VarioMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {  
   switch (cursor_position) {
     case cursor_vario_volume:
-      if (state == RELEASED) settings_adjustVolumeVario(dir);
+      if (state != RELEASED) return; 
+      settings_adjustVolumeVario(dir);
       break;
     case cursor_vario_sensitive:
       if (state == RELEASED) settings_adjustVarioAverage(dir);
@@ -112,13 +113,13 @@ void VarioMenuPage::setting_change(Button dir, ButtonState state, uint8_t count)
       if (state == RELEASED) settings_adjustSinkAlarm(dir);
       break;
     case cursor_vario_altadj:
-      if (dir == 0 && count == 1 && state == HELD) {  // if center button held for 1 'action time'
+      if (dir == Button::NONE && count == 1 && state == HELD) {  // if center button held for 1 'action time'
         if (settings_matchGPSAlt()) { // successful adjustment of altimeter setting to match GPS altitude
           speaker_playSound(fx_enter);  
         } else {                      // unsuccessful 
           speaker_playSound(fx_cancel);
         }
-      } else if (dir != 0) {
+      } else if (dir != Button::NONE) {
         if (state == PRESSED || state == HELD || state == HELD_LONG) {
           baro_adjustAltSetting(dir, count);
           speaker_playSound(fx_neutral);
@@ -143,15 +144,15 @@ void VarioMenuPage::setting_change(Button dir, ButtonState state, uint8_t count)
 // helpful switch constructors to copy-paste as needed:
 /*
 switch (button) {
-  case UP:
+  case Button::UP:
     break;
-  case DOWN:
+  case Button::DOWN:
     break;
-  case LEFT:
+  case Button::LEFT:
     break;
-  case RIGHT:
+  case Button::RIGHT:
     break;
-  case CENTER:
+  case Button::CENTER:
     break;
 */
 

--- a/src/vario/PageMenuVario.h
+++ b/src/vario/PageMenuVario.h
@@ -13,7 +13,7 @@ class VarioMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(int8_t dir, uint8_t state, uint8_t count);
+    void setting_change(buttons dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuVario.h
+++ b/src/vario/PageMenuVario.h
@@ -13,7 +13,7 @@ class VarioMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(buttons dir, button_states state, uint8_t count);
+    void setting_change(Button dir, button_states state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageMenuVario.h
+++ b/src/vario/PageMenuVario.h
@@ -13,7 +13,7 @@ class VarioMenuPage : public SettingsMenuPage {
     void draw();
 
   protected:
-    void setting_change(Button dir, button_states state, uint8_t count);
+    void setting_change(Button dir, ButtonState state, uint8_t count);
 
   private:
     static constexpr char * labels[8] = {

--- a/src/vario/PageNavigate.cpp
+++ b/src/vario/PageNavigate.cpp
@@ -360,7 +360,7 @@ void navigatePage_draw() {
   
 }
 
-void nav_cursor_move(uint8_t button) {
+void nav_cursor_move(buttons button) {
 	if (button == UP) {
 		navigatePage_cursorPosition--;
 		if (navigatePage_cursorPosition < 0) navigatePage_cursorPosition = navigatePage_cursorMax;
@@ -384,7 +384,7 @@ void nav_cursor_move(uint8_t button) {
 }
 
 
-void navigatePage_button(uint8_t button, uint8_t state, uint8_t count) {
+void navigatePage_button(buttons button, button_states state, uint8_t count) {
 
 	// reset cursor time out count if a button is pushed
 	navigatePage_cursorTimeCount = 0;

--- a/src/vario/PageNavigate.cpp
+++ b/src/vario/PageNavigate.cpp
@@ -38,9 +38,9 @@ uint8_t navigatePage_cursorTimeOut = 8;	// after 8 page draws (4 seconds) reset 
 int16_t destination_selection_index = 0; 
 bool destination_selection_routes_vs_waypoints = true; // start showing routes not waypoints
 
-void navigatePage_destinationSelect(int8_t dir) {
+void navigatePage_destinationSelect(Button dir) {
 	switch (dir) {
-		case -1: 
+		case Button::LEFT: 
 			destination_selection_index--;
 			if (destination_selection_index < 0) {											// if we wrap off the left end
 				if (destination_selection_routes_vs_waypoints) {					// ..and we're showing routes
@@ -63,7 +63,7 @@ void navigatePage_destinationSelect(int8_t dir) {
 
 
 
-		case 1:
+		case Button::RIGHT:
 			destination_selection_index++;
 			if (destination_selection_routes_vs_waypoints) {							// if we're currently showing Routes...				
 				if (destination_selection_index > gpxData.totalRoutes) {		// 		if we're passed the number of Routes we have...					
@@ -85,7 +85,7 @@ void navigatePage_destinationSelect(int8_t dir) {
 				}
 			}
 			break;
-		case 0:
+		case Button::CENTER:
 			if (destination_selection_routes_vs_waypoints) gpx_activateRoute(destination_selection_index);
 			else gpx_activatePoint(destination_selection_index);
 			navigatePage_cursorPosition = cursor_navigatePage_none;
@@ -361,11 +361,11 @@ void navigatePage_draw() {
 }
 
 void nav_cursor_move(Button button) {
-	if (button == UP) {
+	if (button == Button::UP) {
 		navigatePage_cursorPosition--;
 		if (navigatePage_cursorPosition < 0) navigatePage_cursorPosition = navigatePage_cursorMax;
 	}
-	if (button == DOWN) {
+	if (button == Button::DOWN) {
 		navigatePage_cursorPosition++;
   	if (navigatePage_cursorPosition > navigatePage_cursorMax) navigatePage_cursorPosition = 0;
 	}
@@ -392,46 +392,46 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
 	switch (navigatePage_cursorPosition) {
 		case cursor_navigatePage_none:
 			switch(button) {
-				case UP:
-				case DOWN:
+				case Button::UP:
+				case Button::DOWN:
 					if (state == RELEASED) nav_cursor_move(button);     					
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					if (state == RELEASED) {
 						display_turnPage(page_next);
 						speaker_playSound(fx_increase);
 					}
 					break;
-				case LEFT:
+				case Button::LEFT:
 					if (state == RELEASED) {
 						display_turnPage(page_prev);
 						speaker_playSound(fx_decrease);
 					}
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 		case cursor_navigatePage_alt1:
 			switch(button) {
-				case UP:
-				case DOWN:					
+				case Button::UP:
+				case Button::DOWN:					
 					if (state == RELEASED) nav_cursor_move(button);     					
 					break;
-				case LEFT:
+				case Button::LEFT:
 					if (NAVPG_ALT_TYP == altType_MSL && (state == PRESSED || state == HELD || state == HELD_LONG)) {
-          	baro_adjustAltSetting(-1, count);
+          	baro_adjustAltSetting(Button::LEFT, count);
           	speaker_playSound(fx_neutral);
         	}
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					if (NAVPG_ALT_TYP == altType_MSL && (state == PRESSED || state == HELD || state == HELD_LONG)) {
-          	baro_adjustAltSetting(1, count);
+          	baro_adjustAltSetting(Button::RIGHT, count);
           	speaker_playSound(fx_neutral);
         	}
 					break;
-				case CENTER:
-					if (state == RELEASED) settings_adjustDisplayField_navPage_alt(1);
+				case Button::CENTER:
+					if (state == RELEASED) settings_adjustDisplayField_navPage_alt(Button::CENTER);
 					else if (state == HELD && count == 1 && NAVPG_ALT_TYP == altType_MSL)  {
 						if (settings_matchGPSAlt()) { // successful adjustment of altimeter setting to match GPS altitude
           		speaker_playSound(fx_enter);  
@@ -445,18 +445,18 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
 			break;
 		case cursor_navigatePage_waypoint:
 			switch(button) {
-				case UP:
-				case DOWN:
+				case Button::UP:
+				case Button::DOWN:
 					if (state == RELEASED) nav_cursor_move(button);     					
 					break;
-				case LEFT:
-					if (state == RELEASED) navigatePage_destinationSelect(-1);
+				case Button::LEFT:
+					if (state == RELEASED) navigatePage_destinationSelect(Button::LEFT);
 					break;
-				case RIGHT:
-				  if (state == RELEASED) navigatePage_destinationSelect(1);
+				case Button::RIGHT:
+				  if (state == RELEASED) navigatePage_destinationSelect(Button::RIGHT);
 					break;
-				case CENTER:
-					if (state == RELEASED) navigatePage_destinationSelect(0);
+				case Button::CENTER:
+					if (state == RELEASED) navigatePage_destinationSelect(Button::CENTER);
 					if (state == HELD) { 
 						gpx_cancelNav();
 						navigatePage_cursorPosition = cursor_navigatePage_none;
@@ -467,44 +467,44 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
 		/*
 		case cursor_navigatePage_userField1:
 			switch(button) {
-				case UP:
+				case Button::UP:
 					break;
-				case DOWN:
+				case Button::DOWN:
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 		case cursor_navigatePage_userField2:
 			switch(button) {
-				case UP:
+				case Button::UP:
 					break;
-				case DOWN:
+				case Button::DOWN:
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 			*/
 		case cursor_navigatePage_timer:
 			switch(button) {
-				case UP:
-				case DOWN:
+				case Button::UP:
+				case Button::DOWN:
 					if (state == RELEASED) nav_cursor_move(button);     					
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 						if (state == RELEASED) {
 							flightTimer_toggle();
 							navigatePage_cursorPosition = cursor_navigatePage_none;

--- a/src/vario/PageNavigate.cpp
+++ b/src/vario/PageNavigate.cpp
@@ -360,7 +360,7 @@ void navigatePage_draw() {
   
 }
 
-void nav_cursor_move(buttons button) {
+void nav_cursor_move(Button button) {
 	if (button == UP) {
 		navigatePage_cursorPosition--;
 		if (navigatePage_cursorPosition < 0) navigatePage_cursorPosition = navigatePage_cursorMax;
@@ -384,7 +384,7 @@ void nav_cursor_move(buttons button) {
 }
 
 
-void navigatePage_button(buttons button, button_states state, uint8_t count) {
+void navigatePage_button(Button button, button_states state, uint8_t count) {
 
 	// reset cursor time out count if a button is pushed
 	navigatePage_cursorTimeCount = 0;

--- a/src/vario/PageNavigate.cpp
+++ b/src/vario/PageNavigate.cpp
@@ -384,7 +384,7 @@ void nav_cursor_move(Button button) {
 }
 
 
-void navigatePage_button(Button button, button_states state, uint8_t count) {
+void navigatePage_button(Button button, ButtonState state, uint8_t count) {
 
 	// reset cursor time out count if a button is pushed
 	navigatePage_cursorTimeCount = 0;

--- a/src/vario/PageNavigate.h
+++ b/src/vario/PageNavigate.h
@@ -9,7 +9,7 @@
 void navigatePage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void navigatePage_button(uint8_t button, uint8_t state, uint8_t count);
+void navigatePage_button(buttons button, button_states state, uint8_t count);
 
 
 #endif

--- a/src/vario/PageNavigate.h
+++ b/src/vario/PageNavigate.h
@@ -9,7 +9,7 @@
 void navigatePage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void navigatePage_button(buttons button, button_states state, uint8_t count);
+void navigatePage_button(Button button, button_states state, uint8_t count);
 
 
 #endif

--- a/src/vario/PageNavigate.h
+++ b/src/vario/PageNavigate.h
@@ -9,7 +9,7 @@
 void navigatePage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void navigatePage_button(Button button, button_states state, uint8_t count);
+void navigatePage_button(Button button, ButtonState state, uint8_t count);
 
 
 #endif

--- a/src/vario/PageThermal.cpp
+++ b/src/vario/PageThermal.cpp
@@ -137,7 +137,7 @@ void thermalPage_draw() {
   
 }
 
-void cursor_move(uint8_t button) {
+void cursor_move(buttons button) {
 	if (button == UP) {
 		cursor_position--;
 		if (cursor_position < 0) cursor_position = cursor_max;
@@ -149,7 +149,7 @@ void cursor_move(uint8_t button) {
 }
 
 
-void thermalPage_button(uint8_t button, uint8_t state, uint8_t count) {
+void thermalPage_button(buttons button, button_states state, uint8_t count) {
 
 	// reset cursor time out count if a button is pushed
 	cursor_timeCount = 0;

--- a/src/vario/PageThermal.cpp
+++ b/src/vario/PageThermal.cpp
@@ -138,11 +138,11 @@ void thermalPage_draw() {
 }
 
 void cursor_move(Button button) {
-	if (button == UP) {
+	if (button == Button::UP) {
 		cursor_position--;
 		if (cursor_position < 0) cursor_position = cursor_max;
 	}
-	if (button == DOWN) {
+	if (button == Button::DOWN) {
 		cursor_position++;
   	if (cursor_position > cursor_max) cursor_position = 0;
 	}
@@ -157,46 +157,46 @@ void thermalPage_button(Button button, ButtonState state, uint8_t count) {
 	switch (cursor_position) {
 		case cursor_thermalPage_none:
 			switch(button) {
-				case UP:
-				case DOWN:
+				case Button::UP:
+				case Button::DOWN:
 					if (state == RELEASED) cursor_move(button);     					
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					if (state == RELEASED) {
 						display_turnPage(page_next);
 						speaker_playSound(fx_increase);
 					}
 					break;
-				case LEFT:
+				case Button::LEFT:
 					if (state == RELEASED) {
 						display_turnPage(page_prev);
 						speaker_playSound(fx_decrease);
 					}
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 		case cursor_thermalPage_alt1:
 			switch(button) {
-				case UP:
-				case DOWN:
+				case Button::UP:
+				case Button::DOWN:
 					if (state == RELEASED) cursor_move(button);     					
 					break;
-				case LEFT:
+				case Button::LEFT:
 					if (NAVPG_ALT_TYP == altType_MSL && (state == PRESSED || state == HELD || state == HELD_LONG)) {
-          	baro_adjustAltSetting(-1, count);
+          	baro_adjustAltSetting(Button::LEFT, count);
           	speaker_playSound(fx_neutral);
         	}
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					if (NAVPG_ALT_TYP == altType_MSL && (state == PRESSED || state == HELD || state == HELD_LONG)) {
-          	baro_adjustAltSetting(1, count);
+          	baro_adjustAltSetting(Button::RIGHT, count);
           	speaker_playSound(fx_neutral);
         	}
 					break;
-				case CENTER:
-					if (state == RELEASED) settings_adjustDisplayField_thermalPage_alt(1);
+				case Button::CENTER:
+					if (state == RELEASED) settings_adjustDisplayField_thermalPage_alt(Button::CENTER);
 					else if (state == HELD && count == 1 && THMPG_ALT_TYP == altType_MSL)  {
 						if (settings_matchGPSAlt()) { // successful adjustment of altimeter setting to match GPS altitude
           		speaker_playSound(fx_enter);  
@@ -210,58 +210,58 @@ void thermalPage_button(Button button, ButtonState state, uint8_t count) {
 			break;
 		/* case cursor_thermalPage_alt2:
 			switch(button) {
-				case UP:
+				case Button::UP:
 					break;
-				case DOWN:
+				case Button::DOWN:
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 		case cursor_thermalPage_userField1:
 			switch(button) {
-				case UP:
+				case Button::UP:
 					break;
-				case DOWN:
+				case Button::DOWN:
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 		case cursor_thermalPage_userField2:
 			switch(button) {
-				case UP:
+				case Button::UP:
 					break;
-				case DOWN:
+				case Button::DOWN:
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 			*/
 		case cursor_thermalPage_timer:
 			switch(button) {
-				case UP:
-				case DOWN:
+				case Button::UP:
+				case Button::DOWN:
 					if (state == RELEASED) cursor_move(button);     					
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 						if (state == RELEASED) {
 							flightTimer_toggle();
 							cursor_position = cursor_thermalPage_none;

--- a/src/vario/PageThermal.cpp
+++ b/src/vario/PageThermal.cpp
@@ -137,7 +137,7 @@ void thermalPage_draw() {
   
 }
 
-void cursor_move(buttons button) {
+void cursor_move(Button button) {
 	if (button == UP) {
 		cursor_position--;
 		if (cursor_position < 0) cursor_position = cursor_max;
@@ -149,7 +149,7 @@ void cursor_move(buttons button) {
 }
 
 
-void thermalPage_button(buttons button, button_states state, uint8_t count) {
+void thermalPage_button(Button button, button_states state, uint8_t count) {
 
 	// reset cursor time out count if a button is pushed
 	cursor_timeCount = 0;

--- a/src/vario/PageThermal.cpp
+++ b/src/vario/PageThermal.cpp
@@ -149,7 +149,7 @@ void cursor_move(Button button) {
 }
 
 
-void thermalPage_button(Button button, button_states state, uint8_t count) {
+void thermalPage_button(Button button, ButtonState state, uint8_t count) {
 
 	// reset cursor time out count if a button is pushed
 	cursor_timeCount = 0;

--- a/src/vario/PageThermal.h
+++ b/src/vario/PageThermal.h
@@ -9,7 +9,7 @@
 void thermalPage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void thermalPage_button(uint8_t button, uint8_t state, uint8_t count);
+void thermalPage_button(buttons button, button_states state, uint8_t count);
 
 
 #endif

--- a/src/vario/PageThermal.h
+++ b/src/vario/PageThermal.h
@@ -9,7 +9,7 @@
 void thermalPage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void thermalPage_button(buttons button, button_states state, uint8_t count);
+void thermalPage_button(Button button, button_states state, uint8_t count);
 
 
 #endif

--- a/src/vario/PageThermal.h
+++ b/src/vario/PageThermal.h
@@ -9,7 +9,7 @@
 void thermalPage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void thermalPage_button(Button button, button_states state, uint8_t count);
+void thermalPage_button(Button button, ButtonState state, uint8_t count);
 
 
 #endif

--- a/src/vario/PageThermalSimple.cpp
+++ b/src/vario/PageThermalSimple.cpp
@@ -172,7 +172,7 @@ void thermalSimplePage_draw() {
   
 }
 
-void thermalSimple_page_cursor_move(uint8_t button) {
+void thermalSimple_page_cursor_move(buttons button) {
 	if (button == UP) {
 		thermalSimple_page_cursor_position--;
 		if (thermalSimple_page_cursor_position < 0) thermalSimple_page_cursor_position = thermalSimple_page_cursor_max;
@@ -184,7 +184,7 @@ void thermalSimple_page_cursor_move(uint8_t button) {
 }
 
 
-void thermalSimplePage_button(uint8_t button, uint8_t state, uint8_t count) {
+void thermalSimplePage_button(buttons button, button_states state, uint8_t count) {
 
 	// reset cursor time out count if a button is pushed
 	thermalSimple_page_cursor_timeCount = 0;

--- a/src/vario/PageThermalSimple.cpp
+++ b/src/vario/PageThermalSimple.cpp
@@ -173,11 +173,11 @@ void thermalSimplePage_draw() {
 }
 
 void thermalSimple_page_cursor_move(Button button) {
-	if (button == UP) {
+	if (button == Button::UP) {
 		thermalSimple_page_cursor_position--;
 		if (thermalSimple_page_cursor_position < 0) thermalSimple_page_cursor_position = thermalSimple_page_cursor_max;
 	}
-	if (button == DOWN) {
+	if (button == Button::DOWN) {
 		thermalSimple_page_cursor_position++;
   	if (thermalSimple_page_cursor_position > thermalSimple_page_cursor_max) thermalSimple_page_cursor_position = 0;
 	}
@@ -192,46 +192,46 @@ void thermalSimplePage_button(Button button, ButtonState state, uint8_t count) {
 	switch (thermalSimple_page_cursor_position) {
 		case cursor_thermalSimplePage_none:
 			switch(button) {
-				case UP:
-				case DOWN:
+				case Button::UP:
+				case Button::DOWN:
 					if (state == RELEASED) thermalSimple_page_cursor_move(button);     					
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					if (state == RELEASED) {
 						display_turnPage(page_next);
 						speaker_playSound(fx_increase);
 					}
 					break;
-				case LEFT:
+				case Button::LEFT:
 					if (state == RELEASED) {
 						display_turnPage(page_prev);
 						speaker_playSound(fx_decrease);
 					}
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 		case cursor_thermalSimplePage_alt1:
 			switch(button) {
-				case UP:
-				case DOWN:
+				case Button::UP:
+				case Button::DOWN:
 					if (state == RELEASED) thermalSimple_page_cursor_move(button);     					
 					break;
-				case LEFT:
+				case Button::LEFT:
 					if (NAVPG_ALT_TYP == altType_MSL && (state == PRESSED || state == HELD || state == HELD_LONG)) {
-          	baro_adjustAltSetting(-1, count);
+          	baro_adjustAltSetting(Button::LEFT, count);
           	speaker_playSound(fx_neutral);
         	}
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					if (NAVPG_ALT_TYP == altType_MSL && (state == PRESSED || state == HELD || state == HELD_LONG)) {
-          	baro_adjustAltSetting(1, count);
+          	baro_adjustAltSetting(Button::RIGHT, count);
           	speaker_playSound(fx_neutral);
         	}
 					break;
-				case CENTER:
-					if (state == RELEASED) settings_adjustDisplayField_thermalPage_alt(1);
+				case Button::CENTER:
+					if (state == RELEASED) settings_adjustDisplayField_thermalPage_alt(Button::CENTER);
 					else if (state == HELD && count == 1 && THMPG_ALT_TYP == altType_MSL)  {
 						if (settings_matchGPSAlt()) { // successful adjustment of altimeter setting to match GPS altitude
           		speaker_playSound(fx_enter);  
@@ -245,58 +245,58 @@ void thermalSimplePage_button(Button button, ButtonState state, uint8_t count) {
 			break;
 		/* case cursor_thermalSimplePage_alt2:
 			switch(button) {
-				case UP:
+				case Button::UP:
 					break;
-				case DOWN:
+				case Button::DOWN:
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 		case cursor_thermalSimplePage_userField1:
 			switch(button) {
-				case UP:
+				case Button::UP:
 					break;
-				case DOWN:
+				case Button::DOWN:
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 		case cursor_thermalSimplePage_userField2:
 			switch(button) {
-				case UP:
+				case Button::UP:
 					break;
-				case DOWN:
+				case Button::DOWN:
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 					break;
 			}
 			break;
 			*/
 		case cursor_thermalSimplePage_timer:
 			switch(button) {
-				case UP:
-				case DOWN:
+				case Button::UP:
+				case Button::DOWN:
 					if (state == RELEASED) thermalSimple_page_cursor_move(button);     					
 					break;
-				case LEFT:
+				case Button::LEFT:
 					break;
-				case RIGHT:
+				case Button::RIGHT:
 					break;
-				case CENTER:
+				case Button::CENTER:
 						if (state == RELEASED) {
 							flightTimer_toggle();
 							thermalSimple_page_cursor_position = cursor_thermalSimplePage_none;

--- a/src/vario/PageThermalSimple.cpp
+++ b/src/vario/PageThermalSimple.cpp
@@ -184,7 +184,7 @@ void thermalSimple_page_cursor_move(Button button) {
 }
 
 
-void thermalSimplePage_button(Button button, button_states state, uint8_t count) {
+void thermalSimplePage_button(Button button, ButtonState state, uint8_t count) {
 
 	// reset cursor time out count if a button is pushed
 	thermalSimple_page_cursor_timeCount = 0;

--- a/src/vario/PageThermalSimple.cpp
+++ b/src/vario/PageThermalSimple.cpp
@@ -172,7 +172,7 @@ void thermalSimplePage_draw() {
   
 }
 
-void thermalSimple_page_cursor_move(buttons button) {
+void thermalSimple_page_cursor_move(Button button) {
 	if (button == UP) {
 		thermalSimple_page_cursor_position--;
 		if (thermalSimple_page_cursor_position < 0) thermalSimple_page_cursor_position = thermalSimple_page_cursor_max;
@@ -184,7 +184,7 @@ void thermalSimple_page_cursor_move(buttons button) {
 }
 
 
-void thermalSimplePage_button(buttons button, button_states state, uint8_t count) {
+void thermalSimplePage_button(Button button, button_states state, uint8_t count) {
 
 	// reset cursor time out count if a button is pushed
 	thermalSimple_page_cursor_timeCount = 0;

--- a/src/vario/PageThermalSimple.h
+++ b/src/vario/PageThermalSimple.h
@@ -9,7 +9,7 @@
 void thermalSimplePage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void thermalSimplePage_button(uint8_t button, uint8_t state, uint8_t count);
+void thermalSimplePage_button(buttons button, button_states state, uint8_t count);
 
 
 #endif

--- a/src/vario/PageThermalSimple.h
+++ b/src/vario/PageThermalSimple.h
@@ -9,7 +9,7 @@
 void thermalSimplePage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void thermalSimplePage_button(buttons button, button_states state, uint8_t count);
+void thermalSimplePage_button(Button button, button_states state, uint8_t count);
 
 
 #endif

--- a/src/vario/PageThermalSimple.h
+++ b/src/vario/PageThermalSimple.h
@@ -9,7 +9,7 @@
 void thermalSimplePage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void thermalSimplePage_button(Button button, button_states state, uint8_t count);
+void thermalSimplePage_button(Button button, ButtonState state, uint8_t count);
 
 
 #endif

--- a/src/vario/baro.cpp
+++ b/src/vario/baro.cpp
@@ -8,6 +8,7 @@
 #include "settings.h"
 #include "Leaf_I2C.h"
 #include "tempRH.h"
+#include "buttons.h"
 
 #define DEBUG_BARO 0  // flag for printing serial debugging messages
 
@@ -64,13 +65,13 @@
   int64_t SENS2;
 
 
-  void baro_adjustAltSetting(int8_t dir, uint8_t count) {
+  void baro_adjustAltSetting(Button dir, uint8_t count) {
     float increase = .001;              //     
     if (count >= 1) increase *= 5;
     if (count >= 8) increase *= 4;
 
-    if (dir >= 1) baro.altimeterSetting += increase;
-    else if (dir <= -1) baro.altimeterSetting -= increase;	
+    if (dir == Button::RIGHT) baro.altimeterSetting += increase;
+    else if (dir == Button::LEFT) baro.altimeterSetting -= increase;	
     ALT_SETTING = baro.altimeterSetting;
   }
 

--- a/src/vario/baro.h
+++ b/src/vario/baro.h
@@ -10,6 +10,7 @@
 
 #include <Arduino.h>
 #include "Leaf_SPI.h"
+#include "buttons.h"
 
 // Sensor I2C address
 #define ADDR_BARO 0x77
@@ -55,7 +56,7 @@ extern BARO baro;
 	void baro_filterPressure(void);
 	void baro_calculateAlt(void);
 	void baro_updateClimb(void);	
-	void baro_adjustAltSetting(int8_t dir, uint8_t count);
+	void baro_adjustAltSetting(Button dir, uint8_t count);
 
 // Converstion functions
 	int32_t baro_altToUnits(int32_t alt_input, bool units_feet);  

--- a/src/vario/buttons.cpp
+++ b/src/vario/buttons.cpp
@@ -23,14 +23,14 @@
 
 
 //button debouncing 
-uint8_t button_debounce_last = NONE;
+buttons button_debounce_last = NONE;
 uint32_t button_debounce_time = 5;    // time in ms for stabilized button state before returning the button press
 uint32_t button_time_initial = 0;
 uint32_t button_time_elapsed = 0;
 
 //button actions
-uint8_t button_last = NONE;
-uint8_t button_state = NO_STATE;
+buttons button_last = NONE;
+button_states button_state = NO_STATE;
 bool button_everHeld = false;   // in a single button-push event, track if it was ever held long enough to reach the "HELD" or "HELD_LONG" states (no we know not to also take action when it is released)
 uint16_t button_min_hold_time = 800;  // time in ms to count a button as "held down"
 uint16_t button_max_hold_time = 3500; // time in ms to start further actions on long-holds
@@ -40,7 +40,7 @@ uint16_t button_hold_action_time_elapsed = 0; // counting time between 'action s
 uint16_t button_hold_action_time_limit = 500; // time in ms required between "action steps" while holding the button
 uint16_t button_hold_counter = 0;
 
-uint8_t buttons_init(void) {
+buttons buttons_init(void) {
 
   //configure pins
   pinMode(BUTTON_PIN_UP, INPUT_PULLDOWN);
@@ -49,14 +49,14 @@ uint8_t buttons_init(void) {
   pinMode(BUTTON_PIN_RIGHT, INPUT_PULLDOWN);
   pinMode(BUTTON_PIN_CENTER, INPUT_PULLDOWN);
 
-  uint8_t button = buttons_inspectPins();
+  auto button = buttons_inspectPins();
   return button;
 }
 
-uint8_t buttons_update(void) {
+buttons buttons_update(void) {
 
-  uint8_t which_button = buttons_check();  
-  uint8_t button_state = buttons_get_state();
+  buttons which_button = buttons_check();  
+  button_states button_state = buttons_get_state();
   if(which_button == NONE || button_state == NO_STATE) return which_button;  // don't take any action if no button
   //TODO: not jumping out of this function on NO_STATE was causing speaker issues... investigate!
     
@@ -175,7 +175,7 @@ uint8_t buttons_update(void) {
   return which_button;
 }
 
-uint8_t buttons_get_state(void) {
+button_states buttons_get_state(void) {
   return button_state;
 }
 
@@ -187,9 +187,9 @@ uint16_t buttons_get_hold_count(void) {
 
 
 // the recurring call to see if user is pressing buttons.  Handles debounce and button state changes
-uint8_t buttons_check(void) {
+buttons buttons_check(void) {
   button_state = NO_STATE;            // assume no_state on this pass, we'll update if necessary as we go
-  uint8_t button = buttons_debounce(buttons_inspectPins());  // check if we have a button press in a stable state
+  auto button = buttons_debounce(buttons_inspectPins());  // check if we have a button press in a stable state
 
   // reset and exit if bouncing
   if (button == BOUNCE) {
@@ -296,8 +296,8 @@ Serial.println(button_hold_counter);
 }
 
 // check the state of the button hardware pins (this is pulled out as a separate function so we can use this for a one-time check at startup)
-uint8_t buttons_inspectPins(void) {
-  uint8_t button = NONE;
+buttons buttons_inspectPins(void) {
+  buttons button = NONE;
   if      (digitalRead(BUTTON_PIN_CENTER) == HIGH) button = CENTER;
   else if (digitalRead(BUTTON_PIN_DOWN)   == HIGH) button = DOWN;
   else if (digitalRead(BUTTON_PIN_LEFT)   == HIGH) button = LEFT;
@@ -307,7 +307,7 @@ uint8_t buttons_inspectPins(void) {
 }
 
 // check for a minimal stable time before asserting that a button has been pressed or released
-uint8_t buttons_debounce(uint8_t button) {  
+buttons buttons_debounce(buttons button) {  
   if (button != button_debounce_last) {                   // if this is a new button state
     button_time_initial = millis();                       // capture the initial start time
     button_time_elapsed = 0;                              // and reset the elapsed time

--- a/src/vario/buttons.cpp
+++ b/src/vario/buttons.cpp
@@ -23,13 +23,13 @@
 
 
 //button debouncing 
-Button button_debounce_last = NONE;
+Button button_debounce_last = Button::NONE;
 uint32_t button_debounce_time = 5;    // time in ms for stabilized button state before returning the button press
 uint32_t button_time_initial = 0;
 uint32_t button_time_elapsed = 0;
 
 //button actions
-Button button_last = NONE;
+Button button_last = Button::NONE;
 ButtonState button_state = NO_STATE;
 bool button_everHeld = false;   // in a single button-push event, track if it was ever held long enough to reach the "HELD" or "HELD_LONG" states (no we know not to also take action when it is released)
 uint16_t button_min_hold_time = 800;  // time in ms to count a button as "held down"
@@ -57,7 +57,7 @@ Button buttons_update(void) {
 
   Button which_button = buttons_check();  
   ButtonState button_state = buttons_get_state();
-  if(which_button == NONE || button_state == NO_STATE) return which_button;  // don't take any action if no button
+  if(which_button == Button::NONE || button_state == NO_STATE) return which_button;  // don't take any action if no button
   //TODO: not jumping out of this function on NO_STATE was causing speaker issues... investigate!
     
   power_resetAutoOffCounter();                // pressing any button should reset the auto-off counter
@@ -81,7 +81,7 @@ Button buttons_update(void) {
 
   } else if (display_getPage() == page_charging) {
     switch (which_button) {
-      case CENTER:
+      case Button::CENTER:
         if (button_state == HELD && button_hold_counter == 1) {          
           display_clear();          
           display_setPage(page_thermalSimple);
@@ -89,7 +89,7 @@ Button buttons_update(void) {
           power_switchToOnState();
         }
         break;
-      case UP:
+      case Button::UP:
         switch (button_state) {
           case RELEASED:
             break;
@@ -100,7 +100,7 @@ Button buttons_update(void) {
             break;
         }
         break;
-      case DOWN:
+      case Button::DOWN:
         switch (button_state) {
           case RELEASED:            
             break;
@@ -113,7 +113,7 @@ Button buttons_update(void) {
     }
   } else { // NOT CHARGING PAGE (i.e., our satellites test page)
     switch (which_button) {
-      case CENTER:
+      case Button::CENTER:
         switch (button_state) {
           case HELD:
             if (button_hold_counter == 1) {
@@ -121,7 +121,7 @@ Button buttons_update(void) {
               speaker_playSound(fx_exit);
               delay(600);
               power_shutdown();
-              while(buttons_inspectPins() == CENTER) {} // freeze here until user lets go of power button
+              while(buttons_inspectPins() == Button::CENTER) {} // freeze here until user lets go of power button
               display_setPage(page_charging);              
             }
             break;
@@ -130,13 +130,13 @@ Button buttons_update(void) {
             break;
         }      
         break;
-      case RIGHT:
+      case Button::RIGHT:
         if (button_state == RELEASED) {
           display_turnPage(page_next);
           speaker_playSound(fx_increase);
         }
         break;
-      case LEFT:
+      case Button::LEFT:
         /* Don't allow turning page further to the left
         if (button_state == RELEASED) {
           display_turnPage(page_prev);
@@ -144,29 +144,29 @@ Button buttons_update(void) {
         }
         */
         break;
-      case UP:
+      case Button::UP:
         switch (button_state) {
           case RELEASED:
-            baro_adjustAltSetting(1, 0);
+            baro_adjustAltSetting(Button::RIGHT, 0);
             break;
           case HELD:
-            baro_adjustAltSetting(1, 1);
+            baro_adjustAltSetting(Button::RIGHT, 1);
             break;
           case HELD_LONG:
-            baro_adjustAltSetting(1, 10);
+            baro_adjustAltSetting(Button::RIGHT, 10);
             break;
         }
         break;
-      case DOWN:
+      case Button::DOWN:
         switch (button_state) {
           case RELEASED:
-            baro_adjustAltSetting(-1, 0);            
+            baro_adjustAltSetting(Button::LEFT, 0);            
             break;
           case HELD:
-            baro_adjustAltSetting(-1, 1) ;
+            baro_adjustAltSetting(Button::LEFT, 1) ;
             break;
           case HELD_LONG:
-            baro_adjustAltSetting(-1, 10);
+            baro_adjustAltSetting(Button::LEFT, 10);
             break;
         }
         break;
@@ -192,9 +192,9 @@ Button buttons_check(void) {
   auto button = buttons_debounce(buttons_inspectPins());  // check if we have a button press in a stable state
 
   // reset and exit if bouncing
-  if (button == BOUNCE) {
+  if (button == Button::BOUNCE) {
     button_hold_counter = 0;
-    return NONE;
+    return Button::NONE;
   }
 
   // if we have a state change (low to high or high to low)
@@ -202,7 +202,7 @@ Button buttons_check(void) {
 
     button_hold_counter = 0;  // reset hold counter because button changed -- which means it's not being held
 
-    if (button != NONE) {     // if not-none, we have a pressed button!
+    if (button != Button::NONE) {     // if not-none, we have a pressed button!
       button_state = PRESSED;       
     } else {                  // if it IS none, we have a just-released button
       if (!button_everHeld)  { // we only want to report a released button if it wasn't already held before.  This prevents accidental immediate 'release' button actions when you let go of a held button
@@ -212,7 +212,7 @@ Button buttons_check(void) {
       button_everHeld = false;    // we can reset this now
     }
   // otherwise we have a non-state change (button is held)
-  } else if (button != NONE) {
+  } else if (button != Button::NONE) {
     if (button_time_elapsed >= button_max_hold_time) {
       button_state = HELD_LONG;
     } else if (button_time_elapsed >= button_min_hold_time) {
@@ -246,22 +246,22 @@ Serial.println(button_hold_counter);
 
   if(button_state != NO_STATE) {
     switch(button) {
-      case CENTER:
+      case Button::CENTER:
         Serial.print("button: CENTER");
         break;
-      case LEFT:
+      case Button::LEFT:
         Serial.print("button: LEFT  ");
         break;
-      case RIGHT:
+      case Button::RIGHT:
         Serial.print("button: RIGHT ");
         break;
-      case UP:
+      case Button::UP:
         Serial.print("button: UP    ");
         break;
-      case DOWN:
+      case Button::DOWN:
         Serial.print("button: DOWN  ");
         break;
-      case NONE: 
+      case Button::NONE: 
         Serial.print("button: NONE  ");     
         break;
     }
@@ -288,7 +288,7 @@ Serial.println(button_hold_counter);
   //save button to track for next time.
   // ..if state is RELEASED, then button_last should be 'NONE', since we're seeing the falling edge of the previous button press
   if (button_state == RELEASED) {
-    button_last = NONE;
+    button_last = Button::NONE;
   } else {
     button_last = button;
   }
@@ -297,12 +297,12 @@ Serial.println(button_hold_counter);
 
 // check the state of the button hardware pins (this is pulled out as a separate function so we can use this for a one-time check at startup)
 Button buttons_inspectPins(void) {
-  Button button = NONE;
-  if      (digitalRead(BUTTON_PIN_CENTER) == HIGH) button = CENTER;
-  else if (digitalRead(BUTTON_PIN_DOWN)   == HIGH) button = DOWN;
-  else if (digitalRead(BUTTON_PIN_LEFT)   == HIGH) button = LEFT;
-  else if (digitalRead(BUTTON_PIN_RIGHT)  == HIGH) button = RIGHT;
-  else if (digitalRead(BUTTON_PIN_UP)     == HIGH) button = UP;   
+  Button button = Button::NONE;
+  if      (digitalRead(BUTTON_PIN_CENTER) == HIGH) button = Button::CENTER;
+  else if (digitalRead(BUTTON_PIN_DOWN)   == HIGH) button = Button::DOWN;
+  else if (digitalRead(BUTTON_PIN_LEFT)   == HIGH) button = Button::LEFT;
+  else if (digitalRead(BUTTON_PIN_RIGHT)  == HIGH) button = Button::RIGHT;
+  else if (digitalRead(BUTTON_PIN_UP)     == HIGH) button = Button::UP;   
   return button;
 }
 
@@ -318,7 +318,7 @@ Button buttons_debounce(Button button) {
       return button;
     }
   }
-  return BOUNCE;
+  return Button::BOUNCE;
 }
 
 

--- a/src/vario/buttons.cpp
+++ b/src/vario/buttons.cpp
@@ -30,7 +30,7 @@ uint32_t button_time_elapsed = 0;
 
 //button actions
 Button button_last = NONE;
-button_states button_state = NO_STATE;
+ButtonState button_state = NO_STATE;
 bool button_everHeld = false;   // in a single button-push event, track if it was ever held long enough to reach the "HELD" or "HELD_LONG" states (no we know not to also take action when it is released)
 uint16_t button_min_hold_time = 800;  // time in ms to count a button as "held down"
 uint16_t button_max_hold_time = 3500; // time in ms to start further actions on long-holds
@@ -56,7 +56,7 @@ Button buttons_init(void) {
 Button buttons_update(void) {
 
   Button which_button = buttons_check();  
-  button_states button_state = buttons_get_state();
+  ButtonState button_state = buttons_get_state();
   if(which_button == NONE || button_state == NO_STATE) return which_button;  // don't take any action if no button
   //TODO: not jumping out of this function on NO_STATE was causing speaker issues... investigate!
     
@@ -175,7 +175,7 @@ Button buttons_update(void) {
   return which_button;
 }
 
-button_states buttons_get_state(void) {
+ButtonState buttons_get_state(void) {
   return button_state;
 }
 

--- a/src/vario/buttons.cpp
+++ b/src/vario/buttons.cpp
@@ -2,7 +2,7 @@
  * buttons.cpp
  *
  * 5-way joystick switch (UP DOWN LEFT RIGHT CENTER)
- * Buttons are active-high, via resistor dividers fed from "SYSPOWER", which is typically 4.4V (supply from Battery Charger under USB power) or Battery voltage (when no USB power is applied)
+ * Button are active-high, via resistor dividers fed from "SYSPOWER", which is typically 4.4V (supply from Battery Charger under USB power) or Battery voltage (when no USB power is applied)
  * Use internal pull-down resistors on button pins 
  *
  */
@@ -23,13 +23,13 @@
 
 
 //button debouncing 
-buttons button_debounce_last = NONE;
+Button button_debounce_last = NONE;
 uint32_t button_debounce_time = 5;    // time in ms for stabilized button state before returning the button press
 uint32_t button_time_initial = 0;
 uint32_t button_time_elapsed = 0;
 
 //button actions
-buttons button_last = NONE;
+Button button_last = NONE;
 button_states button_state = NO_STATE;
 bool button_everHeld = false;   // in a single button-push event, track if it was ever held long enough to reach the "HELD" or "HELD_LONG" states (no we know not to also take action when it is released)
 uint16_t button_min_hold_time = 800;  // time in ms to count a button as "held down"
@@ -40,7 +40,7 @@ uint16_t button_hold_action_time_elapsed = 0; // counting time between 'action s
 uint16_t button_hold_action_time_limit = 500; // time in ms required between "action steps" while holding the button
 uint16_t button_hold_counter = 0;
 
-buttons buttons_init(void) {
+Button buttons_init(void) {
 
   //configure pins
   pinMode(BUTTON_PIN_UP, INPUT_PULLDOWN);
@@ -53,9 +53,9 @@ buttons buttons_init(void) {
   return button;
 }
 
-buttons buttons_update(void) {
+Button buttons_update(void) {
 
-  buttons which_button = buttons_check();  
+  Button which_button = buttons_check();  
   button_states button_state = buttons_get_state();
   if(which_button == NONE || button_state == NO_STATE) return which_button;  // don't take any action if no button
   //TODO: not jumping out of this function on NO_STATE was causing speaker issues... investigate!
@@ -187,7 +187,7 @@ uint16_t buttons_get_hold_count(void) {
 
 
 // the recurring call to see if user is pressing buttons.  Handles debounce and button state changes
-buttons buttons_check(void) {
+Button buttons_check(void) {
   button_state = NO_STATE;            // assume no_state on this pass, we'll update if necessary as we go
   auto button = buttons_debounce(buttons_inspectPins());  // check if we have a button press in a stable state
 
@@ -296,8 +296,8 @@ Serial.println(button_hold_counter);
 }
 
 // check the state of the button hardware pins (this is pulled out as a separate function so we can use this for a one-time check at startup)
-buttons buttons_inspectPins(void) {
-  buttons button = NONE;
+Button buttons_inspectPins(void) {
+  Button button = NONE;
   if      (digitalRead(BUTTON_PIN_CENTER) == HIGH) button = CENTER;
   else if (digitalRead(BUTTON_PIN_DOWN)   == HIGH) button = DOWN;
   else if (digitalRead(BUTTON_PIN_LEFT)   == HIGH) button = LEFT;
@@ -307,7 +307,7 @@ buttons buttons_inspectPins(void) {
 }
 
 // check for a minimal stable time before asserting that a button has been pressed or released
-buttons buttons_debounce(buttons button) {  
+Button buttons_debounce(Button button) {  
   if (button != button_debounce_last) {                   // if this is a new button state
     button_time_initial = millis();                       // capture the initial start time
     button_time_elapsed = 0;                              // and reset the elapsed time

--- a/src/vario/buttons.h
+++ b/src/vario/buttons.h
@@ -1,37 +1,50 @@
-#ifndef buttons_h
-#define buttons_h
+#pragma once
 
 #include <Arduino.h>
 
-
-//Pinout for Leaf V3.2.0
-#define BUTTON_PIN_CENTER  2  // INPUT
-#define BUTTON_PIN_LEFT    3  // INPUT
-#define BUTTON_PIN_DOWN    4  // INPUT
-#define BUTTON_PIN_UP      5  // INPUT
-#define BUTTON_PIN_RIGHT   6 // INPUT
+// Pinout for Leaf V3.2.0
+#define BUTTON_PIN_CENTER 2 // INPUT
+#define BUTTON_PIN_LEFT 3   // INPUT
+#define BUTTON_PIN_DOWN 4   // INPUT
+#define BUTTON_PIN_UP 5     // INPUT
+#define BUTTON_PIN_RIGHT 6  // INPUT
 
 /*
 //Pinout for Breadboard
-#define BUTTON_PIN_UP     40  
+#define BUTTON_PIN_UP     40
 #define BUTTON_PIN_DOWN   38
 #define BUTTON_PIN_LEFT   39
 #define BUTTON_PIN_RIGHT  42
 #define BUTTON_PIN_CENTER 41
 */
 
-enum buttons {NONE, UP, DOWN, LEFT, RIGHT, CENTER, BOUNCE};
-enum button_states {NO_STATE, PRESSED, RELEASED, HELD, HELD_LONG};
+// D pad button states.
+// NOTE:  Left is -1 as to make casting to an int for settings easier
+enum buttons : int8_t
+{
+    NONE = 0,
+    LEFT = -1,
+    RIGHT = 1,
+    UP = 2,
+    DOWN = 3,
+    CENTER = 4,
+    BOUNCE = 5
+};
+enum button_states : uint8_t
+{
+    NO_STATE,
+    PRESSED,
+    RELEASED,
+    HELD,
+    HELD_LONG
+};
 
-uint8_t buttons_init(void);
+buttons buttons_init(void);
 
-uint8_t buttons_check(void);
-uint8_t buttons_inspectPins(void);
-uint8_t buttons_debounce(uint8_t button);
-uint8_t buttons_get_state(void);
+buttons buttons_check(void);
+buttons buttons_inspectPins(void);
+buttons buttons_debounce(buttons button);
+button_states buttons_get_state(void);
 uint16_t buttons_get_hold_count(void);
 
-uint8_t buttons_update(void); // the main task of checking and handling button pushes
-
-
-#endif 
+buttons buttons_update(void); // the main task of checking and handling button pushes

--- a/src/vario/buttons.h
+++ b/src/vario/buttons.h
@@ -30,7 +30,7 @@ enum Button : int8_t
     CENTER = 4,
     BOUNCE = 5
 };
-enum button_states : uint8_t
+enum ButtonState : uint8_t
 {
     NO_STATE,
     PRESSED,
@@ -44,7 +44,7 @@ Button buttons_init(void);
 Button buttons_check(void);
 Button buttons_inspectPins(void);
 Button buttons_debounce(Button button);
-button_states buttons_get_state(void);
+ButtonState buttons_get_state(void);
 uint16_t buttons_get_hold_count(void);
 
 Button buttons_update(void); // the main task of checking and handling button pushes

--- a/src/vario/buttons.h
+++ b/src/vario/buttons.h
@@ -20,17 +20,17 @@
 
 // D pad button states.
 // NOTE:  Left is -1 as to make casting to an int for settings easier
-enum Button : int8_t
+enum Button
 {
-    NONE = 0,
-    LEFT = -1,
-    RIGHT = 1,
-    UP = 2,
-    DOWN = 3,
-    CENTER = 4,
-    BOUNCE = 5
+    NONE,
+    LEFT,
+    RIGHT,
+    UP,
+    DOWN,
+    CENTER,
+    BOUNCE
 };
-enum ButtonState : uint8_t
+enum ButtonState
 {
     NO_STATE,
     PRESSED,

--- a/src/vario/buttons.h
+++ b/src/vario/buttons.h
@@ -3,11 +3,11 @@
 #include <Arduino.h>
 
 // Pinout for Leaf V3.2.0
-#define BUTTON_PIN_CENTER 2 // INPUT
-#define BUTTON_PIN_LEFT 3   // INPUT
-#define BUTTON_PIN_DOWN 4   // INPUT
-#define BUTTON_PIN_UP 5     // INPUT
-#define BUTTON_PIN_RIGHT 6  // INPUT
+#define BUTTON_PIN_CENTER 2  // INPUT
+#define BUTTON_PIN_LEFT 3    // INPUT
+#define BUTTON_PIN_DOWN 4    // INPUT
+#define BUTTON_PIN_UP 5      // INPUT
+#define BUTTON_PIN_RIGHT 6   // INPUT
 
 /*
 //Pinout for Breadboard
@@ -20,24 +20,8 @@
 
 // D pad button states.
 // NOTE:  Left is -1 as to make casting to an int for settings easier
-enum Button
-{
-    NONE,
-    LEFT,
-    RIGHT,
-    UP,
-    DOWN,
-    CENTER,
-    BOUNCE
-};
-enum ButtonState
-{
-    NO_STATE,
-    PRESSED,
-    RELEASED,
-    HELD,
-    HELD_LONG
-};
+enum class Button { NONE, UP, DOWN, LEFT, RIGHT, CENTER, BOUNCE };
+enum ButtonState { NO_STATE, PRESSED, RELEASED, HELD, HELD_LONG };
 
 Button buttons_init(void);
 
@@ -47,4 +31,5 @@ Button buttons_debounce(Button button);
 ButtonState buttons_get_state(void);
 uint16_t buttons_get_hold_count(void);
 
-Button buttons_update(void); // the main task of checking and handling button pushes
+Button buttons_update(
+    void);  // the main task of checking and handling button pushes

--- a/src/vario/buttons.h
+++ b/src/vario/buttons.h
@@ -20,7 +20,7 @@
 
 // D pad button states.
 // NOTE:  Left is -1 as to make casting to an int for settings easier
-enum buttons : int8_t
+enum Button : int8_t
 {
     NONE = 0,
     LEFT = -1,
@@ -39,12 +39,12 @@ enum button_states : uint8_t
     HELD_LONG
 };
 
-buttons buttons_init(void);
+Button buttons_init(void);
 
-buttons buttons_check(void);
-buttons buttons_inspectPins(void);
-buttons buttons_debounce(buttons button);
+Button buttons_check(void);
+Button buttons_inspectPins(void);
+Button buttons_debounce(Button button);
 button_states buttons_get_state(void);
 uint16_t buttons_get_hold_count(void);
 
-buttons buttons_update(void); // the main task of checking and handling button pushes
+Button buttons_update(void); // the main task of checking and handling button pushes

--- a/src/vario/menu_page.cpp
+++ b/src/vario/menu_page.cpp
@@ -11,7 +11,7 @@ void MenuPage::cursor_next() {
   if (cursor_position > cursor_max) cursor_position = 0;
 }
 
-bool SettingsMenuPage::button_event(uint8_t button, uint8_t state, uint8_t count) {      
+bool SettingsMenuPage::button_event(buttons button, button_states state, uint8_t count) {      
   switch (button) {
     case UP:
       if (state == RELEASED) cursor_prev();      
@@ -20,13 +20,13 @@ bool SettingsMenuPage::button_event(uint8_t button, uint8_t state, uint8_t count
       if (state == RELEASED) cursor_next();      
       break;
     case LEFT:
-      setting_change(-1, state, count);
+      setting_change(LEFT, state, count);
       break;
     case RIGHT:
-      setting_change(1, state, count);
+      setting_change(RIGHT, state, count);
       break;
     case CENTER:
-      setting_change(0, state, count);
+      setting_change(CENTER, state, count);
       break;    
   }    
   bool redraw = false;

--- a/src/vario/menu_page.cpp
+++ b/src/vario/menu_page.cpp
@@ -11,7 +11,7 @@ void MenuPage::cursor_next() {
   if (cursor_position > cursor_max) cursor_position = 0;
 }
 
-bool SettingsMenuPage::button_event(buttons button, button_states state, uint8_t count) {      
+bool SettingsMenuPage::button_event(Button button, button_states state, uint8_t count) {      
   switch (button) {
     case UP:
       if (state == RELEASED) cursor_prev();      

--- a/src/vario/menu_page.cpp
+++ b/src/vario/menu_page.cpp
@@ -13,23 +13,23 @@ void MenuPage::cursor_next() {
 
 bool SettingsMenuPage::button_event(Button button, ButtonState state, uint8_t count) {      
   switch (button) {
-    case UP:
+    case Button::UP:
       if (state == RELEASED) cursor_prev();      
       break;
-    case DOWN:
+    case Button::DOWN:
       if (state == RELEASED) cursor_next();      
       break;
-    case LEFT:
-      setting_change(LEFT, state, count);
+    case Button::LEFT:
+      setting_change(Button::LEFT, state, count);
       break;
-    case RIGHT:
-      setting_change(RIGHT, state, count);
+    case Button::RIGHT:
+      setting_change(Button::RIGHT, state, count);
       break;
-    case CENTER:
-      setting_change(CENTER, state, count);
+    case Button::CENTER:
+      setting_change(Button::CENTER, state, count);
       break;    
   }    
   bool redraw = false;
-  if (button != NONE && state != NO_STATE) redraw = true;
+  if (button != Button::NONE && state != NO_STATE) redraw = true;
   return redraw;   //update display after button push so that the UI reflects any changes immediately
 }

--- a/src/vario/menu_page.cpp
+++ b/src/vario/menu_page.cpp
@@ -11,7 +11,7 @@ void MenuPage::cursor_next() {
   if (cursor_position > cursor_max) cursor_position = 0;
 }
 
-bool SettingsMenuPage::button_event(Button button, button_states state, uint8_t count) {      
+bool SettingsMenuPage::button_event(Button button, ButtonState state, uint8_t count) {      
   switch (button) {
     case UP:
       if (state == RELEASED) cursor_prev();      

--- a/src/vario/menu_page.h
+++ b/src/vario/menu_page.h
@@ -2,14 +2,15 @@
 #define MENU_PAGE_H
 
 #include <Arduino.h>
+#include "buttons.h"
 
 class MenuPage {
   public:
     // Called whenever a button event occurs
-    //   button: Button to which the event pertains (TODO: change to enum)
-    //   state: New state of button (TODO: change to enum)
+    //   button: Button to which the event pertains
+    //   state: New state of button
     //   count: (TODO: document)
-    virtual bool button_event(uint8_t button, uint8_t state, uint8_t count) = 0;
+    virtual bool button_event(buttons button, button_states state, uint8_t count) = 0;
 
     // Called to draw the menu page.
     // Assumes(?) the screen is already clear.
@@ -26,10 +27,10 @@ class MenuPage {
 
 class SettingsMenuPage : public MenuPage {
   public:
-    bool button_event(uint8_t button, uint8_t state, uint8_t cound);
+    bool button_event(buttons button, button_states state, uint8_t count);
 
   protected:
-    virtual void setting_change(int8_t dir, uint8_t state, uint8_t count) = 0;
+    virtual void setting_change(buttons dir, button_states state, uint8_t count) = 0;
 };
 
 #endif

--- a/src/vario/menu_page.h
+++ b/src/vario/menu_page.h
@@ -10,7 +10,7 @@ class MenuPage {
     //   button: Button to which the event pertains
     //   state: New state of button
     //   count: (TODO: document)
-    virtual bool button_event(Button button, button_states state, uint8_t count) = 0;
+    virtual bool button_event(Button button, ButtonState state, uint8_t count) = 0;
 
     // Called to draw the menu page.
     // Assumes(?) the screen is already clear.
@@ -27,10 +27,10 @@ class MenuPage {
 
 class SettingsMenuPage : public MenuPage {
   public:
-    bool button_event(Button button, button_states state, uint8_t count);
+    bool button_event(Button button, ButtonState state, uint8_t count);
 
   protected:
-    virtual void setting_change(Button dir, button_states state, uint8_t count) = 0;
+    virtual void setting_change(Button dir, ButtonState state, uint8_t count) = 0;
 };
 
 #endif

--- a/src/vario/menu_page.h
+++ b/src/vario/menu_page.h
@@ -10,7 +10,7 @@ class MenuPage {
     //   button: Button to which the event pertains
     //   state: New state of button
     //   count: (TODO: document)
-    virtual bool button_event(buttons button, button_states state, uint8_t count) = 0;
+    virtual bool button_event(Button button, button_states state, uint8_t count) = 0;
 
     // Called to draw the menu page.
     // Assumes(?) the screen is already clear.
@@ -27,10 +27,10 @@ class MenuPage {
 
 class SettingsMenuPage : public MenuPage {
   public:
-    bool button_event(buttons button, button_states state, uint8_t count);
+    bool button_event(Button button, button_states state, uint8_t count);
 
   protected:
-    virtual void setting_change(buttons dir, button_states state, uint8_t count) = 0;
+    virtual void setting_change(Button dir, button_states state, uint8_t count) = 0;
 };
 
 #endif

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -38,7 +38,7 @@ void power_simple_init(void) {
 void power_bootUp() {
 
   power_init();                                     // configure power supply
-  uint8_t button = buttons_init();                  // initialize buttons and check if holding the center button is what turned us on
+  uint8_t button = buttons_init();                  // initialize Button and check if holding the center button is what turned us on
   if (button == CENTER) powerOnState = POWER_ON;    // if center button, then latch on and start operating!
   else powerOnState = POWER_OFF_USB;                // if not center button, then USB power turned us on, go into charge mode
   settings_init();                                  // grab user settings (or populate defaults if no saved settings)

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -38,8 +38,8 @@ void power_simple_init(void) {
 void power_bootUp() {
 
   power_init();                                     // configure power supply
-  uint8_t button = buttons_init();                  // initialize Button and check if holding the center button is what turned us on
-  if (button == CENTER) powerOnState = POWER_ON;    // if center button, then latch on and start operating!
+  auto button = buttons_init();                  // initialize Button and check if holding the center button is what turned us on
+  if (button == Button::DOWN) powerOnState = POWER_ON;    // if center button, then latch on and start operating!
   else powerOnState = POWER_OFF_USB;                // if not center button, then USB power turned us on, go into charge mode
   settings_init();                                  // grab user settings (or populate defaults if no saved settings)
   power_init_peripherals();                         // init peripherals (even if we're not turning on and just going into charge mode, we still need to initialize devices so we can put some of them back to sleep)
@@ -226,8 +226,8 @@ bool power_getBattCharging() {
 }
 
 
-void power_adjustInputCurrent(int8_t dir) {
-  int8_t newVal = power_getInputCurrent() + dir;
+void power_adjustInputCurrent(int8_t offset) {
+  int8_t newVal = power_getInputCurrent() + offset;
   if (newVal > iMax) newVal = iMax;
   else if (newVal < iStandby) newVal = iStandby;
   power_set_input_current(newVal);

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -58,7 +58,7 @@ bool power_autoOff();
 void power_resetAutoOffCounter(void);
 
 
-void power_adjustInputCurrent(int8_t dir);
+void power_adjustInputCurrent(int8_t offset);
 void power_set_input_current(uint8_t current);
 uint16_t power_getBattLevel(uint8_t value);
 bool power_getBattCharging(void);

--- a/src/vario/settings.cpp
+++ b/src/vario/settings.cpp
@@ -242,18 +242,18 @@ void settings_totallyEraseNVS() {
 // Adjust individual settings
 
 // Contrast Adjustment
-void settings_adjustContrast(int8_t dir) {
+void settings_adjustContrast(Button dir) {
   uint16_t * sound = fx_neutral;
-  if (dir) sound = fx_increase;
-  else if (dir < 0) sound = fx_decrease;
-  else if (dir == 0) {              // reset to default
+  if (dir == Button::RIGHT) sound = fx_increase;
+  else if (dir == Button::LEFT) sound = fx_decrease;
+  else if (dir == Button::CENTER) {              // reset to default
     speaker_playSound(fx_confirm);  
     CONTRAST = DEF_CONTRAST;
     display_setContrast(CONTRAST);
     return;
   }
 
-  CONTRAST += dir;
+  CONTRAST += dir == Button::RIGHT ? 1 : -1;
 
   if (CONTRAST > CONTRAST_MAX) {
     CONTRAST = CONTRAST_MAX;
@@ -281,10 +281,10 @@ void settings_adjustContrast(int8_t dir) {
   }
 
 
-void settings_adjustSinkAlarm(int8_t dir) {
+void settings_adjustSinkAlarm(Button dir) {
 	uint16_t * sound = fx_neutral;
 
-  if (dir > 0) {
+  if (dir == Button::RIGHT) {
     sound = fx_increase;
     if (++SINK_ALARM > 0) {      
       SINK_ALARM = SINK_ALARM_MAX;      // if we were at 0 and now are at positive 1, go back to max sink rate
@@ -305,10 +305,10 @@ void settings_adjustSinkAlarm(int8_t dir) {
 	// TODO: really needed? speaker_updateClimbToneParameters();	// call to adjust sinkRateSpread according to new SINK_ALARM value
 }
 
-void settings_adjustVarioAverage(int8_t dir) {
+void settings_adjustVarioAverage(Button dir) {
 	uint16_t * sound = fx_neutral;
 	
-  if (dir > 0) {
+  if (dir == Button::RIGHT) {
     sound = fx_increase;    
     if (++VARIO_AVERAGE >= VARIO_AVERAGE_MAX) {
       VARIO_AVERAGE = VARIO_AVERAGE_MAX;  
@@ -325,10 +325,10 @@ void settings_adjustVarioAverage(int8_t dir) {
 }
 
 // climb average goes between 0 and CLIMB_AVERAGE_MAX
-void settings_adjustClimbAverage(int8_t dir) {
+void settings_adjustClimbAverage(Button dir) {
 	uint16_t * sound = fx_neutral;
 	
-  if (dir > 0) {
+  if (dir == Button::RIGHT) {
     sound = fx_increase;    
     if (++CLIMB_AVERAGE >= CLIMB_AVERAGE_MAX) {
       CLIMB_AVERAGE = CLIMB_AVERAGE_MAX;  
@@ -344,11 +344,11 @@ void settings_adjustClimbAverage(int8_t dir) {
 	speaker_playSound(sound);
 }
 
-void settings_adjustClimbStart(int8_t dir) {
+void settings_adjustClimbStart(Button dir) {
 	uint16_t * sound = fx_neutral;
 	uint8_t inc_size = 5;
 
-  if (dir > 0) {
+  if (dir == Button::RIGHT) {
     sound = fx_increase;    
     if ( (CLIMB_START += inc_size) >= CLIMB_START_MAX) {
       CLIMB_START = CLIMB_START_MAX;  
@@ -366,11 +366,11 @@ void settings_adjustClimbStart(int8_t dir) {
 
 
 
-void settings_adjustLiftyAir(int8_t dir) {
+void settings_adjustLiftyAir(Button dir) {
 	uint16_t * sound = fx_neutral;
-	LIFTY_AIR += dir;
+	LIFTY_AIR += dir == Button::RIGHT ? 1 : -1;
 
-  if (dir > 0) {
+  if (dir == Button::RIGHT) {
     sound = fx_increase;
     if (LIFTY_AIR > 0) {      
       LIFTY_AIR = LIFTY_AIR_MAX;      // if we were at 0 and now are at positive 1, go back to max sink rate
@@ -388,11 +388,11 @@ void settings_adjustLiftyAir(int8_t dir) {
 }
 
 
-void settings_adjustVolumeVario(int8_t dir) {
+void settings_adjustVolumeVario(Button dir) {
 
   uint16_t * sound = fx_neutral;
   
-  if (dir > 0) {
+  if (dir == Button::RIGHT) {
     sound = fx_increase;
     VOLUME_VARIO++;
     if (VOLUME_VARIO > VOLUME_MAX) {
@@ -411,9 +411,9 @@ void settings_adjustVolumeVario(int8_t dir) {
 }
   
 
-void settings_adjustVolumeSystem(int8_t dir) {
+void settings_adjustVolumeSystem(Button dir) {
   uint16_t * sound = fx_neutral;  
-  if (dir > 0) {
+  if (dir == Button::RIGHT) {
     sound = fx_increase;
     VOLUME_SYSTEM++;
     if (VOLUME_SYSTEM > VOLUME_MAX) {
@@ -432,9 +432,9 @@ void settings_adjustVolumeSystem(int8_t dir) {
 }
 
 uint8_t timeZoneIncrement = 60;   // in minutes.  This allows us to change and adjust by 15 minutes for some regions that have half-hour and quarter-hour time zones.
-void settings_adjustTimeZone(int8_t dir) {
+void settings_adjustTimeZone(Button dir) {
 
-  if (dir == 0) { // switch from half-hour to full-hour increments
+  if (dir == Button::CENTER) { // switch from half-hour to full-hour increments
     if (timeZoneIncrement == 60) {
       timeZoneIncrement = 15;
       speaker_playSound(fx_increase);
@@ -443,7 +443,7 @@ void settings_adjustTimeZone(int8_t dir) {
       speaker_playSound(fx_decrease);
     }
   }
-  if (dir == 1)
+  if (dir == Button::RIGHT)
     if (TIME_ZONE >= TIME_ZONE_MAX) {
       speaker_playSound(fx_double);
       TIME_ZONE = TIME_ZONE_MAX;
@@ -451,7 +451,7 @@ void settings_adjustTimeZone(int8_t dir) {
       TIME_ZONE += timeZoneIncrement;
       speaker_playSound(fx_neutral);
     }    
-  else if (dir == -1) {
+  else if (dir == Button::LEFT) {
     if (TIME_ZONE <= TIME_ZONE_MIN) {
       speaker_playSound(fx_double);
       TIME_ZONE = TIME_ZONE_MIN;
@@ -463,8 +463,8 @@ void settings_adjustTimeZone(int8_t dir) {
 }
 
 // Change which altitude is shown on the Nav page (Baro Alt, GPS Alt, or Above-Waypoint Alt)
-void settings_adjustDisplayField_navPage_alt(int8_t dir) {
-  if (dir >0) {
+void settings_adjustDisplayField_navPage_alt(Button dir) {
+  if (dir == Button::RIGHT) {
     NAVPG_ALT_TYP++;
     if (NAVPG_ALT_TYP >= 3) NAVPG_ALT_TYP = 0;
   } else {
@@ -475,8 +475,8 @@ void settings_adjustDisplayField_navPage_alt(int8_t dir) {
 }
 
 // Change which altitude is shown on the Thermal page (Baro Alt or GPS Alt)
-void settings_adjustDisplayField_thermalPage_alt(int8_t dir) {
-  if (dir >0) {
+void settings_adjustDisplayField_thermalPage_alt(Button dir) {
+  if (dir == Button::RIGHT) {
     THMPG_ALT_TYP++;
     if (THMPG_ALT_TYP >= 2) THMPG_ALT_TYP = 0;
   } else {

--- a/src/vario/settings.h
+++ b/src/vario/settings.h
@@ -2,6 +2,7 @@
 #define settings_h
 
 #include <Arduino.h>
+#include "buttons.h"
 
 // Setting bounds and definitions
   // Vario 
@@ -125,21 +126,21 @@ void factoryResetVario(void);
 
 
 // adjust-settings functions
-void settings_adjustContrast(int8_t dir);
+void settings_adjustContrast(Button dir);
 void settings_setAltOffset(int32_t value);
-void settings_adjustAltOffset(int8_t dir, uint8_t count);
+void settings_adjustAltOffset(Button dir, uint8_t count);
 bool settings_matchGPSAlt(void);
-void settings_adjustSinkAlarm(int8_t dir);
-void settings_adjustVarioAverage(int8_t dir);
-void settings_adjustClimbAverage(int8_t dir);
-void settings_adjustClimbStart(int8_t dir);
-void settings_adjustLiftyAir(int8_t dir);
-void settings_adjustVolumeVario(int8_t dir);
-void settings_adjustVolumeSystem(int8_t dir);
-void settings_adjustTimeZone(int8_t dir);
+void settings_adjustSinkAlarm(Button dir);
+void settings_adjustVarioAverage(Button dir);
+void settings_adjustClimbAverage(Button dir);
+void settings_adjustClimbStart(Button dir);
+void settings_adjustLiftyAir(Button dir);
+void settings_adjustVolumeVario(Button dir);
+void settings_adjustVolumeSystem(Button dir);
+void settings_adjustTimeZone(Button dir);
 
-void settings_adjustDisplayField_navPage_alt(int8_t dir);
-void settings_adjustDisplayField_thermalPage_alt(int8_t dir);
+void settings_adjustDisplayField_navPage_alt(Button dir);
+void settings_adjustDisplayField_thermalPage_alt(Button dir);
 
 void settings_toggleBoolNeutral(bool * boolSetting);
 void settings_toggleBoolOnOff(bool * switchSetting);

--- a/src/vario/speaker.cpp
+++ b/src/vario/speaker.cpp
@@ -437,7 +437,7 @@ void IRAM_ATTR onSpeakerTimerSample() {
   //spi_checkFlag(2);
   //Serial.print("ENTER ISR: ");
   
-  //prioritize sound effects from UI & buttons etc before we get to vario beeps
+  //prioritize sound effects from UI & Button etc before we get to vario beeps
   if (sound_fx) {					
     speaker_setVolume(VOLUME_SYSTEM);    // play system sound effects at system volume setting
     
@@ -495,7 +495,7 @@ void IRAM_ATTR onSpeakerTimerAdustable() {
   //Serial.print("ENTER ISR: ");
   timerWrite(speaker_timer, 0);  // reset timer as we enter interrupt
 
-  //prioritize sound effects from UI & buttons etc before we get to vario beeps
+  //prioritize sound effects from UI & Button etc before we get to vario beeps
   if (sound_fx) {								
     Serial.print("FX: "); Serial.print(*snd_index); Serial.print(" @ "); Serial.println(millis());	
 		if (*snd_index != NOTE_END) {

--- a/src/vario/vario.ino
+++ b/src/vario/vario.ino
@@ -162,7 +162,7 @@ void main_CHARGE_loop() {
       SDcard_update();
 
     // Check Buttons
-      uint8_t buttonPushed = buttons_update();       // check buttons for any presses (user can turn ON from charging state)
+      uint8_t buttonPushed = buttons_update();       // check Button for any presses (user can turn ON from charging state)
 
     // Prep to end this cycle and sleep
       chargeman_doTasks = 0;  // done with tasks this timer cycle
@@ -195,7 +195,7 @@ void main_CHARGE_loop() {
         delayMicroseconds(sleepMicros);                   // use delay instead of actual sleep to test sleep logic (allows us to serial print during 'fake sleep' and also re-program over USB mid-'fake sleep')
       }
     } else {
-      //if (buttons_update() != NONE) Serial.println("we see a button!");  // TOOD: erase this
+      //if (Button_update() != NONE) Serial.println("we see a button!");  // TOOD: erase this
     }
   }
 }

--- a/src/vario/vario.ino
+++ b/src/vario/vario.ino
@@ -162,11 +162,11 @@ void main_CHARGE_loop() {
       SDcard_update();
 
     // Check Buttons
-      uint8_t buttonPushed = buttons_update();       // check Button for any presses (user can turn ON from charging state)
+      auto buttonPushed = buttons_update();       // check Button for any presses (user can turn ON from charging state)
 
     // Prep to end this cycle and sleep
       chargeman_doTasks = 0;  // done with tasks this timer cycle
-      if (buttonPushed == NONE) goToSleep = true; // get ready to sleep if no button is being pushed
+      if (buttonPushed == Button::NONE) goToSleep = true; // get ready to sleep if no button is being pushed
   } else {    
     if (goToSleep && ECO_MODE) {  // don't allow sleep if ECO_MODE is off
 
@@ -352,15 +352,15 @@ void taskManager(void) {
 
 void main_loop_test() {
 
-  uint8_t button = buttons_check();
+  auto button = buttons_check();
   uint8_t button_state = buttons_get_state();
 
 
 /*
   if (button_state == PRESSED) {
-    if (button == LEFT || button == UP) {      
+    if (button == LEFT || button == Button::UP) {      
       if (display_page > 0) display_page--;
-    } else if (button == RIGHT || button == CENTER || button == DOWN) {
+    } else if (button == Button::RIGHT || button == Button::DOWN || button == Button::DOWN) {
       display_page++;
       if (display_page > 12) display_page = 12;
     }


### PR DESCRIPTION
In preparation for adding new pages for WiFi settings, I'm cleaning up how buttons and states are passed around.  This removes treating them as int8_t and instead uses their enum type.