### PR TITLE
Improve clang-format settings

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,49 @@
+# Reference: https://releases.llvm.org/19.1.0/tools/clang/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle: Google               # Comparison: https://github.com/motine/cppstylelineup
+
+# === Indentation ===
+IndentWidth: 2                     # Use 2 spaces for indentation
+TabWidth: 2                        # Tab width is also 2 spaces
+UseTab: Never                      # Always use spaces, never tabs
+
+# === Formatting ===
+ColumnLimit: 100                   # Limit line length to 100 characters
+BreakBeforeBraces: Attach          # Place opening braces on same line
+AllowShortIfStatementsOnASingleLine: true
+IndentCaseLabels: true             # Indent case labels in switch statements
+
+# === Namespace Formatting ===
+NamespaceIndentation: All          # Indent everything inside namespaces
+IndentWrappedFunctionNames: false  # Don't indent wrapped function names
+
+# === Pointer and Reference Alignment ===
+DerivePointerAlignment: false         # Use explicitly set PointerAlignment
+PointerAlignment: Left                # Place '*' or '&' next to the data type
+SpaceBeforeParens: ControlStatements  # Add space before parentheses in control statements
+
+# === Include Formatting ===
+SortIncludes: true                 # Automatically sort `#include` statements
+IncludeBlocks: Preserve            # Keep blank lines between include groups
+
+# === Function and Constructor Formatting ===
+AllowShortFunctionsOnASingleLine: InlineOnly  # Only inline trivial functions
+ConstructorInitializerIndentWidth: 4          # Align initializer lists with indentation
+BreakTemplateDeclarations: Yes                # Break all template declarations
+
+# === Comments ===
+CommentPragmas: '^\\s*TODO|FIXME'  # Recognize TODO and FIXME as special comments
+SpaceBeforeCpp11BracedList: false  # No space before C++11 braced lists
+
+# === Function Argument Splitting ===
+# If false, a function declaration’s or function definition’s parameters will either all be on the
+# same line or will have one line each.
+BinPackParameters: false
+
+# If the function declaration doesn’t fit on a line, allow putting all parameters of a function
+# declaration onto the next line even if BinPackParameters is false.
+AllowAllParametersOfDeclarationOnNextLine: false
+
+# If false, a function call’s arguments will either be all on the same line or will have one line
+# each.
+BinPackArguments: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "C_Cpp.errorSquiggles": "enabled",
+    "files.associations": {
+        "compare": "cpp",
+        "typeinfo": "cpp",
+        "cmath": "cpp",
+        "complex": "cpp"
+    },
+    "editor.formatOnSave": true,
+    "[cpp]": {
+        "editor.defaultFormatter": "ms-vscode.cpptools"
+    },
+    "[c]": {
+        "editor.defaultFormatter": "ms-vscode.cpptools"
+    },
+    "C_Cpp.clang_format_style": "file",
+    "C_Cpp.clang_format_fallbackStyle": "none"
+}

--- a/src/.vscode/.gitignore
+++ b/src/.vscode/.gitignore
@@ -1,2 +1,0 @@
-# This file is specific to a user's system; it can be created with configure_vscode.py
-c_cpp_properties.json

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-	"C_Cpp.errorSquiggles": "enabled",
-	"files.associations": {
-		"compare": "cpp",
-		"typeinfo": "cpp",
-		"cmath": "cpp",
-		"complex": "cpp"
-	}
-}

--- a/src/vario/.clang-format
+++ b/src/vario/.clang-format
@@ -1,8 +1,0 @@
-BasedOnStyle: Google
-IndentWidth: 2
-ColumnLimit: 100
-
-ExperimentalAutoDetectBinPacking: false
-AllowAllParametersOfDeclarationOnNextLine: false
-BinPackArguments: false
-BinPackParameters: false


### PR DESCRIPTION
This PR improves the behavior of C++ autoformatting:
* Moves .clang-format to the root of the repo since we want all C++ files in the repo (which is the PlatformIO project) to be subject to this formatting
* Expands and comments the formatting settings in .clang-format
* Autoformats files on save to more aggressively keep formatting consistent
* Removes legacy src/.vscode content