### PR TITLE
Make version.h more robust, clean up warnings

### DIFF
--- a/src/scripts/versioning.py
+++ b/src/scripts/versioning.py
@@ -145,22 +145,26 @@ def update_version_header(env, firmware_version, tag_version, hardware_variant) 
     # Back up current version.h content
     original_version_h_path = os.path.join(vario_path, "version.h.original")
     shutil.copy2(version_h_path, original_version_h_path)
+    print("[versioning.py] version.h backed up to version.h.original")
 
     # Define action to restore version.h to its original state when needed
     restored = False
     def restore_version_h():
         nonlocal restored
         if not restored:
-            print("[versioning.py] Restoring version.h to its original content")
-            shutil.copy2(original_version_h_path, version_h_path)
-            os.remove(original_version_h_path)
+            if os.path.exists(original_version_h_path):
+                print("[versioning.py] Restoring version.h to its original content")
+                shutil.copy2(original_version_h_path, version_h_path)
+                os.remove(original_version_h_path)
 
-            if timestamp:
-                # Restore version.h's last-modified timestamp
-                print(f"[versioning.py] Setting date modified to {datetime.fromtimestamp(timestamp)}")
-                current_time = time.time()
-                os.utime(version_h_path, (current_time, timestamp))
-            restored = True
+                if timestamp:
+                    # Restore version.h's last-modified timestamp
+                    print(f"[versioning.py] Setting date modified to {datetime.fromtimestamp(timestamp)}")
+                    current_time = time.time()
+                    os.utime(version_h_path, (current_time, timestamp))
+                restored = True
+            else:
+                print("[versioning.py] Could not restore version.h to its original content because version.h.original was missing")
         else:
             print("[versioning.py] Already restored version.h to its original content")
 

--- a/src/vario/io_pins.cpp
+++ b/src/vario/io_pins.cpp
@@ -7,11 +7,11 @@
 
 // Pin configuration for the IO Expander (0=output 1=input)
 #ifndef IOEX_REG_CONFIG_PORT0
-#define IOEX_REG_CONFIG_PORT0 B11111111  // default all inputs
+#define IOEX_REG_CONFIG_PORT0 0b11111111  // default all inputs
 #endif
 
 #ifndef IOEX_REG_CONFIG_PORT1
-#define IOEX_REG_CONFIG_PORT1 B11111111  // default all inputs
+#define IOEX_REG_CONFIG_PORT1 0b11111111  // default all inputs
 #endif
 
 // Create IO Expander

--- a/src/vario/wind_estimate/wind_estimate.cpp
+++ b/src/vario/wind_estimate/wind_estimate.cpp
@@ -37,7 +37,8 @@ WindEstimate getWindEstimate(void) { return windEstimate; }
 
 void windEstimate_onNewSentence(NMEASentenceContents contents) {
   if (contents.course || contents.speed) {
-    GroundVelocity v = {.trackAngle = DEG_TO_RAD * gps.course.deg(), .speed = gps.speed.mps()};
+    GroundVelocity v = {.trackAngle = (float)(DEG_TO_RAD * gps.course.deg()),
+                        .speed = (float)gps.speed.mps()};
 
     if (getAreWeFlying()) submitVelocityForWindEstimate(v);
   }


### PR DESCRIPTION
Based on observing `shutil.copy2(original_version_h_path, version_h_path)` fail, this PR tries to avoid that error even in edge case situations (though I'm still not sure how it could have happened).  It also adds slightly more logging to potentially identify similar situations in the future.

This PR also resolves a few small build warnings that were distracting in troubleshooting.