### PR TITLE
Add raw data logging to sdcard

### DIFF
--- a/src/vario/IMU.cpp
+++ b/src/vario/IMU.cpp
@@ -8,6 +8,8 @@
 #include <ICM_20948.h>
 #include "IMU.h"
 #include "Leaf_I2C.h"
+#include "log.h"
+#include "SDcard.h"
 
 #define DEBUG_IMU 0
 
@@ -62,6 +64,12 @@ void imu_update() {
     Serial.print(ay);
     Serial.print(" z: ");
     Serial.println(az);
+  }
+
+  if (logbook.dataFileStarted) {
+    String accelName = "accel,";
+    String accelEntry = accelName + String(at);
+    SDcard_writeData(accelEntry);
   }
 }
 

--- a/src/vario/SDcard.cpp
+++ b/src/vario/SDcard.cpp
@@ -325,8 +325,41 @@ void SDcard_test(void) {
 }
 
 
+// Create & log flight test data for debugging and tuning
 
-// Creating and saving log files to SDCard
+String dataSaveDir = "/Data/";
+String currentDataFile;
+File dataFile;
+String dataFileName;
+
+bool SDcard_createDataFile(String filename) {  
+  dataFileName = filename;
+  createDir(SD_MMC, dataSaveDir.c_str());
+  currentDataFile = dataSaveDir + filename;
+  
+  String header = "millis,sensor, value (lat), lng, alt m, speed mps, heading deg\n";
+
+  writeFile(SD_MMC, currentDataFile.c_str(), header.c_str());
+  dataFile = SD_MMC.open(currentDataFile.c_str(), FILE_APPEND);
+  
+  // check if file was written properly, and return false if not
+  if (!dataFile) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+void SDcard_writeData(String data) {
+  String entry = String(millis()) + "," + data + "\n";
+  appendOpenFile(dataFile, entry.c_str());    
+}
+
+void SDcard_closeDataFile() {
+  dataFile.close();
+}
+
+// Creating and saving track log files to SDCard
 
 String saveDir = "/Tracks/";
 String currentTrackFile;

--- a/src/vario/SDcard.h
+++ b/src/vario/SDcard.h
@@ -41,4 +41,8 @@ void appendOpenFile(File &file, const char * message);
 void SDcard_writeLogHeader(void);
 void SDcard_writeLogFooter(String trackName, String trackDescription);
 
+bool SDcard_createDataFile(String filename);
+void SDcard_writeData(String data);
+void SDcard_closeDataFile(void);
+
 #endif

--- a/src/vario/gps.cpp
+++ b/src/vario/gps.cpp
@@ -12,6 +12,7 @@
 #include "settings.h"
 #include "log.h"
 #include "baro.h"
+#include "SDcard.h"
 
 #define DEBUG_GPS 0
 
@@ -222,6 +223,20 @@ void gps_update() {
   updateGPXnav();
   gps_updateSatList();
   gps_calculateGlideRatio();
+
+  if (logbook.dataFileStarted) {
+    String gpsName = "gps,";
+    String gpsEntryString = gpsName + 
+                            String(gps.location.lat(),8) + ',' +
+                            String(gps.location.lng(),8) + ',' +
+                            String(gps.altitude.meters()) + ',' +
+                            String(gps.speed.mps()) + ',' +
+                            String(gps.course.deg());
+
+    SDcard_writeData(gpsEntryString);
+  }
+
+
 
   /*
 

--- a/src/vario/log.h
+++ b/src/vario/log.h
@@ -38,6 +38,9 @@
   String log_createTrackFileName(void);
   String log_createTrackDescription(void);
 
+// Test data file (all sensor values dumped realtime to csv)
+  String log_createTestDataFileName(void);
+
   void log_captureValues(void);
   void log_checkMinMaxValues(void);
   bool flightTimer_autoStop(void);
@@ -46,6 +49,7 @@
 // baro struct to hold most values 
 	struct LOGBOOK {
     bool flightTrackStarted = false;
+    bool dataFileStarted = false;
 
     int32_t alt = 0;
     int32_t alt_start = 0;


### PR DESCRIPTION
This PR adds basic functionality to store raw sensor data into a .csv file on SD card.

Use the flag at the top of log.cpp to enable or disable:
`    bool DATAFILE = true; // set to false to disable data logging to SDcard`

The data file is created when the vario timer starts running, and is closed & saved when the timer is stopped.  Data will only be captured while the timer is running.

Data is stored from 3 sensors:

- barometric pressure (NOT altitude), every 50ms, at the end of baro_calculatePressure()
- IMU acceleration (total g-load), every 100ms, at the end of imu_update()
- GPS lat, lng, alt (m), speed (m/s), course/heading (deg) inside gps_update()