### PR TITLE
Fix mass storage issues

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,9 +14,13 @@ board_build.flash_mode = qio
 board_upload.flash_size = 8MB
 board_upload.maximum_size = 8388608
 
-build_flags = 
-	-D ARDUINO_USB_MODE=1
-	-D ARDUINO_USB_CDC_ON_BOOT=1  # Required for USB Serial on boot (for debugging)  
+build_unflags =
+    -D ARDUINO_USB_MODE=1
+build_flags =
+    -D ARDUINO_USB_MODE=0
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+    -D ARDUINO_USB_MSC_ON_BOOT=0
+    -D ARDUINO_USB_DFU_ON_BOOT=0
 	-D PIO_BUILD_SYSTEM
 
 # ~3.2Mb for A and B partitions to allow for updates

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,9 +39,6 @@ lib_deps =
 extends = env
 build_flags = 
 	${env.build_flags}
-	# Enables USB Mass Storage for accessing SD card
-	# NOTE:  Disables Serial for debugging / uploading.
-	-D ENABLE_MASS_STORAGE
 
 
 [env:dev]

--- a/src/vario/SDcard.cpp
+++ b/src/vario/SDcard.cpp
@@ -18,7 +18,7 @@ bool SDcardIsPresent = false;
 #include "USBMSC.h"
 #include "FirmwareMSC.h"
 
-FirmwareMSC MSC_Update;
+FirmwareMSC MSC_FirmwareUpdate;
 USBMSC MSC;
 
 void listDir(fs::FS &fs, const char *dirname, uint8_t levels) {
@@ -272,7 +272,7 @@ void SDCard_SetupMassStorage() {
     MSC.isWritable(true);
     MSC.mediaPresent(true);
     MSC.begin(SD_MMC.numSectors(), 512);
-    MSC_Update.begin();
+    MSC_FirmwareUpdate.begin();
     USB.begin();
 }
 

--- a/src/vario/SDcard.cpp
+++ b/src/vario/SDcard.cpp
@@ -289,9 +289,7 @@ bool SDcard_mount() {
   } else {
     if (DEBUG_SDCARD) Serial.println("SDcard Mount Success");
     SDcardIsPresent = true;
-    #ifdef ENABLE_MASS_STORAGE
     SDCard_SetupMassStorage();
-    #endif
   }
   
   return SDcardIsPresent;

--- a/src/vario/vario.ino
+++ b/src/vario/vario.ino
@@ -83,10 +83,6 @@ uint8_t display_do_tracker = 1;
 /////////////////////////////////////////////////
 void setup() {
 
-  #ifdef ENABLE_MASS_STORAGE
-  SDCard_SetupMassStorage();
-  #endif
-
   // Start USB Serial Debugging Port
   Serial.begin(115200);
   delay(200);


### PR DESCRIPTION
This PR addresses some of the mass storage issues we've seen recently.

Unflagging ARDUINO_USB_MODE at the platform level fixes many build warnings when setting ARDUINO_USB_MODE at the flag level.  The combination of ARDUINO_USB_MODE=0 and ARDUINO_CDC_ON_BOOT=1 allows use of both the serial port and mass storage devices (firmware & SD card), however it does not allow firmware upload without manually switching back into bootloader mode.

The ENABLE_MASS_STORAGE flag is no longer needed because the serial port and mass storage work together with these settings, so it is removed.

MSC_Update conflicted with a platform symbol, so its name is upgraded to the more specific MSC_FirmwareUpdate.

These changes were tested to work properly* on a Windows machine after verifying the drives-not-appearing problem using the head of main prior to these changes.

*work properly = 
* Two drives appear immediately after programming
    * One contains FIRMWARE.BIN
    * The other contains SD card contents
* With the drives present, turning on the leaf and operating buttons produces serial output in the serial monitor
* Content on the SD card can be manipulated
* After disconnecting the leaf and reconnecting it, serial output still flows to serial monitor (after reconnecting serial monitor)

Note: if the device turns on without an SD card mounted, the firmware drive will not be mounted either (the drive will be present, but it will not have any contents until the SD card is mounted)