### PR TITLE
Changes "dev" build to allow Serial

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,13 +19,7 @@ board_build.flash_mode = qio
 board_upload.flash_size = 8MB
 board_upload.maximum_size = 8388608
 
-build_unflags =
-    -D ARDUINO_USB_MODE=1
 build_flags =
-    -D ARDUINO_USB_MODE=0
-    -D ARDUINO_USB_CDC_ON_BOOT=1
-    -D ARDUINO_USB_MSC_ON_BOOT=0
-    -D ARDUINO_USB_DFU_ON_BOOT=0
 	-D PIO_BUILD_SYSTEM
 
 # ~3.2Mb for A and B partitions to allow for updates
@@ -51,6 +45,10 @@ lib_deps =
 extends = env
 build_flags = 
 	${env.build_flags}
+	-D ARDUINO_USB_MODE=0
+	-D ARDUINO_USB_CDC_ON_BOOT=0  # Required for USB Serial on boot (for debugging)  
+build_unflags = -D ARDUINO_USB_MODE
+
 
 
 [env:dev]
@@ -59,6 +57,10 @@ build_flags =
 	${env.build_flags}
 	-D WIFI_ON_BOOT  # Enables WiFi on boot
 	-D DEBUG_WEBSERVER  # Enables a web server for debugging
+	-D DISABLE_MASS_STORAGE  # Disables mass storage on SD card mount
+	-D ARDUINO_USB_MODE=1
+	-D ARDUINO_USB_CDC_ON_BOOT=1  # Required for USB Serial on boot (for debugging)  
+
   
 
 build_type = debug  # Might be useful when looking at stack traces

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,12 +43,13 @@ lib_deps =
 
 [env:release]
 extends = env
+build_unflags = -D ARDUINO_USB_MODE
 build_flags = 
 	${env.build_flags}
 	-D ARDUINO_USB_MODE=0
-	-D ARDUINO_USB_CDC_ON_BOOT=0  # Required for USB Serial on boot (for debugging)  
-build_unflags = -D ARDUINO_USB_MODE
-
+    -D ARDUINO_USB_CDC_ON_BOOT=1 # Required for USB Serial on boot (for debugging)  
+    -D ARDUINO_USB_MSC_ON_BOOT=0
+    -D ARDUINO_USB_DFU_ON_BOOT=0
 
 
 [env:dev]

--- a/src/vario/DebugWebserver.cpp
+++ b/src/vario/DebugWebserver.cpp
@@ -1,6 +1,7 @@
 #include "DebugWebserver.h"
-#include "WebServer.h"
 #include <WiFi.h>
+#include "SDcard.h"
+#include "WebServer.h"
 #include "display.h"
 
 WebServer server;
@@ -26,6 +27,7 @@ void webserver_setup() {
           <h1>ESP32 Vario Debug Webserver</h1>
           <ul>
             <li><a href="/screenshot" target="_blank">Download Screenshot</a></li>
+            <li><a href="/mass_storage" target="_blank">Start Mass Storage</a></li>
           </ul>
         </body>
       </html>
@@ -36,6 +38,12 @@ void webserver_setup() {
     send_buffer = "";
     u8g2_WriteBufferXBM(u8g2.getU8g2(), writeScreenshotBuffer);
     server.send(200, "image/x-xbitmap", send_buffer);
+  });
+
+  server.on("/mass_storage", HTTP_GET, []() {
+    // Serial.end();
+    SDCard_SetupMassStorage();
+    server.send(200, "text/html", "OK!");
   });
 
   // Give it a chance to connect so this debug message means something


### PR DESCRIPTION
- Dev mode disables USB Mass storage on boot
- Dev mode can "upload" without the need for the reset buttons now. refactor: update USB mode and mass storage setup

Disable debug output for the SD card and adjust USB mode flags to  ensure proper functionality during boot. Add a new endpoint to the  web server for initiating mass storage mode. This improves the  debugging experience and enhances the usability of the mass storage  feature.

## Test Plan:
![image](https://github.com/user-attachments/assets/6ba60ab2-5029-46af-8239-c39ea66bb69c)
