### PR TITLE
Add Arduino CI workflow and update PlatformIO CI

### DIFF
--- a/.github/workflows/arduino.yaml
+++ b/.github/workflows/arduino.yaml
@@ -1,0 +1,35 @@
+name: Arduino
+
+on:
+  pull_request: # All
+  push:
+    branches:
+    - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # For more information: https://github.com/arduino/compile-sketches#readme
+      - name: Compile sketch
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: esp32:esp32:esp32s3:CDCOnBoot=cdc,FlashSize=8M,PartitionScheme=default_8MB
+          platforms: |
+            - name: esp32:esp32
+              version: 3.0.2
+          sketch-paths: |
+            - ./src/vario
+          libraries: |
+            - name: "TinyGPSPlus-ESP32"
+              version: 0.0.2
+            - name: U8g2
+              version: 2.34.22
+            - name: "SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library"
+              version: 1.2.12
+            - name: AHT20
+              version: 1.0.1

--- a/.github/workflows/platformio.yaml
+++ b/.github/workflows/platformio.yaml
@@ -1,22 +1,31 @@
-name: PlatformIO CI
+name: PlatformIO
 
-on: [push]
+on:
+  pull_request: # All
+  push:
+    branches:
+    - main
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
-      - uses: actions/setup-python@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
 

--- a/src/vario/README.md
+++ b/src/vario/README.md
@@ -1,9 +1,6 @@
 ## Required libraries
 
-* TinyGPSPlus-ESP32 0.0.2
-* U8g2 LCD: 2.34.22
-* SparkFun 9DoF IMU Breakout - ICM 20948 - Arduino Library: 1.2.12
-* AHT20: 1.0.1
+See list of required libraries in the `libraries` section of the [Arduino workflow](../../.github/workflows/arduino.yaml).
 
 ## ESP32 configuration
 
@@ -14,6 +11,8 @@ ESP Board Manager Package 3.0.2
 * Partition Scheme -> 8M with spiffs (3MB APP/1.5MB SPIFFS)
 
 Arduino board: ESP32S3 Dev Module
+
+(see [Arduino workflow](../../.github/workflows/arduino.yaml) to confirm specifics)
 
 ## Programming
 


### PR DESCRIPTION
This PR adds a continuous integration Arduino-platform workflow that makes sure the sketch can build for Arduino.

To reduce redundancy (and therefore the possibility of inconsistency), the list of libraries needed is removed from the README and instead readers are linked to the list of libraries in the workflow file.  This is slightly more difficult to read, but it ensures that we don't need to keep the README and workflow file in sync manually.

The ESP32 configuration is also encoded in the workflow file, but it's not encoded in a readable way so I just added a note at the bottom of the README section hinting that the plain-English settings can be compared against the settings in the workflow file for sophisticated users.

Finally, the PlatformIO workflow is also updated to be triggered on pull request (previously, the pull request trigger was omitted).  Two steps are also given names to be slightly more user-friendly.

I believe I have tested both of these workflows to work on my fork, but CI stuff can be a little tricky to test correctly.