### PR TITLE
Adding Binary Telemetry

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -59,7 +59,7 @@ build_flags =
 	${env.build_flags}
 	-D WIFI_ON_BOOT  # Enables WiFi on boot
 	-D DEBUG_WEBSERVER  # Enables a web server for debugging
-  
+	; -D ENABLE_TELEMETRY  # Enables debugging telemetry to the SD card (expensive)
 
 build_type = debug  # Might be useful when looking at stack traces
 # Used to take exception traces and decode them to meaningful errors

--- a/src/vario/IMU.cpp
+++ b/src/vario/IMU.cpp
@@ -66,11 +66,6 @@ void imu_update() {
     Serial.print(" z: ");
     Serial.println(az);
   }
-
-    String accelName = "accel,";
-    String accelEntry = accelName + String(at);
-    Telemetry.writeText(accelEntry);
-  
 }
 
 float IMU_getAccel() { return at; }

--- a/src/vario/logbook/flight.cpp
+++ b/src/vario/logbook/flight.cpp
@@ -3,8 +3,8 @@
 #include <SD_MMC.h>
 
 #include "FS.h"
-#include "telemetry.h"
 #include "page_flight_summary.h"
+#include "telemetry.h"
 
 void Flight::startFlight() {
   File trackLogsDir = SD_MMC.open(this->desiredFilePath());
@@ -38,6 +38,9 @@ void Flight::startFlight() {
 
   // Create the file for writing
   file = SD_MMC.open(fileName, "w", true);
+
+  // Start logging telemetry
+  Telemetry.begin();
 }
 
 void Flight::end(const FlightStats stats) {
@@ -49,4 +52,6 @@ void Flight::end(const FlightStats stats) {
   dialog.show(stats);
 }
 
-bool Flight::started() { return (boolean)file; }
+bool Flight::started() {
+  return (boolean)file;
+}

--- a/src/vario/telemetry.cpp
+++ b/src/vario/telemetry.cpp
@@ -4,45 +4,195 @@
 
 #include "Arduino.h"
 #include "gps.h"
-#include "settings.h"
 #include "log.h"
+#include "settings.h"
 
 bool Telemetry_t::begin() {
-  // Get the local time
+// Get the local time
+#ifndef ENABLE_TELEMETRY
+  return true;
+#endif
+
   tm cal;
-  if(!gps_getLocalDateTime(cal)) {
+  if (!gps_getLocalDateTime(cal)) {
     return false;
   }
+
+  // gps.altitude.value();
 
   // format with strftime format.  Eg FlightTrack_2025-01-08_2301
   char fileName[60];
-  String formatString = "/Data/TestData_%F_%H%M%S.csv";
+  String formatString = "/Data/TestData_%F_%H%M%S.dat";
   strftime(fileName, sizeof(fileName), formatString.c_str(), &cal);
 
   // Open the file to write the telemetry
-  file = SD_MMC.open(fileName, "w", true);
+  file = SD_MMC.open(fileName, "wb", true);
   if (!file) {
     return false;
   }
 
-  // Write the CSV header
-  file.println("millis,sensor, value (lat), lng, alt m, speed mps, heading deg");
+  // Write the 32-bit version number 0x01 constant
+  uint32_t version = 0x01;
+  file.write((uint8_t*)&version, sizeof(version));
+  file.flush();
+
+  // Always write the Baro sensor calibrations at the start of the file recording
+  // If we don't do this, subsequent data records will be be missing the calibration data
+  dataChanged |= BARO_SENSOR_CALIBRATIONS_CHANGED;
+
   return true;
 }
 
-void Telemetry_t::end() { file.close(); }
+void Telemetry_t::end() {
+  file.close();
+}
 
-void Telemetry_t::writeText(const String text) {
-  // Only write telemetry if a flight has started
-  if(!flightTimer_isRunning())
+void Telemetry_t::setGPSPosition(int32_t altitude, double latitude, double longitude) {
+  // If the values are the same, don't update
+  if (gpsPosition.altitude == altitude && gpsPosition.latitude == latitude &&
+      gpsPosition.longitude == longitude) {
     return;
-  
-  // Try to start the telemetry file if not started
-  if (!file) {
-    begin();
-    if (!file) return;
   }
-  file.println((String)millis() + "," + text);
+
+  gpsPosition.altitude = altitude;
+  gpsPosition.latitude = latitude;
+  gpsPosition.longitude = longitude;
+  dataChanged |= GPS_POSITION_CHANGED;
+}
+
+void Telemetry_t::setTemperatureHumidity(int32_t temperature, int32_t humidity) {
+  temperatureHumidity.temperature = temperature;
+  temperatureHumidity.humidity = humidity;
+  dataChanged |= TEMPERATURE_HUMIDITY_CHANGED;
+}
+
+void Telemetry_t::setBaroPressure(int32_t d1) {
+  baroPressure.d1 = d1;
+  dataChanged |= BARO_PRESSURE_CHANGED;
+}
+
+void Telemetry_t::setBaroTemp(int32_t d2_t) {
+  baroTemp.d2_t = d2_t;
+  dataChanged |= BARO_TEMP_CHANGED;
+}
+
+void Telemetry_t::setBaroSensorCalibrations(uint16_t c_sens,
+                                            uint16_t c_off,
+                                            uint16_t c_tcs,
+                                            uint16_t c_tco,
+                                            uint16_t c_tref,
+                                            uint16_t c_tempsens) {
+  baroSensorCalibrations.c_sens = c_sens;
+  baroSensorCalibrations.c_off = c_off;
+  baroSensorCalibrations.c_tcs = c_tcs;
+  baroSensorCalibrations.c_tco = c_tco;
+  baroSensorCalibrations.c_tref = c_tref;
+  baroSensorCalibrations.c_tempsens = c_tempsens;
+  dataChanged |= BARO_SENSOR_CALIBRATIONS_CHANGED;
+}
+
+void Telemetry_t::setClimbRate(int32_t climbRate) {
+  this->climbRate.climbRate = climbRate;
+  dataChanged |= CLIMB_RATE_CHANGED;
+}
+
+void Telemetry_t::setIMUOrientation(double q1, double q2, double q3, int16_t accuracy) {
+  imuOrientation.q1 = q1;
+  imuOrientation.q2 = q2;
+  imuOrientation.q3 = q3;
+  imuOrientation.accuracy = accuracy;
+  dataChanged |= IMU_ORIENTATION_CHANGED;
+}
+
+void Telemetry_t::setIMUAcceleration(int16_t x, int16_t y, int16_t z, int8_t accuracy) {
+  imuAcceleration.x = x;
+  imuAcceleration.y = y;
+  imuAcceleration.z = z;
+  imuAcceleration.accuracy = accuracy;
+  dataChanged |= IMU_ACCELERATION_CHANGED;
+}
+
+void Telemetry_t::writeTelemetryRecord(uint32_t timestamp) {
+#ifndef ENABLE_TELEMETRY
+  return;
+#endif
+  // This should serialize the data structures and write them in the specified binary format
+
+  // If there's no data to write, return
+  if (dataChanged == 0 || !file) {
+    return;
+  }
+
+  // Add the timestamp
+  dataChanged |= TIMESTAMP_CHANGED;
+
+  // Write the payloads header
+  file.write((uint8_t*)&dataChanged, sizeof(dataChanged));
+
+  // Write the timestamp
+  if (dataChanged & TIMESTAMP_CHANGED) {
+    file.write((uint8_t*)&timestamp, sizeof(timestamp));
+  }
+
+  // Write the GPS position if changed
+  if (dataChanged & GPS_POSITION_CHANGED) {
+    file.write((uint8_t*)&gpsPosition.altitude, sizeof(gpsPosition.altitude));
+    file.write((uint8_t*)&gpsPosition.latitude, sizeof(gpsPosition.latitude));
+    file.write((uint8_t*)&gpsPosition.longitude, sizeof(gpsPosition.longitude));
+  }
+
+  // Write the temperature and humidity if changed
+  if (dataChanged & TEMPERATURE_HUMIDITY_CHANGED) {
+    file.write((uint8_t*)&temperatureHumidity.temperature, sizeof(temperatureHumidity.temperature));
+    file.write((uint8_t*)&temperatureHumidity.humidity, sizeof(temperatureHumidity.humidity));
+  }
+
+  // Write the baro pressure if changed
+  if (dataChanged & BARO_PRESSURE_CHANGED) {
+    file.write((uint8_t*)&baroPressure.d1, sizeof(baroPressure.d1));
+  }
+
+  // Write the baro temp if changed
+  if (dataChanged & BARO_TEMP_CHANGED) {
+    file.write((uint8_t*)&baroTemp.d2_t, sizeof(baroTemp.d2_t));
+  }
+
+  // Write the baro sensor calibrations if changed
+  if (dataChanged & BARO_SENSOR_CALIBRATIONS_CHANGED) {
+    file.write((uint8_t*)&baroSensorCalibrations.c_sens, sizeof(baroSensorCalibrations.c_sens));
+    file.write((uint8_t*)&baroSensorCalibrations.c_off, sizeof(baroSensorCalibrations.c_off));
+    file.write((uint8_t*)&baroSensorCalibrations.c_tcs, sizeof(baroSensorCalibrations.c_tcs));
+    file.write((uint8_t*)&baroSensorCalibrations.c_tco, sizeof(baroSensorCalibrations.c_tco));
+    file.write((uint8_t*)&baroSensorCalibrations.c_tref, sizeof(baroSensorCalibrations.c_tref));
+    file.write((uint8_t*)&baroSensorCalibrations.c_tempsens,
+               sizeof(baroSensorCalibrations.c_tempsens));
+  }
+
+  // Write the climb rate
+  if (dataChanged & CLIMB_RATE_CHANGED) {
+    file.write((uint8_t*)&climbRate.climbRate, sizeof(climbRate.climbRate));
+  }
+
+  // Write the IMU orientation if changed
+  if (dataChanged & IMU_ORIENTATION_CHANGED) {
+    file.write((uint8_t*)&imuOrientation.q1, sizeof(imuOrientation.q1));
+    file.write((uint8_t*)&imuOrientation.q2, sizeof(imuOrientation.q2));
+    file.write((uint8_t*)&imuOrientation.q3, sizeof(imuOrientation.q3));
+    file.write((uint8_t*)&imuOrientation.accuracy, sizeof(imuOrientation.accuracy));
+  }
+
+  // Write the IMU acceleration if changed
+  if (dataChanged & IMU_ACCELERATION_CHANGED) {
+    file.write((uint8_t*)&imuAcceleration.x, sizeof(imuAcceleration.x));
+    file.write((uint8_t*)&imuAcceleration.y, sizeof(imuAcceleration.y));
+    file.write((uint8_t*)&imuAcceleration.z, sizeof(imuAcceleration.z));
+    file.write((uint8_t*)&imuAcceleration.accuracy, sizeof(imuAcceleration.accuracy));
+  }
+
+  file.flush();
+
+  // Clear the data changed flags
+  dataChanged = 0;
 }
 
 Telemetry_t Telemetry;

--- a/src/vario/telemetry.h
+++ b/src/vario/telemetry.h
@@ -2,21 +2,202 @@
 
 #include "files.h"
 
-/* 
-*  This is a VERY basic CSV telemetry module for logging data.
-*  It currently works by writing data into a csv file every second
-*  This WILL be re-factored into a binary file format for very quick logging
-*  at some point
-*/
-class Telemetry_t {
-    public:
-        Telemetry_t() {}
-        bool begin();
-        void end();
-        void writeText(const String text);
+/*
+ * # Telemetry Logging
+ * Telemetry logging uses a binary file format to log telemetry data.
+ * This is to ensure that the data is logged as quickly and as smallest as possible.
+ *
+ * ## File Format
+ * The binary file log will include a header of the Version of the file format (currently 0x1).
+ * followed by a "payload header" containing a bitfield of ordered telemetry payloads.
+ * Each of the telemetry type payloads are written in the order shown below
+ *
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ * | Version                                                       |
+ * ----------------------------------------------------------------|
+ * |                    Payload Header                             |
+ * ----------------------------------------------------------------|
+ * |                     (payloads...)                             |
+ * ----------------------------------------------------------------|
+ *
+ * ## Payloads (in order)
+ *
+ *
+ * ### Timestamp (bit 1)
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ * |                    Timestamp (micros uint32_t)                |
+ * ----------------------------------------------------------------|
+ *
+ * ### GPS Position (bit 2)
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ * |                    Altitude  (int32_t)                        |
+ * ----------------------------------------------------------------|
+ * |                          Lat                                  |
+ * |                   (double, 64 bits)                           |
+ * ----------------------------------------------------------------|
+ * |                          Long                                 |
+ * |                   (double, 64 bits)                           |
+ * ----------------------------------------------------------------|
+ *
+ * ### Temperature / Humidity (bit 3)
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ * |                    Temp  (int32_t)                            |
+ * ----------------------------------------------------------------|
+ * |                    Humidity (int32_t)                         |
+ * ----------------------------------------------------------------|
+ *
+ * ### Baro Pressure (bit 4)
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ * |        D1 (digital pressure value)  (int32_t)                 |
+ * ----------------------------------------------------------------|
+ *
+ * ### Baro Temp (bit 5)
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ * |        D2_T (digital pressure value)  (int32_t)               |
+ * ----------------------------------------------------------------|
+ *
+ * ### Baro Sensor Calibrations (bit 6)
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ *      uint16_t C_SENS            |         uint16_t C_OFF        |
+ * ----------------------------------------------------------------|
+ *      uint16_t C_TCS             |         uint16_t C_TCO        |
+ * ----------------------------------------------------------------|
+ *      uint16_t C_TREF            |         uint16_t C_TEMPSENS   |
+ * ----------------------------------------------------------------|
+ *
+ * ### Climb Rate (bit 7)
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ * |                      int32_t climb_rate                       |
+ * ----------------------------------------------------------------|
+ *
+ *
+ * ### IMU Orientation Quaternion 9-dof (bit 8)
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ * |                          q1                                   |
+ * |                   (double, 64 bits)                           |
+ * ----------------------------------------------------------------|
+ * |                          q2                                   |
+ * |                   (double, 64 bits)                           |
+ * ----------------------------------------------------------------|
+ * |                          q3                                   |
+ * |                   (double, 64 bits)                           |
+ * ----------------------------------------------------------------|
+ * |      Accuracy (int16_5)       |                               |
+ *
+ * ### IMU Acceleration (bit 9)
+ * 1               8               16                              32
+ * ----------------------------------------------------------------|
+ *      int16_t x                  |          int16_t y            |
+ * ----------------------------------------------------------------|
+ *      int16_t z                  |int8_t accuracy|               |
+ * ----------------------------------------------------------------|
+ *
+ */
 
-    private:
-        File file;
+struct T_Timestamp {
+  uint32_t micros;
+};
+
+struct T_GPSPosition {
+  int32_t altitude;
+  int64_t latitude;
+  int64_t longitude;
+};
+
+struct T_TemperatureHumidity {
+  int32_t temperature;
+  int32_t humidity;
+};
+
+struct T_BaroPressure {
+  int32_t d1;
+};
+
+struct T_BaroTemp {
+  int32_t d2_t;
+};
+
+struct T_BaroSensorCalibrations {
+  uint16_t c_sens;
+  uint16_t c_off;
+  uint16_t c_tcs;
+  uint16_t c_tco;
+  uint16_t c_tref;
+  uint16_t c_tempsens;
+};
+
+struct T_ClimbRate {
+  int32_t climbRate;
+};
+
+struct T_IMUOrientation {
+  double q1;
+  double q2;
+  double q3;
+  int16_t accuracy;
+};
+
+struct T_IMUAcceleration {
+  int16_t x;
+  int16_t y;
+  int16_t z;
+  int8_t accuracy;
+};
+
+class Telemetry_t {
+ public:
+  Telemetry_t() : dataChanged(0) {}
+  bool begin();
+  void end();
+
+  void setGPSPosition(int32_t altitude, double latitude, double longitude);
+  void setTemperatureHumidity(int32_t temperature, int32_t humidity);
+  void setBaroPressure(int32_t d1);
+  void setBaroTemp(int32_t d2_t);
+  void setBaroSensorCalibrations(uint16_t c_sens,
+                                 uint16_t c_off,
+                                 uint16_t c_tcs,
+                                 uint16_t c_tco,
+                                 uint16_t c_tref,
+                                 uint16_t c_tempsens);
+  void setIMUOrientation(double q1, double q2, double q3, int16_t accuracy);
+  void setIMUAcceleration(int16_t x, int16_t y, int16_t z, int8_t accuracy);
+  void setClimbRate(int32_t climbRate);
+  void writeTelemetryRecord(uint32_t timestamp);
+
+ private:
+  File file;
+  T_GPSPosition gpsPosition;
+  T_TemperatureHumidity temperatureHumidity;
+  T_BaroPressure baroPressure;
+  T_BaroTemp baroTemp;
+  T_BaroSensorCalibrations baroSensorCalibrations;
+  T_ClimbRate climbRate;
+  T_IMUOrientation imuOrientation;
+  T_IMUAcceleration imuAcceleration;
+
+  uint32_t dataChanged;
+
+  enum DataChangedFlags {
+    TIMESTAMP_CHANGED = 1 << 0,                 // Bit 1
+    GPS_POSITION_CHANGED = 1 << 1,              // Bit 2
+    TEMPERATURE_HUMIDITY_CHANGED = 1 << 2,      // Bit 3
+    BARO_PRESSURE_CHANGED = 1 << 3,             // Bit 4
+    BARO_TEMP_CHANGED = 1 << 4,                 // Bit 5
+    BARO_SENSOR_CALIBRATIONS_CHANGED = 1 << 5,  // Bit 6
+    CLIMB_RATE_CHANGED = 1 << 6,                // Bit 7
+    IMU_ORIENTATION_CHANGED = 1 << 7,           // Bit 8
+    IMU_ACCELERATION_CHANGED = 1 << 8           // Bit 9
+  };
 };
 
 extern Telemetry_t Telemetry;

--- a/src/vario/tempRH.cpp
+++ b/src/vario/tempRH.cpp
@@ -1,6 +1,7 @@
 #include "tempRH.h"
 
 #include "Leaf_I2C.h"
+#include "telemetry.h"
 
 #define DEBUG_TEMPRH 0  // flag for outputting debugf messages on UBS serial port
 
@@ -9,9 +10,13 @@ bool measurementStarted = false;
 float ambientTemp = 0;      // calculated deg C
 float ambientHumidity = 0;  // calculated % relative humidity
 
-float tempRH_getTemp() { return ambientTemp; }
+float tempRH_getTemp() {
+  return ambientTemp;
+}
 
-float tempRH_getHumidity() { return ambientHumidity; }
+float tempRH_getHumidity() {
+  return ambientHumidity;
+}
 
 bool tempRH_init() {
   bool success = true;
@@ -88,6 +93,10 @@ void tempRH_update(uint8_t process_step) {
       ambientTemp += TEMP_OFFSET;
       ambientHumidity = ((float)sensorData.humidity / 1048576) * 100;
       currently_processing = false;
+
+      // Write to telemetry
+      Telemetry.setTemperatureHumidity(ambientTemp, ambientHumidity);
+
       if (DEBUG_TEMPRH) {
         Serial.print("Temp_RH - Temp: ");
         Serial.print(ambientTemp);
@@ -170,9 +179,13 @@ bool tempRH_initialize() {
   return false;
 }
 
-bool tempRH_isBusy() { return (tempRH_getStatus() & (1 << 7)); }
+bool tempRH_isBusy() {
+  return (tempRH_getStatus() & (1 << 7));
+}
 
-bool tempRH_isCalibrated() { return (tempRH_getStatus() & (1 << 3)); }
+bool tempRH_isCalibrated() {
+  return (tempRH_getStatus() & (1 << 3));
+}
 
 uint8_t tempRH_getStatus() {
   Wire.requestFrom(ADDR_AHT20, (uint8_t)1);

--- a/src/vario/vario.ino
+++ b/src/vario/vario.ino
@@ -14,6 +14,7 @@
 #include "power.h"
 #include "settings.h"
 #include "speaker.h"
+#include "telemetry.h"
 #include "tempRH.h"
 #include "wind_estimate/wind_estimate.h"
 
@@ -417,6 +418,8 @@ void taskManager(void) {
     SDcard_update();
     taskman_SDCard = 0;
   }
+  // Log telemetry (no-op is no changes)
+  Telemetry.writeTelemetryRecord(micros());
 
   if (taskman_didSomeTasks && DEBUG_MAIN_LOOP) {
     taskman_didSomeTasks = 0;


### PR DESCRIPTION
- Using a build flag (commented out), we can enable writing telemetry data.  This is very expensive, a bit slow, and will use up a lot of SD card space.
- The telemetry can be viewed at https://github.com/scottyob/leaf-telemetry-viewer

- We have removed CSV telemetry, but, you can use that online tool to dump a CSV file.
