### PR TITLE
gpx cleanup: Route array -> vector

### DIFF
--- a/src/vario/baro.cpp
+++ b/src/vario/baro.cpp
@@ -322,7 +322,7 @@ void Barometer::update(bool startNewCycle, bool doTemp) {
       // finally, update the speaker sound based on the new climbrate
       speaker_updateVarioNote(climbRateFiltered);
 
-      Serial.println("**BR** climbRate Filtered: " + String(climbRateFiltered));
+      if (DEBUG_BARO) Serial.println("**BR** climbRate Filtered: " + String(climbRateFiltered));
 
       break;
   }

--- a/src/vario/gpx.h
+++ b/src/vario/gpx.h
@@ -10,7 +10,6 @@
 #define waypointRadius 150  // meters radius to count as "reaching/crossing" a waypoint
 #define maxWaypoints 15
 #define maxRoutes 5
-#define maxRoutePoints 12
 
 struct Waypoint {
   String name;
@@ -22,8 +21,7 @@ struct Waypoint {
 // Route definition and memory allocation
 struct Route {
   String name;
-  uint8_t totalPoints = 0;
-  Waypoint routepoints[maxRoutePoints];
+  std::vector<Waypoint> routepoints;
 };
 
 // GPXdata object for storing available waypoints and routes
@@ -41,26 +39,30 @@ struct GPXnav {
   Waypoint nextPoint;    // next waypoint in the current route
   Waypoint goalPoint;    // final waypoint in the current route
 
-  int16_t activePointIndex =
-      0;  // waypoint currently navigating to (index value for element inside of waypoints[], or
-          // inside of route.routepoints[], if on an active route)
-  int16_t nextPointIndex =
-      0;  // the next waypoint (can prepare you which direction you'll need to turn next as you
-          // approach the currently active waypoint).  We create this as a separate variable
-          // (instead of just adding 1 to the acive index) because sometimes there IS NO next point
-          // (i.e., you're on the last point) and we want to know this.
-  int16_t activeRouteIndex =
-      0;  // route currently navigating along (index value for route inside of routes[])
+  // (1-based) waypoint currently navigating to (index value for element inside of waypoints[], or
+  // inside of route.routepoints, if on an active route)
+  int16_t activePointIndex = 0;
+  // (1-based) the next waypoint (can prepare you which direction you'll need to turn next as you
+  // approach the currently active waypoint).  We create this as a separate variable
+  // (instead of just adding 1 to the acive index) because sometimes there IS NO next point
+  // (i.e., you're on the last point) and we want to know this.
+  int16_t nextPointIndex = 0;
+  // (1-based) route currently navigating along (index value for route inside of routes[])
+  int16_t activeRouteIndex = 0;
 
-  int32_t altAboveWaypoint = 0;  // (gps measured) Altitude in cm above current waypoint
-  int32_t altAboveGoal = 0;      // (gps measured) Altitude in cm above goal waypoint
+  // (gps measured) Altitude in cm above current waypoint
+  int32_t altAboveWaypoint = 0;
+  // (gps measured) Altitude in cm above goal waypoint
+  int32_t altAboveGoal = 0;
 
-  float averageSpeed =
-      0;  // keep a running average speed, to smooth out glide ratio and time-remaning calculations.
+  // keep a running average speed, to smooth out glide ratio and time-remaning calculations.
+  float averageSpeed = 0;
 
-  float glideToActive = 0;  // glide ratio from current position to active waypoint
-  float glideToGoal = 0;    // glide ratio from current position to final (goal) waypoint, ALONG the
-                            // route //TODO: should this be along route or straight to?
+  // glide ratio from current position to active waypoint
+  float glideToActive = 0;
+  // glide ratio from current position to final (goal) waypoint, ALONG the
+  // route //TODO: should this be along route or straight to?
+  float glideToGoal = 0;
 
   double segmentDistance;         // distance between adjacent waypoints
   double pointDistanceRemaining;  // distance remaining to next waypoint

--- a/src/vario/gpx_parser.cpp
+++ b/src/vario/gpx_parser.cpp
@@ -367,7 +367,7 @@ bool GPXParser::readFullTagName(char* key) {
 }
 
 bool GPXParser::readRoute(Route* route) {
-  route->totalPoints = 0;
+  route->routepoints.clear();
 
   char key[MAX_VALUE_LENGTH + 1];
   char value[MAX_VALUE_LENGTH + 1];
@@ -399,19 +399,12 @@ bool GPXParser::readRoute(Route* route) {
       break;
     } else if (equalsIgnoreCase(key, "rtept")) {
       // This is an opening route point tag
-      if (route->totalPoints >= maxRoutePoints) {
-        _error = "maximum number of route points exceeded";
-        return false;
-      }
       Waypoint waypoint;
       if (!readWaypoint(&waypoint, "rtept")) {
         _error = " while reading rtept";
         return false;
       }
-      route->routepoints[route->totalPoints + 1] =
-          waypoint;  // TODO: changed to add +1 to index, now routepoints start at 1, not 0.  Change
-                     // back if desired later
-      route->totalPoints++;
+      route->routepoints.push_back(waypoint);
     } else if (equalsIgnoreCase(key, "name")) {
       // This is an opening name tag
       if (!readLiteral(value)) {


### PR DESCRIPTION
This PR starts cleanup of gpx (navigation/routes/waypoints) by changing the statically-sized array in Route to a vector.

It also re-silences a noisy baro Serial statement that got unsilenced in the merge of parallel PRs and places comments on certain variables before the variables rather than after them on the same line (and following lines).