### PR TITLE
Fix Climb Initialization & Baro Altitudes

### DIFF
--- a/src/vario/IMU.cpp
+++ b/src/vario/IMU.cpp
@@ -29,7 +29,7 @@ Kalmanvert kalmanvert;
 
 #define POSITION_MEASURE_STANDARD_DEVIATION 0.1f
 #define ACCELERATION_MEASURE_STANDARD_DEVIATION 0.3f
-#define IMU_STARTUP_CYCLES 50  // #samples to bypass at startup while accel calibrates
+#define IMU_STARTUP_CYCLES 80  // #samples to bypass at startup while accel calibrates
 
 #define DEBUG_IMU 0
 

--- a/src/vario/IMU.cpp
+++ b/src/vario/IMU.cpp
@@ -29,6 +29,7 @@ Kalmanvert kalmanvert;
 
 #define POSITION_MEASURE_STANDARD_DEVIATION 0.1f
 #define ACCELERATION_MEASURE_STANDARD_DEVIATION 0.3f
+#define IMU_STARTUP_CYCLES 50  // #samples to bypass at startup while accel calibrates
 
 #define DEBUG_IMU 0
 
@@ -249,6 +250,8 @@ void imu_init() {
   tPrev = millis();
 }
 
+uint8_t startupCycleCount = IMU_STARTUP_CYCLES;
+
 void imu_update() {
   /*
   String accelName = "accel,";
@@ -257,6 +260,14 @@ void imu_update() {
   */
 
   if (processQuaternion()) {
+    // if we're starting up, block accel values until it's stable
+    if (startupCycleCount > 0) {
+      startupCycleCount--;
+      // submit accel = 0 to kalman filter and return
+      kalmanvert.update(baro.altF, 0.0f, millis());
+      return;
+    }
+
     // update kalman filter
     kalmanvert.update(baro.altF, accelVert * 9.80665f, millis());
 

--- a/src/vario/baro.h
+++ b/src/vario/baro.h
@@ -24,13 +24,14 @@
 
 class Barometer {
  public:
+  int32_t pressure;
   int32_t pressureFiltered;
   float altimeterSetting = 29.921;
   // cm raw pressure altitude calculated off standard altimeter setting (29.92)
   int32_t alt;
   // m raw pressure altitude (float)
   float altF;
-  // the resulting altitude after being corrected by the altimeter setting
+  // cm pressure altitude corrected by the altimeter setting (int)
   int32_t altAdjusted;
   int32_t altAtLaunch;
   int32_t altAboveLaunch;
@@ -69,7 +70,6 @@ class Barometer {
   // temperature of air in the baro sensor (not to be confused with temperature reading from the
   // temp+humidity sensor)
   int32_t temp_;
-  int32_t pressure_;
   int32_t pressureRegression_;
 
   // LinearRegression to average out noisy sensor readings
@@ -97,8 +97,8 @@ class Barometer {
   // == Device reading & data processing ==
   void calculatePressureAlt(void);
   void filterClimb(void);
+  void calculateAlts(void);
   void filterPressure(void);  // TODO: Use or remove (currently unused)
-  void calculateAlt(void);    // TODO: Use or remove (currently unused)
 
   // ======
   // Sensor Calibration Values (stored in chip PROM; must be read at startup before performing baro

--- a/src/vario/buttons.cpp
+++ b/src/vario/buttons.cpp
@@ -33,17 +33,18 @@ uint32_t button_time_elapsed = 0;
 // button actions
 Button button_last = Button::NONE;
 ButtonState button_state = NO_STATE;
-bool button_everHeld =
-    false;  // in a single button-push event, track if it was ever held long enough to reach the
-            // "HELD" or "HELD_LONG" states (no we know not to also take action when it is released)
+
+// in a single button-push event, track if it was ever held long enough to reach the
+// "HELD" or "HELD_LONG" states (so we know not to also take action when it is released)
+bool button_everHeld = false;
 uint16_t button_min_hold_time = 800;   // time in ms to count a button as "held down"
 uint16_t button_max_hold_time = 3500;  // time in ms to start further actions on long-holds
 
 uint16_t button_hold_action_time_initial = 0;
-uint16_t button_hold_action_time_elapsed =
-    0;  // counting time between 'action steps' while holding the button
-uint16_t button_hold_action_time_limit =
-    500;  // time in ms required between "action steps" while holding the button
+// counting time between 'action steps' while holding the button
+uint16_t button_hold_action_time_elapsed = 0;
+// time in ms required between "action steps" while holding the button
+uint16_t button_hold_action_time_limit = 500;
 uint16_t button_hold_counter = 0;
 
 Button buttons_init(void) {
@@ -80,6 +81,7 @@ Button buttons_update(void) {
   // executed center-hold event.  This prevents multiple sequential actions being executed if user
   // keeps holding the center button (i.e., resetting timer, then turning off)
   if (centerHoldLockButtons && which_button == Button::CENTER) {
+    button_state = NO_STATE;
     return which_button;  // return early without executing further tasks
   } else {
     centerHoldLockButtons = false;  // user let go of center button, so we can reset the lock.

--- a/src/vario/settings.cpp
+++ b/src/vario/settings.cpp
@@ -333,8 +333,7 @@ bool settings_matchGPSAlt() {
   bool success = false;
   if (gps.altitude.isValid()) {
     baro.altimeterSetting =
-        baro.pressureFiltered /
-        (3386.389 * pow(1 - gps.altitude.meters() * 100 / 4433100.0, 1 / 0.190264));
+        baro.pressure / (3386.389 * pow(1 - gps.altitude.meters() * 100 / 4433100.0, 1 / 0.190264));
     ALT_SETTING = baro.altimeterSetting;
     success = true;
   }

--- a/src/vario/ui/PageNavigate.cpp
+++ b/src/vario/ui/PageNavigate.cpp
@@ -580,6 +580,8 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
           } else if (state == HELD && flightTimer_isRunning()) {
             flightTimer_stop();
             navigatePage_cursorPosition = cursor_navigatePage_none;
+            buttons_lockAfterHold();  // lock buttons so we don't turn off if user keeps holding
+                                      // button
           }
 
           break;

--- a/src/vario/ui/PageNavigate.cpp
+++ b/src/vario/ui/PageNavigate.cpp
@@ -484,14 +484,14 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
         case Button::LEFT:
           if (NAVPG_ALT_TYP == altType_MSL &&
               (state == PRESSED || state == HELD || state == HELD_LONG)) {
-            baro.adjustAltSetting(1, count);
+            baro.adjustAltSetting(-1, count);
             speaker_playSound(fx_neutral);
           }
           break;
         case Button::RIGHT:
           if (NAVPG_ALT_TYP == altType_MSL &&
               (state == PRESSED || state == HELD || state == HELD_LONG)) {
-            baro.adjustAltSetting(-1, count);
+            baro.adjustAltSetting(1, count);
             speaker_playSound(fx_neutral);
           }
           break;

--- a/src/vario/ui/PageThermalSimple.cpp
+++ b/src/vario/ui/PageThermalSimple.cpp
@@ -248,14 +248,14 @@ void thermalSimplePage_button(Button button, ButtonState state, uint8_t count) {
         case Button::LEFT:
           if (NAVPG_ALT_TYP == altType_MSL &&
               (state == PRESSED || state == HELD || state == HELD_LONG)) {
-            baro.adjustAltSetting(1, count);
+            baro.adjustAltSetting(-1, count);
             speaker_playSound(fx_neutral);
           }
           break;
         case Button::RIGHT:
           if (NAVPG_ALT_TYP == altType_MSL &&
               (state == PRESSED || state == HELD || state == HELD_LONG)) {
-            baro.adjustAltSetting(-1, count);
+            baro.adjustAltSetting(1, count);
             speaker_playSound(fx_neutral);
           }
           break;


### PR DESCRIPTION
* Add IMU_STARTUP_CYCLES to zero-out accelerations while the sensor (and average gravity vector magnitude) calibrate.  This avoids spiking climb/sink values when you first turn the unit on.

* Fix baro altitudes (initially moving to the Kalman filter neglected to update the other altitudes (above launch, etc)).

* Fix turn-on bug that would immediately shut-down if user kept holding button

* Fix Alt adjutment shortcut on Thermal/Nav pages had backwards button directions.

* Small style adjustments and tweaks (cleaning up comments)