### PR TITLE
[Bugfix][For Discussion] Unload BLE on OTA.

### DIFF
--- a/src/vario/ble.cpp
+++ b/src/vario/ble.cpp
@@ -130,6 +130,9 @@ void BLE::end() {
 }
 
 void BLE::on_receive(const GpsReading& msg) {
+  // Short circuit if not initialized
+  if (pServer == nullptr) return;
+
   // Only process GPS updates twice a second at most.
   if (millis() - lastGpsMs < 500) {
     return;
@@ -141,6 +144,9 @@ void BLE::on_receive(const GpsReading& msg) {
 }
 
 void BLE::on_receive(const FanetPacket& msg) {
+  // Short circuit if not initialized
+  if (pServer == nullptr) return;
+
   WakeupMessage message(WakeupMessage::Reason::FANET_RX, msg);
   xQueueSend(BLE::get().xQueue, &message, 0);
 }

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -191,7 +191,12 @@ void power_latch_on() { digitalWrite(POWER_LATCH, HIGH); }
 
 // If no USB power is available, systems will immediately lose
 // power and shut down (after user lets go of center button)
-void power_latch_off() { digitalWrite(POWER_LATCH, LOW); }
+void power_latch_off() {
+  digitalWrite(POWER_LATCH, LOW);
+  // In the case the device is charging, OR the user is holding
+  // down the center button, reboot
+  esp_restart();
+}
 
 void power_update() {
   // update battery state

--- a/src/vario/ui/PageMenuSystemWifi.h
+++ b/src/vario/ui/PageMenuSystemWifi.h
@@ -92,6 +92,7 @@ class PageMenuSystemWifiUpdate : public SimpleSettingsMenuPage {
   void shown() override;
   void draw_extra() override;
   void loop() override;
+  virtual void closed(bool removed_from_Stack) override;
 
  private:
   WifiState* wifi_state;


### PR DESCRIPTION
tldr;  Changes behavior to de-init BLE when checking for OTA updates using TLS.  Open for discussion or a hijack to do it in a better way, as this forces operator to reboot device after ¯\_(ツ)_/¯.

Quick and dirty hack for #108

Longer version:

* TLS is expensive.
* We don't have telemetry to figure out *how* much memory this is using to do HTTPS, but [this reference](https://github.com/espressif/arduino-esp32/issues/4523#issuecomment-725529583) suggests 64K.
* With all bells and whistles loaded, we're currently sitting at about 53K of Free HEAP memory at the best of times.
* Worst offenders we know by far are BLE and WiFi.
* This unloads BLE, freeing up ~58KB of RAM before performing the OTA check.

Test Plan:
1. Enable periodic heap memory usage dump:  https://leafvario.com/dev-references/debug-memory/
2. Perform OTA update.

### Before BLE Unload
```
=== Memory Stats ===
Total Heap: 275 KB
Free Heap: 53 KB
Used Heap: 221 KB
Largest Free Block: 30 KB
Minimum Free Heap Ever: 51 KB
Main Task Stack High Water Mark: 12 KB
Free PSRAM: 0 bytes
Largest Free PSRAM Block: 0 bytes
====================
```

### After
```
button: CENTER state: RELEASED  hold count: 0
[ 14489][E][NetworkClient.cpp:323] setSocketOption(): fail on 0, errno: 9, "Bad file number"
=== Memory Stats ===
Total Heap: 275 KB
Free Heap: 111 KB
Used Heap: 163 KB
Largest Free Block: 31 KB
Minimum Free Heap Ever: 44 KB
Main Task Stack High Water Mark: 11 KB
Free PSRAM: 0 bytes
Largest Free PSRAM Block: 0 bytes
====================
```
