### PR TITLE
Graceful reboot

### DIFF
--- a/src/vario/ota.cpp
+++ b/src/vario/ota.cpp
@@ -5,6 +5,7 @@
 
 #include <stdexcept>
 
+#include "settings.h"
 #include "version.h"
 
 String getLatestVersion() {
@@ -55,6 +56,8 @@ void PerformOTAUpdate() {
 
   if (Update.end()) {
     Serial.println("Update successfully completed. Rebooting.");
+    BOOT_TO_ON = true;  // restart into 'on' state on reboot
+    settings_save();
     ESP.restart();
   } else {
     throw std::runtime_error("Error finishing firmware update");

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -51,13 +51,19 @@ void power_bootUp() {
 void power_init() {
   Serial.print("power_init: ");
   Serial.println(power.onState);
-  // Set output / input pins to control battery charge and power supply
+
+  // configure power-latch pin for main power regulator
   pinMode(POWER_LATCH, OUTPUT);
+  digitalWrite(POWER_LATCH, LOW);  // start with power OFF (to handle reboots etc)
+
+  // Set output / input pins to control battery charge and power supply
   pinMode(POWER_CHARGE_I1, OUTPUT);
   pinMode(POWER_CHARGE_I2, OUTPUT);
   pinMode(POWER_CHARGE_GOOD, INPUT_PULLUP);
   pinMode(BATT_SENSE, INPUT);
   power_setInputCurrent(i500mA);  // set default current
+
+  // populate battery % and charging state
   power_readBatteryState();
 }
 

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -23,12 +23,17 @@ POWER power;  // struct for battery-state and on-state variables
 void power_bootUp() {
   power_init();  // configure power supply
 
+  // grab user settings (or populate defaults if no saved settings)
+  settings_init();
+
   // initialize Buttons and check if holding the center button is what turned us on
   auto button = buttons_init();
 
-  if (button == Button::CENTER) {
-    // if center button turned us on, set state to ON (as opposed to charging state,
-    // which can turn us on if plugged into USB but not by the center button)
+  // go to "ON" state if button (user input) or BOOT_TO_ON flag from firmware update
+  if (button == Button::CENTER || BOOT_TO_ON) {
+    BOOT_TO_ON = false;
+    settings_save();
+
     power.onState = POWER_ON;
 
     display_showOnSplash();  // show the splash screen if user turned us on
@@ -37,9 +42,6 @@ void power_bootUp() {
     // if not center button, then USB power turned us on, go into charge mode
     power.onState = POWER_OFF_USB;
   }
-
-  // grab user settings (or populate defaults if no saved settings)
-  settings_init();
 
   // init peripherals (even if we're not turning on and just going into
   // charge mode, we still need to initialize devices so we can put some
@@ -52,11 +54,8 @@ void power_init() {
   Serial.print("power_init: ");
   Serial.println(power.onState);
 
-  // configure power-latch pin for main power regulator
-  pinMode(POWER_LATCH, OUTPUT);
-  digitalWrite(POWER_LATCH, LOW);  // start with power OFF (to handle reboots etc)
-
   // Set output / input pins to control battery charge and power supply
+  pinMode(POWER_LATCH, OUTPUT);
   pinMode(POWER_CHARGE_I1, OUTPUT);
   pinMode(POWER_CHARGE_I2, OUTPUT);
   pinMode(POWER_CHARGE_GOOD, INPUT_PULLUP);
@@ -90,6 +89,8 @@ void power_init_peripherals() {
   if (power.onState == POWER_ON) {
     power_latch_on();
     speaker_playSound(fx_enter);
+  } else {
+    power_latch_off();  // turn off 3.3V regulator (if we're plugged into USB, we'll stay on)
   }
 
   // then initialize the rest of the devices

--- a/src/vario/settings.cpp
+++ b/src/vario/settings.cpp
@@ -37,12 +37,15 @@ SettingLogFormat LOG_FORMAT;
 // System Settings
 int16_t TIME_ZONE;
 int8_t VOLUME_SYSTEM;
-bool ENTER_BOOTLOAD;
 bool ECO_MODE;
 bool AUTO_OFF;
 bool WIFI_ON;
 bool BLUETOOTH_ON;
 bool SHOW_WARNING;
+
+// Boot Flags
+bool ENTER_BOOTLOAD;
+bool BOOT_TO_ON;
 
 // Display Settings
 uint8_t CONTRAST;
@@ -121,12 +124,15 @@ void settings_loadDefaults() {
   // System Settings
   TIME_ZONE = DEF_TIME_ZONE;
   VOLUME_SYSTEM = DEF_VOLUME_SYSTEM;
-  ENTER_BOOTLOAD = DEF_ENTER_BOOTLOAD;
   ECO_MODE = DEF_ECO_MODE;
   AUTO_OFF = DEF_AUTO_OFF;
   WIFI_ON = DEF_WIFI_ON;
   BLUETOOTH_ON = DEF_BLUETOOTH_ON;
   SHOW_WARNING = DEF_SHOW_WARNING;
+
+  // Boot Flags
+  ENTER_BOOTLOAD = DEF_ENTER_BOOTLOAD;
+  BOOT_TO_ON = DEF_BOOT_TO_ON;
 
   // Display Settings
   CONTRAST = DEF_CONTRAST;
@@ -175,12 +181,15 @@ void settings_retrieve() {
   // System Settings
   TIME_ZONE = leafPrefs.getShort("TIME_ZONE");
   VOLUME_SYSTEM = leafPrefs.getChar("VOLUME_SYSTEM");
-  ENTER_BOOTLOAD = leafPrefs.getBool("ENTER_BOOTLOAD");
   ECO_MODE = leafPrefs.getBool("ECO_MODE");
   AUTO_OFF = leafPrefs.getBool("AUTO_OFF");
   WIFI_ON = leafPrefs.getBool("WIFI_ON");
   BLUETOOTH_ON = leafPrefs.getBool("BLUETOOTH_ON");
   SHOW_WARNING = leafPrefs.getBool("SHOW_WARNING");
+
+  // Boot Flags
+  ENTER_BOOTLOAD = leafPrefs.getBool("ENTER_BOOTLOAD");
+  BOOT_TO_ON = leafPrefs.getBool("BOOT_TO_ON");
 
   // Display Settings
   CONTRAST = leafPrefs.getUChar("CONTRAST");
@@ -241,12 +250,14 @@ void settings_save() {
   // System Settings
   leafPrefs.putShort("TIME_ZONE", TIME_ZONE);
   leafPrefs.putChar("VOLUME_SYSTEM", VOLUME_SYSTEM);
-  leafPrefs.putBool("ENTER_BOOTLOAD", ENTER_BOOTLOAD);
   leafPrefs.putBool("ECO_MODE", ECO_MODE);
   leafPrefs.putBool("AUTO_OFF", AUTO_OFF);
   leafPrefs.putBool("WIFI_ON", WIFI_ON);
   leafPrefs.putBool("BLUETOOTH_ON", BLUETOOTH_ON);
   leafPrefs.putBool("SHOW_WARNING", SHOW_WARNING);
+  // Boot Flags
+  leafPrefs.putBool("ENTER_BOOTLOAD", ENTER_BOOTLOAD);
+  leafPrefs.putBool("BOOT_TO_ON", BOOT_TO_ON);
   // Display Settings
   leafPrefs.putUChar("CONTRAST", CONTRAST);
   leafPrefs.putUChar("NAVPG_ALT_TYP", NAVPG_ALT_TYP);

--- a/src/vario/settings.h
+++ b/src/vario/settings.h
@@ -20,13 +20,13 @@ typedef uint8_t SettingLogFormat;
 
 /* Vario Sensitivity
 setting | samples | time avg
-    1   |   30    | 1.5  second
-    2   |   25    | 1.25 second
-    3   |   20    | 1    second
-    4   |   15    | 0.75 second
-    5   |   10    | 0.5  second
+    1   |   20    | 20/20 second (1 second moving average)
+    2   |   12    | 12/20 second
+    3   |   6     |  6/20 second
+    4   |   3     |  3/20 second
+    5   |   1     |  1/20 second (single sample -- instant)
 */
-#define VARIO_SENSE_MAX 5  // units of 1/4 seconds
+#define VARIO_SENSE_MAX 5
 #define VARIO_SENSE_MIN 1
 // Lifty Air Thermal Sniffer
 #define LIFTY_AIR_MAX -8  // 0.1 m/s - sinking less than this will trigger
@@ -36,9 +36,7 @@ setting | samples | time avg
 
 // System
 // Display Contrast
-#define CONTRAST_MAX \
-  20  // 20 steps of contrast user selectable (corresponds to actual values sent to dislpay of
-      // 115-135)
+#define CONTRAST_MAX 20
 #define CONTRAST_MIN 1
 // Volume (max for both vario and system volume settings)
 #define VOLUME_MAX 3
@@ -72,17 +70,22 @@ setting | samples | time avg
 #define DEF_LOG_FORMAT LOG_FORMAT_IGC  // IGC or KML
 
 // Default System Settings
-#define DEF_TIME_ZONE \
-  0  // mm (in minutes) UTC -8 (PST) would therefor be -8*60, or 480.  This allows us to cover all
-     // time zones, including the :30 minute and :15 minute ones
-#define DEF_VOLUME_SYSTEM 1   // 0=off, 1=low, 2=med, 3=high
-#define DEF_ENTER_BOOTLOAD 0  // by default, don't enter bootloader on reset
-#define DEF_ECO_MODE \
-  0  // default off to allow reprogramming easier.  TODO: switch to 'on' for production release
-#define DEF_AUTO_OFF 0      // 1 = ENABLE, 0 = DISABLE
-#define DEF_WIFI_ON 0       // default wifi off
-#define DEF_BLUETOOTH_ON 0  // default bluetooth off
-#define DEF_SHOW_WARNING 1  // default show warning on startup
+
+// Time Zone offset in minutes. UTC -8 (PST) would therefore be -8*60, or 480
+// This allows us to cover all time zones, including the :30 minute and :15 minute ones
+#define DEF_TIME_ZONE 0
+#define DEF_VOLUME_SYSTEM 1  // 0=off, 1=low, 2=med, 3=high
+#define DEF_ECO_MODE 0       // default off to allow reprogramming easier
+#define DEF_AUTO_OFF 0       // 1 = ENABLE, 0 = DISABLE
+#define DEF_WIFI_ON 0        // default wifi off
+#define DEF_BLUETOOTH_ON 0   // default bluetooth off
+#define DEF_SHOW_WARNING 1   // default show warning on startup
+
+// Boot Flags
+// Boot-to-ON Flag (when resetting from system updates,
+// reboot to "ON" even if not holding power button)
+#define DEF_BOOT_TO_ON false;
+#define DEF_ENTER_BOOTLOAD false;
 
 // Display Settings
 #define DEF_CONTRAST 7  // default contrast setting
@@ -130,12 +133,15 @@ extern SettingLogFormat LOG_FORMAT;
 // System Settings
 extern int16_t TIME_ZONE;
 extern int8_t VOLUME_SYSTEM;
-extern bool ENTER_BOOTLOAD;
 extern bool ECO_MODE;
 extern bool AUTO_OFF;
 extern bool WIFI_ON;
 extern bool BLUETOOTH_ON;
 extern bool SHOW_WARNING;
+
+// Boot Flags
+extern bool ENTER_BOOTLOAD;
+extern bool BOOT_TO_ON;
 
 // Display Settings
 extern uint8_t CONTRAST;


### PR DESCRIPTION
Previously, the power_latch pin would be left floating / uninitialized when starting up, and set HIGH only when user input turned the device on.  This works from cold-starts, but creates undesirable behavior when hot-restarting (from firmware updates, or processor crash, etc).

Now the power latch pin is definitively set to LOW when starting up, unless we're going into the "ON" state (from user input on center button, etc).

Also added BOOT_TO_ON flag in nvm settings so during intentional restarts (like after a firmware update) the system will boot back up into the ON state as user would expect, even though they're not holding the center button.  The flag is then cleared. 