### PR TITLE
Logger bugfixes

### DIFF
--- a/src/vario/log.cpp
+++ b/src/vario/log.cpp
@@ -92,9 +92,9 @@ void log_update() {
 
       // We have a GPS fix, we're able to start recording of the flight.
       // TODO:  A second sound effect to show that recording has now started??
-      flight->startFlight();
-      // TODO:  Make this sound much cooler
-      speaker_playSound(fx_buttonhold);
+      if (flight->startFlight())
+        // TODO:  Make this sound much cooler
+        speaker_playSound(fx_buttonhold);
     }
 
     // Generate a record to log

--- a/src/vario/logbook/flight.cpp
+++ b/src/vario/logbook/flight.cpp
@@ -3,10 +3,14 @@
 #include <SD_MMC.h>
 
 #include "FS.h"
+#include "SDcard.h"
 #include "telemetry.h"
 #include "ui/page_flight_summary.h"
 
-void Flight::startFlight() {
+bool Flight::startFlight() {
+  // Short circuit if the card is not mounted or reading properly
+  if (!SDcard_present()) return false;
+  Serial.printf("Sectors: %d\n", SD_MMC.numSectors());
   File trackLogsDir = SD_MMC.open(this->desiredFilePath());
 
   auto filePrefix = this->desiredFilePath() + "/" + this->desiredFileName();
@@ -38,6 +42,8 @@ void Flight::startFlight() {
 
   // Create the file for writing
   file = SD_MMC.open(fileName, "w", true);
+
+  return true;
 }
 
 void Flight::end(const FlightStats stats) {

--- a/src/vario/logbook/flight.h
+++ b/src/vario/logbook/flight.h
@@ -6,8 +6,9 @@
 
 class Flight {
  public:
-  // We wish to start recording a flight
-  virtual void startFlight();
+  // We wish to start recording a flight.
+  // Returns:  Flight log created successfully
+  virtual bool startFlight();
   virtual void end(const FlightStats stats);
 
   // Logs a datapoint

--- a/src/vario/logbook/igc.cpp
+++ b/src/vario/logbook/igc.cpp
@@ -104,7 +104,10 @@ void Igc::startFlight() {
 }
 
 void Igc::end(const FlightStats stats) {
-  logger.writeGRecord();
+  // If we've not started a flight yet, don't write to disk.
+  if (started()) {
+    logger.writeGRecord();
+  }
   Flight::end(stats);
 }
 

--- a/src/vario/logbook/igc.cpp
+++ b/src/vario/logbook/igc.cpp
@@ -54,6 +54,9 @@ const String Igc::desiredFileName() const {
 }
 
 void Igc::log(unsigned long durationSec) {
+  // Short-circuit if we've not yet started a flight
+  if (!started()) return;
+
   // Generate the time in HHMMSS
   char buf[8];
   tm cal;
@@ -69,8 +72,9 @@ void Igc::log(unsigned long durationSec) {
                       toDigits((int)gpsFixInfo.error, 3));
 }
 
-void Igc::startFlight() {
-  Flight::startFlight();
+bool Igc::startFlight() {
+  auto success = Flight::startFlight();
+  if (!success) return false;
 
   logger.setOutput(file);
 
@@ -101,6 +105,8 @@ void Igc::startFlight() {
   // Log the I record (saying we're going to log the, now manditory, FXA record)
   const IRecordExtension extensions[] = {IRecordExtension(3, "FXA")};
   logger.writeIRecord(sizeof(extensions) / sizeof(extensions[0]), extensions);
+
+  return true;
 }
 
 void Igc::end(const FlightStats stats) {

--- a/src/vario/logbook/igc.h
+++ b/src/vario/logbook/igc.h
@@ -7,7 +7,7 @@
 
 class Igc : public Flight {
  public:
-  void startFlight() override;
+  bool startFlight() override;
   void end(const FlightStats stats) override;
 
   const String fileNameSuffix() const override { return "igc"; }

--- a/src/vario/logbook/kml.cpp
+++ b/src/vario/logbook/kml.cpp
@@ -18,9 +18,10 @@ const String Kml::desiredFileName() const {
   return fileString;
 }
 
-void Kml::startFlight() {
-  Flight::startFlight();
+bool Kml::startFlight() {
+  if (!Flight::startFlight()) return false;
   file.println(KMLtrackHeader);
+  return true;
 }
 
 void Kml::log(unsigned long durationSec) {

--- a/src/vario/logbook/kml.h
+++ b/src/vario/logbook/kml.h
@@ -3,12 +3,10 @@
 
 class Kml : public Flight {
  public:
-  void startFlight() override;
+  bool startFlight() override;
   void end(const FlightStats stats) override;
 
-  const String fileNameSuffix() const override {
-    return "kml";
-  }
+  const String fileNameSuffix() const override { return "kml"; }
   const String desiredFileName() const override;
   void log(unsigned long durationSec) override;
 };


### PR DESCRIPTION
- Fixes #96 
- Fixed #65 

- Won't try to record a flight without SD card mounted.  
- Won't try to write records or suffix without a flight record started.