### PR TITLE
Update to specified tag version rather than latest

### DIFF
--- a/src/vario/ota.cpp
+++ b/src/vario/ota.cpp
@@ -7,21 +7,24 @@
 
 #include "version.h"
 
-String getLatestVersion() {
+String getLatestTagVersion() {
+  Serial.print("[OTA] Getting latest tag version from ");
+  Serial.println(OTA_VERSIONS_URL);
   HTTPClient http;
-  String url = "https://" + String(OTA_HOST) + OTA_VERSIONS_FILENAME;
-  http.begin(url);
+  http.begin(OTA_VERSIONS_URL);
   http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
   int httpCode = http.GET();
   if (httpCode != HTTP_CODE_OK) {
-    throw std::runtime_error(((String) "HTTP GET failed with code " + httpCode).c_str());
+    throw std::runtime_error(((String) "HTTP GET failed " + httpCode).c_str());
   }
 
   String payload = http.getString();
   JsonDocument doc;
   deserializeJson(doc, payload);
 
-  return doc["latest_tag_versions"][HARDWARE_VARIANT];
+  String tagVersion = doc["latest_tag_versions"][HARDWARE_VARIANT];
+  Serial.printf("[OTA] Latest tag version for %s is %s\n", HARDWARE_VARIANT, tagVersion);
+  return tagVersion;
 }
 
 /*
@@ -30,34 +33,36 @@ String getLatestVersion() {
    TODO:  Have this return a data type with meaningul information
    about the result
 */
-void PerformOTAUpdate() {
+void PerformOTAUpdate(const char* tag) {
+  char url[120];
+  snprintf(url, sizeof(url), OTA_BIN_URL, tag);
+  Serial.print("[OTA] Starting OTA from ");
+  Serial.println(url);
   HTTPClient http;
-
-  http.begin(String("https://") + OTA_HOST + OTA_BIN_FILENAME);
+  http.begin(url);
   http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
-  Serial.println("Starting OTA over HTTPS");
   auto httpCode = http.GET();
   if (httpCode != HTTP_CODE_OK) {
-    throw std::runtime_error(((String) "HTTP GET failed with code " + httpCode).c_str());
+    throw std::runtime_error(((String) "HTTP GET failed " + httpCode).c_str());
   }
 
   auto binarySize = http.getSize();
-  Serial.print("Remote binary size: ");
+  Serial.print("[OTA] Remote binary size: ");
   Serial.println(binarySize);
 
   auto payloadPtr = http.getStreamPtr();
   Update.begin(binarySize);
   if (Update.writeStream(*payloadPtr) != binarySize) {
-    throw std::runtime_error("Error writing binary to flash");
+    throw std::runtime_error("Err writing bin->flash");
   }
 
-  Serial.println("OTA done!");
+  Serial.println("[OTA] Done!");
 
   if (Update.end()) {
-    Serial.println("Update successfully completed. Rebooting.");
+    Serial.println("[OTA] Update successfully completed. Rebooting.");
     ESP.restart();
   } else {
-    throw std::runtime_error("Error finishing firmware update");
+    throw std::runtime_error("Err finishing update");
   }
 
   delay(1000);

--- a/src/vario/ota.h
+++ b/src/vario/ota.h
@@ -3,8 +3,8 @@
 #include <Update.h>
 #include <WiFi.h>
 
-// Gets the latest version from Github's version!
-String getLatestVersion();
+// Gets the latest tag version for this hardware variant from latest release on Github
+String getLatestTagVersion();
 
 // Performs an over the air update
-void PerformOTAUpdate();
+void PerformOTAUpdate(const char* tag);

--- a/src/vario/ui/PageMenuSystemWifi.cpp
+++ b/src/vario/ui/PageMenuSystemWifi.cpp
@@ -187,9 +187,8 @@ void PageMenuSystemWifiUpdate::loop() {
       }
       break;
     case WifiState::OTA_CHECKING_VERSION: {
-      String latest_version;
       try {
-        latest_version = getLatestVersion();
+        latest_version_ = getLatestTagVersion();
       } catch (const std::runtime_error& e) {
         log_lines.push_back("*ERROR WHILE CHECKING");
         log_lines.push_back("*");
@@ -197,13 +196,13 @@ void PageMenuSystemWifiUpdate::loop() {
         *wifi_state = WifiState::ERROR;
         break;
       }
-      if (latest_version == TAG_VERSION) {
+      if (latest_version_ == TAG_VERSION && !OTA_ALWAYS_UPDATE) {
         log_lines.push_back("*YOU'RE UP TO DATE!");
         *wifi_state = WifiState::OTA_UP_TO_DATE;
       } else {
         log_lines.push_back("*NEW VERSION AVAILABLE!");
         log_lines.push_back("*UPDATING TO:");
-        log_lines.push_back((String) "   " + latest_version);
+        log_lines.push_back((String) "   " + latest_version_ + " for " + HARDWARE_VARIANT);
         log_lines.push_back("(this will take a while)");
         log_lines.push_back("*WILL REBOOT WHEN DONE");
         *wifi_state = WifiState::OTA_UPDATING;
@@ -211,8 +210,7 @@ void PageMenuSystemWifiUpdate::loop() {
     } break;
     case WifiState::OTA_UPDATING:
       try {
-        // TODO:  Enable this
-        PerformOTAUpdate();
+        PerformOTAUpdate(latest_version_.c_str());
       } catch (const std::runtime_error& e) {
         log_lines.push_back("*ERROR UPDATING!");
         log_lines.push_back("*");

--- a/src/vario/ui/PageMenuSystemWifi.h
+++ b/src/vario/ui/PageMenuSystemWifi.h
@@ -96,6 +96,7 @@ class PageMenuSystemWifiUpdate : public SimpleSettingsMenuPage {
  private:
   WifiState* wifi_state;
   etl::vector<String, 20> log_lines;  // Log of the update process
+  String latest_version_;
 };
 
 /////////////////////////////////////////

--- a/src/vario/version.h
+++ b/src/vario/version.h
@@ -12,7 +12,13 @@
 // ---------------------------------------------------------------
 
 // Where to check for the latest version
-#define OTA_HOST "github.com"
-#define OTA_BIN_FILENAME \
-  "/DangerMonkeys/leaf/releases/latest/download/firmware-" HARDWARE_VARIANT ".bin"
-#define OTA_VERSIONS_FILENAME "/DangerMonkeys/leaf/releases/latest/download/latest_versions.json"
+#define OTA_ORG "DangerMonkeys"
+
+#define OTA_BIN_PATH OTA_ORG "/leaf/releases/download/v%s/firmware-" HARDWARE_VARIANT ".bin"
+#define OTA_BIN_URL "https://github.com/" OTA_BIN_PATH
+
+#define OTA_VERSIONS_PATH OTA_ORG "/leaf/releases/latest/download/latest_versions.json"
+#define OTA_VERSIONS_URL "https://github.com/" OTA_VERSIONS_PATH
+
+// If true, always perform OTA update regardless of whether already on latest version
+#define OTA_ALWAYS_UPDATE false


### PR DESCRIPTION
Currently, the OTA update procedure downloads and installs firmware for the latest tag version regardless of what latest_versions.json says should be used for the particular hardware variant.  This PR fixes that by downloading the tag version specified for the hardware variant in latest_versions.json.  This enables future removal of ongoing support for older hardware without breaking it if the user attempts to use OTA updates.

A few additional Serial messages are added in case someone needs to debug functionality in the future, and this should be a minimal burden because of how infrequently this functionality is used.  A few messages are shortened so their content is actually visible on the LCD (before, the useful information was off the screen).

This PR has been tested successfully on 3.2.3 by verifying that Update can be commanded multiple times successfully (each time recognizing that the software is already on the latest tag version), and also that the update works properly (tested twice) by setting the `OTA_ALWAYS_UPDATE` constant to `true`.

There are difficulties with 3.2.5 as documented in #108 but should not be due to these changes.