### PR TITLE
[Bugfix] Fixed PlatformIO broken build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@ src_dir = src/vario
 
 # Mostly taken from 
 # https://github.com/sivar2311/ESP32-S3-PlatformIO-Flash-and-PSRAM-configurations?tab=readme-ov-file#esp32-s3-fn8
-[env:base]
+[env]
 # platform = espressif32  # Old, default platform
 # https://github.com/pioarduino/platform-espressif32
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
@@ -36,31 +36,27 @@ lib_extra_dirs = src/libraries
 lib_deps = 
 	; STL like library for Arduino platform and embedded systems
 	etlcpp/Embedded Template Library@^20.39.4
-
 	; WiFi Manager for configuring WiFi credentials over captive portal 
 	WiFiManager
 
 
 
-
 [env:release]
-extends = env:base
+extends = env
 build_flags = 
 	${env.build_flags}
 
 
+
 [env:dev]
-extends = env:base
+extends = env
 build_flags = 
 	${env.build_flags}
 	-D WIFI_ON_BOOT  # Enables WiFi on boot
 	-D DEBUG_WEBSERVER  # Enables a web server for debugging
-  
-
 build_type = debug  # Might be useful when looking at stack traces
 # Used to take exception traces and decode them to meaningful errors
 monitor_filters = esp32_exception_decoder
-
 
 
 


### PR DESCRIPTION
Sorry about that, seems that env:base isn't a valid extend.  Rolled forward with the PlatformIO fixes.
