### PR TITLE
[Trivial] Debug webserver port

### DIFF
--- a/src/vario/DebugWebserver.cpp
+++ b/src/vario/DebugWebserver.cpp
@@ -167,10 +167,12 @@ void webserver_setup() {
     server.send(200, "text/html", "OK!");
   });
 
-  // Give it a chance to connect so this debug message means something
-  delay(1000);
-  server.begin();
-  Serial.println("Webserver started: http://" + WiFi.localIP().toString());
+  // Give it a chance to connect so this debug message means something.
+  delay(250);
+  // The captive portal belongs on port 80 for setting up WiFi.  Keep the debug
+  // webserver on port 81.
+  server.begin(81);
+  Serial.printf("Webserver started: http://%s:81/\n", WiFi.localIP().toString());
 }
 
 void webserver_loop() { server.handleClient(); }


### PR DESCRIPTION
- When running debug builds, webserver prevents WiFi setup using captive portal.
- This changes the webserver to run on port 81 instead.

## Test Plan:
```
Initializing Taskman Service
WiFi Event 0.0.0.0: 112
WiFi Event 10.11.1.76: 115
Webserver started: http://10.11.1.76:81/
```
