### PR TITLE
Add Modal page Support with a Wifi template.

### DIFF
--- a/.github/workflows/arduino.yaml
+++ b/.github/workflows/arduino.yaml
@@ -33,3 +33,5 @@ jobs:
               version: 1.2.12
             - name: AHT20
               version: 1.0.1
+            - name: "Embedded Template Library ETL"
+              version: 20.39.4

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,10 @@ board_build.partitions = default_8MB.csv
 
 lib_extra_dirs = src/libraries
 
+lib_deps = 
+	; STL like library for Arduino platform and embedded systems
+	etlcpp/Embedded Template Library@^20.39.4
+
 [platformio]
 src_dir = src/vario
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ board_upload.maximum_size = 8388608
 build_flags = 
 	-D ARDUINO_USB_MODE=1
 	-D ARDUINO_USB_CDC_ON_BOOT=1  # Required for USB Serial on boot (for debugging)  
+	-D PIO_BUILD_SYSTEM
 
 # ~3.2Mb for A and B partitions to allow for updates
 board_build.partitions = default_8MB.csv

--- a/src/vario/PageMenuSystem.cpp
+++ b/src/vario/PageMenuSystem.cpp
@@ -8,6 +8,7 @@
 #include "settings.h"
 #include "power.h"
 #include "speaker.h"
+#include "PageMenuSystemWifi.h"
 
 
 enum system_menu_items { 
@@ -143,7 +144,12 @@ void SystemMenuPage::setting_change(Button dir, ButtonState state, uint8_t count
       if (state == RELEASED) settings_toggleBoolOnOff(&ECO_MODE);
       break;
     case cursor_system_wifi:
-      if (state == RELEASED) {}
+      if (state != RELEASED) break;
+
+      // User has selected WiFi, show this page
+      static PageMenuSystemWifi wifiPage;
+      push_page(&wifiPage);
+      redraw = true;
       break;
     case cursor_system_bluetooth:
       if (state == RELEASED) {}

--- a/src/vario/PageMenuSystem.h
+++ b/src/vario/PageMenuSystem.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include "menu_page.h"
+#include "PageMenuSystemWifi.h"
 
 class SystemMenuPage : public SettingsMenuPage {
   public:

--- a/src/vario/PageMenuSystemWifi.cpp
+++ b/src/vario/PageMenuSystemWifi.cpp
@@ -1,0 +1,18 @@
+#include "PageMenuSystemWifi.h"
+
+void PageMenuSystemWifi::setting_change(Button dir, ButtonState state, uint8_t count) {
+  if(state != RELEASED) return;
+
+  // Handle updating items
+  switch (cursor_position) {
+    case cursor_system_wifi_setup:
+      push_page(&page_wifi_setup);
+      break;
+    case cursor_system_wifi_update:
+      push_page(&page_wifi_update);
+      break;
+  }
+
+  // Call the parent class to handle the back button
+  SimpleSettingsMenuPage::setting_change(dir, state, count);
+}

--- a/src/vario/PageMenuSystemWifi.h
+++ b/src/vario/PageMenuSystemWifi.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "menu_page.h"
+#include "etl/array.h"
+#include "etl/array_view.h"
+
+enum system_wifi_items {
+    cursor_system_wifi_setup,
+    cursor_system_wifi_update
+};
+
+// WiFi setup sub-page
+class PageMenuSystemWifiSetup : public SimpleSettingsMenuPage {
+  public:
+    const char* get_title() const override { return "Wifi Setup"; }
+};
+
+// WiFi setup sub-page
+class PageMenuSystemWifiUpdate : public SimpleSettingsMenuPage {
+  public:
+    const char* get_title() const override { return "Wifi Update"; }
+};
+
+// Top level menu for the Wifi system
+class PageMenuSystemWifi : public SimpleSettingsMenuPage {
+  public:
+    const char* get_title() const override { return "Wifi"; }
+    etl::array_view<const char*> get_labels() const override {
+      static etl::array labels{ "Setup", "Update", "Dummy" };
+      return etl::array_view<const char*>(labels);
+    }
+  protected:
+    void setting_change(Button dir, ButtonState state, uint8_t count) override;
+  
+  private:
+    PageMenuSystemWifiSetup page_wifi_setup;
+    PageMenuSystemWifiUpdate page_wifi_update;
+};
+

--- a/src/vario/display.cpp
+++ b/src/vario/display.cpp
@@ -26,6 +26,7 @@
 #include "speaker.h"
 #include "power.h"
 #include "SDcard.h"
+#include "menu_page.h"
 
 //#define GLCD_RS LCD_RS
 //#define GLCD_RESET LCD_RESET
@@ -117,7 +118,22 @@ uint8_t display_getPage() {
   return display_page;
 }
 
+// Draws the current page
+// Will first display charging screen if charging,
+// Then will display any current modal pages before
+// falling back to the current 
 void display_update() {
+  if (display_page == page_charging) {
+    display_page_charging();
+    return;
+  }
+
+  auto modalPage = mainMenuPage.get_modal_page();
+  if(modalPage != NULL) {
+    modalPage->draw();
+    return;
+  }
+
   switch (display_page) {
     case page_thermalSimple:
       thermalSimplePage_draw();
@@ -133,9 +149,6 @@ void display_update() {
       break;
     case page_menu:
       mainMenuPage.draw();
-      break;
-    case page_charging:
-      display_page_charging();
       break;
   }  
 }

--- a/src/vario/menu_page.cpp
+++ b/src/vario/menu_page.cpp
@@ -1,14 +1,18 @@
 #include "menu_page.h"
+
 #include "buttons.h"
+#include "display.h"
+#include "fonts.h"
+#include "etl/array.h"
 
 void MenuPage::cursor_prev() {
-  cursor_position--;
-  if (cursor_position < 0) cursor_position = cursor_max;
+    cursor_position--;
+    if (cursor_position < cursor_min) cursor_position = cursor_max;
 }
 
 void MenuPage::cursor_next() {
-  cursor_position++;
-  if (cursor_position > cursor_max) cursor_position = 0;
+    cursor_position++;
+    if (cursor_position > cursor_max) cursor_position = cursor_min;
 }
 
 bool SettingsMenuPage::button_event(Button button, ButtonState state, uint8_t count) {      
@@ -32,4 +36,89 @@ bool SettingsMenuPage::button_event(Button button, ButtonState state, uint8_t co
   bool redraw = false;
   if (button != Button::NONE && state != NO_STATE) redraw = true;
   return redraw;   //update display after button push so that the UI reflects any changes immediately
+}
+
+void MenuPage::push_page(MenuPage* page) {
+    get_current_page_stack().push(page);
+    page->shown();
+}
+
+void MenuPage::pop_page() { get_current_page_stack().pop(); }
+
+MenuPage* MenuPage::get_modal_page() {
+    if (get_current_page_stack().empty()) return NULL;
+    return get_current_page_stack().top();
+}
+
+SimpleSettingsMenuPage::SimpleSettingsMenuPage() : SettingsMenuPage() {
+    cursor_position = 0;
+    cursor_max = 0;
+    cursor_min = -1;  // The back button sits at -1
+}
+
+void SimpleSettingsMenuPage::shown() {
+    cursor_position = CURSOR_BACK;
+    auto labels = get_labels();
+    cursor_max = labels.size() - 1;
+}
+
+void SimpleSettingsMenuPage::draw() {
+    u8g2.firstPage();
+    do {
+        // Title
+        u8g2.setFont(leaf_6x12);
+        u8g2.setCursor(2, 12);
+        u8g2.setDrawColor(1);
+        u8g2.print(get_title());
+        u8g2.drawHLine(0, 15, 95);
+
+        // Draw the cursor selection box
+        const auto BOX_X = 74 - 10;
+        const auto BOX_Y = (cursor_position == CURSOR_BACK ? 190 : 45 + (cursor_position * 15)) - 14;
+        u8g2.drawRBox(BOX_X, BOX_Y, 34, 16, 2);
+
+        // Draw the back item
+        u8g2.setCursor(2, 190);
+        u8g2.print("Back");
+        u8g2.setCursor(74, 190);
+        u8g2.setDrawColor(cursor_position == CURSOR_BACK ? 0 : 1);
+        u8g2.print((char)124); // Print back button
+        u8g2.setDrawColor(1);
+
+        // Draw the menu items starting from the top
+        uint8_t y_pos = 45;
+        for (int i = 0; i <= cursor_max; i++) {
+            // Print the menu label
+            u8g2.setDrawColor(1);
+            u8g2.setCursor(2, y_pos);
+            u8g2.print(get_labels()[i]);
+
+            // Print the menu input
+            u8g2.setCursor(74, y_pos);
+            u8g2.setDrawColor(cursor_position == i ? 0 : 1);
+            // Call the virtual function to draw the input
+            draw_menu_input(i);
+            
+            y_pos += 15;
+        }
+
+    } while (u8g2.nextPage());
+}
+
+// By default, print an enter character
+void SimpleSettingsMenuPage::draw_menu_input(int8_t cursor_position) {
+  u8g2.print((char)126);
+}
+
+// By default, a menu item will have no labels, an empty view
+etl::array_view<const char*> SimpleSettingsMenuPage::get_labels() const {
+  return etl::array_view<const char*>();
+}
+
+// Only handle the default back button closing this dialog
+void SimpleSettingsMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
+  if(cursor_position == CURSOR_BACK && state == RELEASED) {
+    pop_page();
+    return;
+  }
 }

--- a/src/vario/menu_page.h
+++ b/src/vario/menu_page.h
@@ -1,29 +1,66 @@
-#ifndef MENU_PAGE_H
-#define MENU_PAGE_H
+#pragma once
 
 #include <Arduino.h>
+#include <etl/stack.h>
+#include <etl/array_view.h>
+
 #include "buttons.h"
 
+#define MENU_PAGE_STACK_SIZE 10
+#define CURSOR_BACK -1  // cursor position for default back button
+
+// Base class for all Pages to be drawn with Menu Items with support for
+// modal pages.
+// This class is pure virtual and must be inherited by a class that implements
+// the draw() and button_event() functions.
+//
+// Modal Behavior:
+// There's a static stack of MenuPages that is used to keep track of the current
+// page.  If there's a page on the stack, this should receive button events and
+// been drawn.  It is expected that the Back button typically pops from this
+// stack.
 class MenuPage {
-  public:
+   public:
     // Called whenever a button event occurs
     //   button: Button to which the event pertains
     //   state: New state of button
     //   count: (TODO: document)
+    // Returns true if the page should be redrawn after the event.
     virtual bool button_event(Button button, ButtonState state, uint8_t count) = 0;
 
     // Called to draw the menu page.
     // Assumes(?) the screen is already clear.
     virtual void draw() = 0;
 
-  protected:
+    // Returns the current modal page on the stack.
+    // If there is no modal page, returns NULL.
+    MenuPage* get_modal_page();
+
+   protected:
     void cursor_prev();
     void cursor_next();
 
-    int8_t cursor_position;   // 0 means nothing selected
-    int8_t cursor_max;
-};
+    // Pushes a new modal page onto the stack to receive draw events
+    void push_page(MenuPage* page);
 
+    // Pops the current modal page off the stack
+    void pop_page();
+
+    // Called when a modal page is shown
+    virtual void shown() {};
+
+    int8_t cursor_position;  
+    int8_t cursor_max;
+    int8_t cursor_min = 0;
+
+   private:
+    // Pages
+    static etl::stack<MenuPage*, MENU_PAGE_STACK_SIZE>&
+    get_current_page_stack() {
+        static etl::stack<MenuPage*, MENU_PAGE_STACK_SIZE> current_page_stack;
+        return current_page_stack;
+    }
+};
 
 class SettingsMenuPage : public MenuPage {
   public:
@@ -33,4 +70,18 @@ class SettingsMenuPage : public MenuPage {
     virtual void setting_change(Button dir, ButtonState state, uint8_t count) = 0;
 };
 
-#endif
+// A simple helper class to handle simple menu items that draw things like
+// Titles and Labels.
+class SimpleSettingsMenuPage : public SettingsMenuPage {
+    public:
+        SimpleSettingsMenuPage();
+        void draw() override;
+        void shown() override;
+        virtual void draw_menu_input(int8_t cursor_position);
+        virtual const char* get_title() const = 0;
+        virtual etl::array_view<const char*> get_labels() const;
+    
+    protected:
+      virtual void setting_change(Button dir, ButtonState state, uint8_t count) override;
+
+};

--- a/src/vario/menu_page.h
+++ b/src/vario/menu_page.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <Arduino.h>
-#include "Embedded_Template_Library.h"
+#if !defined PIO_BUILD_SYSTEM && !defined __INTELLISENSE__
+// ETL Library has a bug which makes this needed when building
+// on Arduino, and only Arduino IDE.
+#include "Embedded_Template_Library.h"  // NOLINT
+#endif
 #include <etl/stack.h>
 #include <etl/array_view.h>
 

--- a/src/vario/menu_page.h
+++ b/src/vario/menu_page.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include "Embedded_Template_Library.h"
 #include <etl/stack.h>
 #include <etl/array_view.h>
 


### PR DESCRIPTION
Stacked on top of [state button changes to have their own type](https://github.com/DangerMonkeys/leaf/pull/15)

**Problem Statement:**
Currently adding new Pages is very difficult, with global enums and state across multiple places.  The codebase has a few primary pages, then, a couple of System menu pages for configuring the vario and setting up state.

**Proposal:**
This PR adds a new stack for "Modal" pages.  The idea is that any page can push a new Modal page onto the stack, and the topmost page should get the draw and input sent to it.

This is done though a SimpleSettingsMenuPage that by default will allow a back button, and only a few lines of code needed to implement what happens when each menu item is rendered.

**Test Plan:**


https://github.com/user-attachments/assets/afcdbca3-d02d-40cf-ba60-4090c6692411



