### PR TITLE
Separate baro sensor from logical barometer

### DIFF
--- a/src/vario/baro.cpp
+++ b/src/vario/baro.cpp
@@ -8,7 +8,9 @@
 #include "Leaf_I2C.h"
 #include "SDcard.h"
 #include "buttons.h"
+#include "flags_enum.h"
 #include "log.h"
+#include "ms5611.h"
 #include "settings.h"
 #include "speaker.h"
 #include "telemetry.h"
@@ -21,8 +23,10 @@
 // average)
 #define CLIMB_AVERAGE 4
 
+// Singleton sensor to use in barometer
+MS5611 sensor;
 // Singleton barometer instance for device
-Barometer baro;
+Barometer baro(&sensor);
 
 void Barometer::adjustAltSetting(int8_t dir, uint8_t count) {
   float increase = .001;  //
@@ -65,46 +69,6 @@ float baro_climbToUnits(int32_t climbrate, bool units_fpm) {
   return climbrate_converted;
 }
 
-// vvv I2C Communication Functions vvv
-
-uint8_t baro_sendCommand(uint8_t command) {
-  Wire.beginTransmission(ADDR_BARO);
-  Wire.write(command);
-  uint8_t result = Wire.endTransmission();
-  // if (DEBUG_BARO) { Serial.print("Baro Send Command Result: "); Serial.println(result); }
-  return result;
-}
-
-uint16_t baro_readCalibration(uint8_t PROMaddress) {
-  uint16_t value = 0;  // This will be the final 16-bit output from the ADC
-  uint8_t command =
-      0b10100000;  // The command to read from the specified address is 1 0 1 0 ad2 ad1 ad0 0
-  command += (PROMaddress << 1);  // Add PROM address bits to the command byte
-
-  baro_sendCommand(command);
-  Wire.requestFrom(ADDR_BARO, 2);
-  value += (Wire.read() << 8);
-  value += (Wire.read());
-
-  return value;
-}
-
-uint32_t baro_readADC() {
-  uint32_t value = 0;  // This will be the final 24-bit output from the ADC
-  // if (DEBUG_BARO) { Serial.println("Baro sending Read ADC command"); }
-  baro_sendCommand(0b00000000);
-  Wire.requestFrom(ADDR_BARO, 3);
-  value += (Wire.read() << 16);
-  // if (DEBUG_BARO) { Serial.print("Baro ADC Value 16: "); Serial.println(value); }
-  value += (Wire.read() << 8);
-  // if (DEBUG_BARO) { Serial.print("Baro ADC Value 8: "); Serial.println(value); }
-  value += (Wire.read());
-  // if (DEBUG_BARO) { Serial.print("Baro ADC Value 0: "); Serial.println(value); }
-
-  return value;
-}
-// ^^^ I2C Communication Functions ^^^
-
 // vvv Device Management vvv
 
 void Barometer::init(void) {
@@ -114,26 +78,16 @@ void Barometer::init(void) {
   else
     altimeterSetting = 29.92;
 
-  // reset baro sensor for initialization
-  reset();
-  delay(2);
-
-  // read calibration values
-  C_SENS_ = baro_readCalibration(1);
-  C_OFF_ = baro_readCalibration(2);
-  C_TCS_ = baro_readCalibration(3);
-  C_TCO_ = baro_readCalibration(4);
-  C_TREF_ = baro_readCalibration(5);
-  C_TEMPSENS_ = baro_readCalibration(6);
+  pressureSource_->init();
 
   // after initialization, get first baro sensor reading to populate values
-  delay(10);        // wait for baro sensor to be ready
-  update(1, true);  // send convert-pressure command
-  delay(10);        // wait for baro sensor to process
-  update(0, true);  // read pressure, send convert-temp command
-  delay(10);        // wait for baro sensor to process
-  update(0, true);  // read temp, and calculate adjusted pressure
-  delay(10);
+  pressureSource_->startMeasurement();
+  PressureUpdateResult result = pressureSource_->update();
+  while (!FLAG_SET(result, PressureUpdateResult::PressureReady)) {
+    delay(10);
+    result = pressureSource_->update();
+  }
+  pressure_ = pressureSource_->getPressure();
 
   // load the filters with our current start-up pressure (and climb is assumed to be 0)
   for (int i = 1; i <= FILTER_VALS_MAX; i++) {
@@ -149,57 +103,25 @@ void Barometer::init(void) {
   pressureRegression_ = pressure_;
 
   // and start off the linear regression version
-  // pressure_lr.update((double)millis(), (double)pressure);
+  // pressure_lr.update((double)millis(), (double)pressure_);
 
-  update(0, true);  // calculate altitudes
+  calculatePressureAlt();  // calculate altitudes
 
   // initialize all the other alt variables with current altitude to start
-  lastAlt_ = alt;    // used to calculate the alt change for climb rate.  Assume we're stationary
-                     // to start (previous Alt = Current ALt, so climb rate is zero).  Note: Climb
-                     // rate uses the un-adjusted (standard) altitude
-  altInitial = alt;  // also save first value to use as starting point (we assume the
-                     // saved altimeter setting is correct for now, so use adjusted)
-  altAtLaunch = altAdjusted;  // save the starting value as launch altitude (Launch will
-                              // be updated when timer starts)
 
-  if (DEBUG_BARO) {
-    Serial.println("Baro initialization values:");
-    Serial.print("  C_SENS:");
-    Serial.println(C_SENS_);
-    Serial.print("  C_OFF:");
-    Serial.println(C_OFF_);
-    Serial.print("  C_TCS:");
-    Serial.println(C_TCS_);
-    Serial.print("  C_TCO:");
-    Serial.println(C_TCO_);
-    Serial.print("  C_TREF:");
-    Serial.println(C_TREF_);
-    Serial.print("  C_TEMPSENS:");
-    Serial.println(C_TEMPSENS_);
-    Serial.print("  D1:");
-    Serial.println(D1_P_);
-    Serial.print("  D2:");
-    Serial.println(D2_T_);
-    Serial.print("  dT:");
-    Serial.println(dT_);
-    Serial.print("  TEMP:");
-    Serial.println(temp_);
-    Serial.print("  OFF1:");
-    Serial.println(OFF1_);
-    Serial.print("  SENS1:");
-    Serial.println(SENS1_);
-    Serial.print("  P_ALT:");
-    Serial.println(alt);
+  // used to calculate the alt change for climb rate.  Assume we're stationary
+  // to start (previous Alt = Current ALt, so climb rate is zero).  Note: Climb
+  // rate uses the un-adjusted (standard) altitude
+  lastAlt_ = alt;
+  // also save first value to use as starting point (we assume the
+  // saved altimeter setting is correct for now, so use adjusted)
+  altInitial = alt;
+  // save the starting value as launch altitude (Launch will
+  // be updated when timer starts)
+  altAtLaunch = altAdjusted;
 
-    Serial.println(" ");
-  }
-}
-
-void Barometer::reset(void) {
-  unsigned char command = 0b00011110;  // This is the command to reset, and for the sensor to copy
-                                       // calibration data into the register as needed
-  baro_sendCommand(command);
-  delay(3);  // delay time required before sensor is ready
+  pressureSource_->startMeasurement();
+  task_ = BarometerTask::Measure;
 }
 
 void Barometer::resetLaunchAlt() { altAtLaunch = altAdjusted; }
@@ -207,7 +129,9 @@ void Barometer::resetLaunchAlt() { altAtLaunch = altAdjusted; }
 void Barometer::wake() { sleeping_ = false; }
 void Barometer::sleep() { sleeping_ = true; }
 
-void Barometer::update(bool startNewCycle, bool doTemp) {
+void Barometer::startMeasurement() { pressureSource_->startMeasurement(); }
+
+void Barometer::update() {
   // (we don't need to update temp as frequently so we choose to skip it if desired)
   // the baro senor requires ~9ms between the command to prep the ADC and actually reading the
   // value. Since this delay is required between both pressure and temp values, we break the sensor
@@ -225,106 +149,51 @@ void Barometer::update(bool startNewCycle, bool doTemp) {
     return;
   }
 
-  // First check if ADC is not busy (i.e., it's been at least 9ms since we sent a "convert ADC"
-  // command)
-  unsigned long microsNow = micros();
-  if (microsNow - baroADCStartTime_ > 9000) {
-    baroADCBusy_ = false;
-  } else {
-    Serial.print("BARO BUSY!  Executing Process Step # ");
-    Serial.print(processStep_);
-    Serial.print("  Micros since last: ");
-    Serial.println(microsNow - baroADCStartTime_);
-  }
-
-  if (startNewCycle) processStep_ = 0;
-
   if (DEBUG_BARO) {
-    Serial.print("baro step: ");
-    Serial.print(processStep_);
-    Serial.print(" NewCycle? ");
-    Serial.print(startNewCycle);
+    Serial.print("baro task: ");
+    Serial.print((int)task_);
     Serial.print(" time: ");
     Serial.println(micros());
   }
 
-  switch (processStep_) {
-    case 0:  // SEND CONVERT PRESSURE COMMAND
-      if (!baroADCBusy_) {
-        baroADCStartTime_ = micros();
-        baro_sendCommand(CMD_CONVERT_PRESSURE);  // Prep baro sensor ADC to read raw pressure value
-                                                 // (then come back for step 2 in ~10ms)
-        baroADCBusy_ = true;      // ADC will be busy now since we sent a conversion command
-        baroADCPressure_ = true;  // We will have a Pressure value in the ADC when ready
-        baroADCTemp_ =
-            false;  // We won't have a Temp value (even if the ADC was holding an unread Temperature
-                    // value, we're clearning that out since we sent a Pressure command)
-      }
-      break;
+  if (task_ == BarometerTask::None) {
+    // Do nothing
+  } else if (task_ == BarometerTask::Measure) {
+    PressureUpdateResult sensorResult = pressureSource_->update();
 
-    case 1:  // READ PRESSURE THEN SEND CONVERT TEMP COMMAND
-      if (!baroADCBusy_ && baroADCPressure_) {
-        D1_P_ = baro_readADC();  // Read raw pressure value
-        baroADCPressure_ = false;
-        // baroTimeStampPressure = micros() - baroTimeStampPressure; // capture duration between
-        // prep and read
-        if (D1_P_ == 0)
-          D1_P_ = D1_Plast_;  // use the last value if we get an invalid read
-        else
-          D1_Plast_ = D1_P_;  // otherwise save this value for next time if needed
-        // baroTimeStampTemp = micros();
+    if (FLAG_SET(sensorResult, PressureUpdateResult::PressureReady)) {
+      pressure_ = pressureSource_->getPressure();
 
-        if (doTemp) {
-          baroADCStartTime_ = micros();
-          baro_sendCommand(CMD_CONVERT_TEMP);  // Prep baro sensor ADC to read raw temperature value
-                                               // (then come back for step 3 in ~10ms)
-          baroADCBusy_ = true;
-          baroADCTemp_ = true;       // We will have a Temperature value in the ADC when ready
-          baroADCPressure_ = false;  // We won't have a Pressure value (even if the ADC was holding
-                                     // an unread Pressure value, we're clearning that out since we
-                                     // sent a Temperature command)
-        }
-      }
-      break;
-
-    case 2:  // READ TEMP THEN CALCULATE ALTITUDE
-      if (doTemp) {
-        if (!baroADCBusy_ && baroADCTemp_) {
-          D2_T_ = baro_readADC();  // read digital temp data
-          baroADCTemp_ = false;
-          // baroTimeStampTemp = micros() - baroTimeStampTemp; // capture duration between prep and
-          // read
-          if (D2_T_ == 0)
-            D2_T_ = D2_Tlast_;  // use the last value if we get a misread
-          else
-            D2_Tlast_ = D2_T_;  // otherwise save this value for next time if needed
-        }
-      }
       // (even if we skipped some steps above because of mis-reads or mis-timing, we can still
       // calculate a "new" corrected pressure value based on the old ADC values.  It will be a
       // repeat value, but it keeps the filter buffer moving on time)
       calculatePressureAlt();  // calculate Pressure Altitude adjusted for temperature
-      break;
+      task_ = BarometerTask::FilterAltitude;
+    }
+  } else if (task_ == BarometerTask::FilterAltitude) {
+    // Filter Pressure and calculate Final Altitude Values
+    // Note, IMU will have taken an accel reading and updated the Kalman
+    // Filter after Baro_step_2 but before Baro_step_3
 
-    case 3:  // Filter Pressure and calculate Final Altitude Values
-      // Note, IMU will have taken an accel reading and updated the Kalman
-      // Filter after Baro_step_2 but before Baro_step_3
+    // get instant climb rate and altitude
+    climbRate = (float)kalmanvert.getVelocity();    // in m/s
+    alt = int32_t(kalmanvert.getPosition() * 100);  // in cm above sea level
 
-      // get instant climb rate and altitude
-      climbRate = (float)kalmanvert.getVelocity();    // in m/s
-      alt = int32_t(kalmanvert.getPosition() * 100);  // in cm above sea level
+    // filter ClimbRate
+    filterClimb();
 
-      // filter ClimbRate
-      filterClimb();
+    // finally, update the speaker sound based on the new climbrate
+    speaker_updateVarioNote(climbRateFiltered);
 
-      // finally, update the speaker sound based on the new climbrate
-      speaker_updateVarioNote(climbRateFiltered);
+    if (DEBUG_BARO) Serial.println("**BR** climbRate Filtered: " + String(climbRateFiltered));
 
-      if (DEBUG_BARO) Serial.println("**BR** climbRate Filtered: " + String(climbRateFiltered));
-
-      break;
+    pressureSource_->startMeasurement();
+    task_ = BarometerTask::Measure;
+  } else {
+    // TODO: Write generic fatal error handler that prints error message to screen before stopping
+    Serial.printf("Fatal error: Barometer was conducting unknown task %d\n", (int)task_);
+    while (true);
   }
-  processStep_++;
 }
 
 // ^^^ Device Management ^^^
@@ -332,38 +201,6 @@ void Barometer::update(bool startNewCycle, bool doTemp) {
 // vvv Device reading & data processing vvv
 
 void Barometer::calculatePressureAlt() {
-  // calculate temperature (in 100ths of degrees C, from -4000 to 8500)
-  dT_ = D2_T_ - ((int32_t)C_TREF_) * 256;
-  int32_t TEMP = 2000 + (((int64_t)dT_) * ((int64_t)C_TEMPSENS_)) / pow(2, 23);
-
-  // calculate sensor offsets to use in pressure & altitude calcs
-  OFF1_ = (int64_t)C_OFF_ * pow(2, 16) + (((int64_t)C_TCO_) * dT_) / pow(2, 7);
-  SENS1_ = (int64_t)C_SENS_ * pow(2, 15) + ((int64_t)C_TCS_ * dT_) / pow(2, 8);
-
-  // low temperature compensation adjustments
-  TEMP2_ = 0;
-  OFF2_ = 0;
-  SENS2_ = 0;
-  if (TEMP < 2000) {
-    TEMP2_ = pow((int64_t)dT_, 2) / pow(2, 31);
-    OFF2_ = 5 * pow((TEMP - 2000), 2) / 2;
-    SENS2_ = 5 * pow((TEMP - 2000), 2) / 4;
-  }
-  // very low temperature compensation adjustments
-  if (TEMP < -1500) {
-    OFF2_ = OFF2_ + 7 * pow((TEMP + 1500), 2);
-    SENS2_ = SENS2_ + 11 * pow((TEMP + 1500), 2) / 2;
-  }
-  TEMP = TEMP - TEMP2_;
-  OFF1_ = OFF1_ - OFF2_;
-  SENS1_ = SENS1_ - SENS2_;
-
-  // Filter Temp if necessary due to noise in values
-  temp_ = TEMP;  // TODO: actually filter if needed
-
-  // calculate temperature compensated pressure (in 100ths of mbars)
-  pressure_ = ((uint64_t)D1_P_ * SENS1_ / (int64_t)pow(2, 21) - OFF1_) / pow(2, 15);
-
   // record datapoint on SD card if datalogging is turned on
 
   String baroName = "baro mb*100,";
@@ -515,13 +352,7 @@ void Barometer::filterClimb() {
 // Test Functions
 
 void Barometer::debugPrint() {
-  Serial.print("D1_P:");
-  Serial.print(D1_P_);
-  Serial.print(", D2_T:");
-  Serial.print(D2_T_);  // has been zero, perhaps because GPS serial buffer processing delayed the
-                        // ADC prep for reading this from baro chip
-
-  Serial.print(", Press:");
+  Serial.print("Press:");
   Serial.print(pressure_);
   Serial.print(", PressFiltered:");
   Serial.print(pressureFiltered);

--- a/src/vario/baro.h
+++ b/src/vario/baro.h
@@ -1,8 +1,6 @@
 /*
  * baro.h
  *
- * Barometric Pressure Sensor MS5611-01BA03
- * SPI max 20MHz
  */
 
 #pragma once
@@ -12,18 +10,23 @@
 #include "Leaf_SPI.h"
 #include "LinearRegression.h"
 #include "buttons.h"
-
-// Sensor I2C address
-#define ADDR_BARO 0x77
-
-// Sensor commands
-#define CMD_CONVERT_PRESSURE 0b01001000
-#define CMD_CONVERT_TEMP 0b01011000
+#include "flags_enum.h"
+#include "pressure_source.h"
 
 #define FILTER_VALS_MAX 20  // total array size max;
 
+enum class BarometerTask : uint8_t {
+  None,
+  Measure,
+  FilterAltitude,
+};
+
+// Barometer reporting altitude, adjusted altitude, climb rate, and other information.
+// Requires a pressure source.
 class Barometer {
  public:
+  Barometer(IPressureSource* pressureSource) : pressureSource_(pressureSource) {}
+
   int32_t pressureFiltered;
   float altimeterSetting = 29.921;
   // cm raw pressure altitude calculated off standard altimeter setting (29.92)
@@ -47,14 +50,14 @@ class Barometer {
   int32_t varioBar;
 
   // == Device Management ==
-  // Initialize the baro sensor
+  // Initialize the baro
   void init(void);
-  void reset(void);
 
   // Reset launcAlt to current Alt (when starting a new log file, for example)
   void resetLaunchAlt(void);
 
-  void update(bool startNewCycle, bool doTemp);
+  void startMeasurement();
+  void update();
 
   void sleep(void);
   void wake(void);
@@ -66,9 +69,8 @@ class Barometer {
   void debugPrint(void);
 
  private:
-  // temperature of air in the baro sensor (not to be confused with temperature reading from the
-  // temp+humidity sensor)
-  int32_t temp_;
+  IPressureSource* pressureSource_;
+
   int32_t pressure_;
   int32_t pressureRegression_;
 
@@ -88,11 +90,7 @@ class Barometer {
   // Track if we've put baro to sleep (in power off usb state)
   bool sleeping_ = false;
 
-  uint32_t baroADCStartTime_ = 0;
-  uint8_t processStep_ = 0;
-  bool baroADCBusy_ = false;
-  bool baroADCPressure_ = false;
-  bool baroADCTemp_ = false;
+  BarometerTask task_ = BarometerTask::None;
 
   // == Device reading & data processing ==
   void calculatePressureAlt(void);
@@ -101,35 +99,8 @@ class Barometer {
   void calculateAlt(void);    // TODO: Use or remove (currently unused)
 
   // ======
-  // Sensor Calibration Values (stored in chip PROM; must be read at startup before performing baro
-  // calculations)
-  uint16_t C_SENS_;
-  uint16_t C_OFF_;
-  uint16_t C_TCS_;
-  uint16_t C_TCO_;
-  uint16_t C_TREF_;
-  uint16_t C_TEMPSENS_;
 
-  // Digital read-out values
-  uint32_t D1_P_;             //  digital pressure value (D1 in datasheet)
-  uint32_t D1_Plast_ = 1000;  //  save previous value to use if we ever get a mis-read from the baro
-                              //  sensor (initialize with a non zero starter value)
-  uint32_t D2_T_;             //  digital temp value (D2 in datasheet)
-  uint32_t D2_Tlast_ = 1000;  //  save previous value to use if we ever get a mis-read from the baro
-                              //  sensor (initialize with a non zero starter value)
   int32_t lastAlt_ = 0;
-
-  // Temperature Calculations
-  int32_t dT_;
-
-  // Compensation Values
-  int64_t OFF1_;   // Offset at actual temperature
-  int64_t SENS1_;  // Sensitivity at actual temperature
-
-  // Extra compensation values for lower temperature ranges
-  int32_t TEMP2_;
-  int64_t OFF2_;
-  int64_t SENS2_;
 
   // flag to set first climb rate sample to 0 (this allows us to wait for a second baro altitude
   // sample to calculate any altitude change)

--- a/src/vario/flags_enum.h
+++ b/src/vario/flags_enum.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <iostream>
+#include <type_traits>
+
+// Base class template for flag enums
+template <typename Enum>
+class FlagsEnum {
+ public:
+  using UnderlyingType = typename std::underlying_type<Enum>::type;
+
+  constexpr FlagsEnum() : value(0) {}
+  constexpr FlagsEnum(Enum e) : value(static_cast<UnderlyingType>(e)) {}
+  constexpr FlagsEnum(UnderlyingType v) : value(v) {}
+
+  // Bitwise OR
+  constexpr FlagsEnum operator|(FlagsEnum other) const { return FlagsEnum(value | other.value); }
+
+  // Bitwise AND
+  constexpr FlagsEnum operator&(FlagsEnum other) const { return FlagsEnum(value & other.value); }
+
+  // Bitwise OR assignment
+  FlagsEnum& operator|=(FlagsEnum other) {
+    value |= other.value;
+    return *this;
+  }
+
+  // Bitwise AND assignment
+  FlagsEnum& operator&=(FlagsEnum other) {
+    value &= other.value;
+    return *this;
+  }
+
+  // Check if a flag is set
+  constexpr bool hasFlag(Enum flag) const {
+    return (value & static_cast<UnderlyingType>(flag)) == static_cast<UnderlyingType>(flag);
+  }
+
+  // Implicit conversion back to Enum type
+  constexpr operator Enum() const { return static_cast<Enum>(value); }
+
+  // Get underlying value
+  constexpr UnderlyingType raw() const { return value; }
+
+ private:
+  UnderlyingType value;
+};
+
+#define DEFINE_FLAGS_ENUM(EnumName, UnderlyingType)                  \
+  enum class EnumName : UnderlyingType;                              \
+  inline FlagsEnum<EnumName> operator|(EnumName lhs, EnumName rhs) { \
+    return FlagsEnum<EnumName>(lhs) | FlagsEnum<EnumName>(rhs);      \
+  }                                                                  \
+  inline FlagsEnum<EnumName> operator&(EnumName lhs, EnumName rhs) { \
+    return FlagsEnum<EnumName>(lhs) & FlagsEnum<EnumName>(rhs);      \
+  }                                                                  \
+  enum class EnumName : UnderlyingType
+
+#define FLAG_SET(value, flag) (((value) & (flag)) == (flag))

--- a/src/vario/ms5611.cpp
+++ b/src/vario/ms5611.cpp
@@ -1,0 +1,215 @@
+#include "ms5611.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <stdint.h>
+
+// Sensor I2C address
+#define ADDR_BARO 0x77
+
+// Sensor commands
+#define CMD_CONVERT_PRESSURE 0b01001000
+#define CMD_CONVERT_TEMP 0b01011000
+
+// vvv I2C Communication Functions vvv
+
+uint8_t ms5611_sendCommand(uint8_t command) {
+  Wire.beginTransmission(ADDR_BARO);
+  Wire.write(command);
+  uint8_t result = Wire.endTransmission();
+  // if (DEBUG_BARO) { Serial.print("Baro Send Command Result: "); Serial.println(result); }
+  return result;
+}
+
+uint16_t ms5611_readCalibration(uint8_t PROMaddress) {
+  uint16_t value = 0;  // This will be the final 16-bit output from the ADC
+  uint8_t command =
+      0b10100000;  // The command to read from the specified address is 1 0 1 0 ad2 ad1 ad0 0
+  command += (PROMaddress << 1);  // Add PROM address bits to the command byte
+
+  ms5611_sendCommand(command);
+  Wire.requestFrom(ADDR_BARO, 2);
+  value += (Wire.read() << 8);
+  value += (Wire.read());
+
+  return value;
+}
+
+uint32_t ms5611_readADC() {
+  uint32_t value = 0;  // This will be the final 24-bit output from the ADC
+  // if (DEBUG_BARO) { Serial.println("Baro sending Read ADC command"); }
+  ms5611_sendCommand(0b00000000);
+  Wire.requestFrom(ADDR_BARO, 3);
+  value += (Wire.read() << 16);
+  // if (DEBUG_BARO) { Serial.print("Baro ADC Value 16: "); Serial.println(value); }
+  value += (Wire.read() << 8);
+  // if (DEBUG_BARO) { Serial.print("Baro ADC Value 8: "); Serial.println(value); }
+  value += (Wire.read());
+  // if (DEBUG_BARO) { Serial.print("Baro ADC Value 0: "); Serial.println(value); }
+
+  return value;
+}
+
+// ^^^ I2C Communication Functions ^^^
+
+void ms5611_reset(void) {
+  // This is the command to reset, and for the sensor to copy
+  // calibration data into the register as needed
+  unsigned char command = 0b00011110;
+  ms5611_sendCommand(command);
+  delay(3);  // delay time required before sensor is ready
+}
+
+void MS5611::init() {
+  // reset sensor for initialization
+  ms5611_reset();
+  delay(2);
+
+  // read calibration values
+  C_SENS_ = ms5611_readCalibration(1);
+  C_OFF_ = ms5611_readCalibration(2);
+  C_TCS_ = ms5611_readCalibration(3);
+  C_TCO_ = ms5611_readCalibration(4);
+  C_TREF_ = ms5611_readCalibration(5);
+  C_TEMPSENS_ = ms5611_readCalibration(6);
+
+  state_ = MS5611State::Idle;
+}
+
+void MS5611::enableTemp(bool enable) { tempEnabled_ = enable; }
+
+PressureUpdateResult MS5611::update() {
+  // First check if ADC is not busy (i.e., it's been at least 9ms since we sent a "convert ADC"
+  // command)
+  unsigned long microsNow = micros();
+  if (microsNow - baroADCStartTime_ <= 9000) {
+    // Sensor is busy
+    Serial.print("BARO BUSY!  State ");
+    Serial.print((int)state_);
+    Serial.print("  Micros since last: ");
+    Serial.println(microsNow - baroADCStartTime_);
+    return PressureUpdateResult::NoChange;
+  }
+
+  switch (state_) {
+    case MS5611State::Idle:  // SEND CONVERT PRESSURE COMMAND
+      if (startMeasurement_) {
+        // Prep baro sensor ADC to read raw pressure value
+        // (then come back for step 2 in ~10ms)
+        ms5611_sendCommand(CMD_CONVERT_PRESSURE);
+        baroADCStartTime_ = micros();
+        state_ = MS5611State::MeasuringPressure;
+        startMeasurement_ = false;
+      }
+      return PressureUpdateResult::NoChange;
+
+    case MS5611State::MeasuringPressure:  // READ PRESSURE THEN MAYBE SEND CONVERT TEMP COMMAND
+      D1_P_ = ms5611_readADC();           // Read raw pressure value
+      // prep and read
+      if (D1_P_ == 0)
+        D1_P_ = D1_Plast_;  // use the last value if we get an invalid read
+      else
+        D1_Plast_ = D1_P_;  // otherwise save this value for next time if needed
+      // baroTimeStampTemp = micros();
+
+      if (tempEnabled_) {
+        baroADCStartTime_ = micros();
+        ms5611_sendCommand(CMD_CONVERT_TEMP);  // Prep baro sensor ADC to read raw temperature value
+                                               // (then come back for step 3 in ~10ms)
+        state_ = MS5611State::MeasuringTemperature;
+        return PressureUpdateResult::NoChange;
+      } else {
+        state_ = MS5611State::Idle;
+        return PressureUpdateResult::PressureReady;
+      }
+
+    case MS5611State::MeasuringTemperature:  // READ TEMP
+      D2_T_ = ms5611_readADC();              // read digital temp data
+      // read
+      if (D2_T_ == 0)
+        D2_T_ = D2_Tlast_;  // use the last value if we get a misread
+      else
+        D2_Tlast_ = D2_T_;  // otherwise save this value for next time if needed
+      state_ = MS5611State::Idle;
+      return PressureUpdateResult::PressureReady;
+  }
+
+  // TODO: Write generic fatal error handler that prints error message to screen before stopping
+  Serial.printf("Fatal error: MS5611 was in unknown state %d\n", (int)state_);
+  while (true);
+}
+
+void MS5611::startMeasurement() { startMeasurement_ = true; }
+
+int32_t MS5611::getPressure() {
+  // calculate temperature (in 100ths of degrees C, from -4000 to 8500)
+  dT_ = D2_T_ - ((int32_t)C_TREF_) * 256;
+  int32_t TEMP = 2000 + (((int64_t)dT_) * ((int64_t)C_TEMPSENS_)) / pow(2, 23);
+
+  // calculate sensor offsets to use in pressure & altitude calcs
+  OFF1_ = (int64_t)C_OFF_ * pow(2, 16) + (((int64_t)C_TCO_) * dT_) / pow(2, 7);
+  SENS1_ = (int64_t)C_SENS_ * pow(2, 15) + ((int64_t)C_TCS_ * dT_) / pow(2, 8);
+
+  // low temperature compensation adjustments
+  TEMP2_ = 0;
+  OFF2_ = 0;
+  SENS2_ = 0;
+  if (TEMP < 2000) {
+    TEMP2_ = pow((int64_t)dT_, 2) / pow(2, 31);
+    OFF2_ = 5 * pow((TEMP - 2000), 2) / 2;
+    SENS2_ = 5 * pow((TEMP - 2000), 2) / 4;
+  }
+  // very low temperature compensation adjustments
+  if (TEMP < -1500) {
+    OFF2_ = OFF2_ + 7 * pow((TEMP + 1500), 2);
+    SENS2_ = SENS2_ + 11 * pow((TEMP + 1500), 2) / 2;
+  }
+  TEMP = TEMP - TEMP2_;
+  OFF1_ = OFF1_ - OFF2_;
+  SENS1_ = SENS1_ - SENS2_;
+
+  // temperature of air in the baro sensor (not to be confused with temperature reading from the
+  // temp+humidity sensor)
+  int32_t temp = TEMP;
+
+  // calculate temperature compensated pressure (in 100ths of mbars)
+  int32_t pressure = ((uint64_t)D1_P_ * SENS1_ / (int64_t)pow(2, 21) - OFF1_) / pow(2, 15);
+
+  return pressure;
+}
+
+void MS5611::printCoeffs() {
+  Serial.println("Baro initialization values:");
+  Serial.print("  C_SENS:");
+  Serial.println(C_SENS_);
+  Serial.print("  C_OFF:");
+  Serial.println(C_OFF_);
+  Serial.print("  C_TCS:");
+  Serial.println(C_TCS_);
+  Serial.print("  C_TCO:");
+  Serial.println(C_TCO_);
+  Serial.print("  C_TREF:");
+  Serial.println(C_TREF_);
+  Serial.print("  C_TEMPSENS:");
+  Serial.println(C_TEMPSENS_);
+  Serial.print("  D1:");
+  Serial.println(D1_P_);
+  Serial.print("  D2:");
+  Serial.println(D2_T_);
+  Serial.print("  dT:");
+  Serial.println(dT_);
+  Serial.print("  OFF1:");
+  Serial.println(OFF1_);
+  Serial.print("  SENS1:");
+  Serial.println(SENS1_);
+
+  Serial.println(" ");
+}
+
+void MS5611::debugPrint() {
+  Serial.print("D1_P:");
+  Serial.print(D1_P_);
+  Serial.print(", D2_T:");
+  Serial.print(D2_T_);  // has been zero, perhaps because GPS serial buffer processing delayed the
+                        // ADC prep for reading this from baro chip
+}

--- a/src/vario/ms5611.h
+++ b/src/vario/ms5611.h
@@ -1,0 +1,69 @@
+/*
+ * Barometric Pressure Sensor MS5611-01BA03
+ * SPI max 20MHz
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "pressure_source.h"
+
+enum class MS5611State : uint8_t {
+  None,
+  Idle,
+  MeasuringPressure,
+  MeasuringTemperature,
+};
+
+class MS5611 : public IPressureSource {
+ public:
+  void init();
+  PressureUpdateResult update();
+  void startMeasurement();
+  void enableTemp(bool enable);
+  int32_t getPressure();
+
+  void printCoeffs();
+  void debugPrint();
+
+ private:
+  // Sensor Calibration Values (stored in chip PROM; must be read at startup before performing baro
+  // calculations)
+  uint16_t C_SENS_;
+  uint16_t C_OFF_;
+  uint16_t C_TCS_;
+  uint16_t C_TCO_;
+  uint16_t C_TREF_;
+  uint16_t C_TEMPSENS_;
+
+  // Digital read-out values
+
+  // digital pressure value (D1 in datasheet)
+  uint32_t D1_P_;
+  // save previous value to use if we ever get a mis-read from the baro
+  // sensor (initialize with a non zero starter value)
+  uint32_t D1_Plast_ = 1000;
+  // digital temp value (D2 in datasheet)
+  uint32_t D2_T_;
+  // save previous value to use if we ever get a mis-read from the baro
+  // sensor (initialize with a non zero starter value)
+  uint32_t D2_Tlast_ = 1000;
+
+  // Temperature Calculations
+  int32_t dT_;
+
+  // Compensation Values
+  int64_t OFF1_;   // Offset at actual temperature
+  int64_t SENS1_;  // Sensitivity at actual temperature
+
+  // Extra compensation values for lower temperature ranges
+  int32_t TEMP2_;
+  int64_t OFF2_;
+  int64_t SENS2_;
+
+  bool startMeasurement_ = false;
+  MS5611State state_ = MS5611State::None;
+  bool tempEnabled_ = true;
+  uint32_t baroADCStartTime_ = 0;
+};

--- a/src/vario/pressure_source.h
+++ b/src/vario/pressure_source.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "flags_enum.h"
+
+// Resulting state change(s) for an update to an IPressureSource
+DEFINE_FLAGS_ENUM(PressureUpdateResult, uint8_t){
+    None = 0,
+    NoChange = 1 << 0,
+    PressureReady = 1 << 1,
+};
+
+class IPressureSource {
+ public:
+  virtual void init() = 0;
+  virtual PressureUpdateResult update() = 0;
+  virtual void startMeasurement() = 0;
+
+  // setting to control when to update temp reading from sensor (we can do
+  // temp every ~1 sec, even though we're doing pressure every 50ms)
+  // TODO: specify temp measurement every X often instead
+  virtual void enableTemp(bool enable) = 0;
+
+  // Get pressure in 1/100th mBars
+  virtual int32_t getPressure() = 0;
+
+  virtual ~IPressureSource() = default;  // Always provide a virtual destructor
+};

--- a/src/vario/pressure_source.h
+++ b/src/vario/pressure_source.h
@@ -11,8 +11,17 @@ DEFINE_FLAGS_ENUM(PressureUpdateResult, uint8_t){
 
 class IPressureSource {
  public:
+  // Initialize the pressure source.  Before this method is called, none of the other
+  // methods are expected to behave correctly.  After this method completes, all of
+  // the other methods are expected to behave correctly.
   virtual void init() = 0;
+
+  // Call this method as frequently as desired to perform pressure acquisition tasks.
+  // The return result indicates when new pressure information has been acquired.
   virtual PressureUpdateResult update() = 0;
+
+  // Inform the pressure source that new pressure information is desired.  After
+  // calling this method, call `update` until the pressure information is obtained.
   virtual void startMeasurement() = 0;
 
   // setting to control when to update temp reading from sensor (we can do

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -303,11 +303,6 @@ void main_ON_loop() {
   // serial port to be quiet
 }
 
-bool doBaroTemp = true;  // flag to track when to update temp reading from Baro Sensor (we can do
-                         // temp every ~1 sec, even though we're doing pressure every 50ms)
-bool baro_startNewCycle =
-    false;  // flag to track when Baro should start over processing a new pressure measurement
-
 void setTasks(void) {
   // increment time counters
   if (++counter_10ms_block >= 10) {
@@ -326,7 +321,7 @@ void setTasks(void) {
   // statements allow for tasks every second, spaced out on different 100ms blocks)
   switch (counter_10ms_block) {
     case 0:
-      baro_startNewCycle = true;  // begin updating baro every 50ms on the 0th and 5th blocks
+      baro.startMeasurement();  // begin updating baro every 50ms on the 0th and 5th blocks
       // taskman_baro = 0;  // begin updating baro every 50ms on the 0th and 5th blocks
       break;
     case 1:
@@ -343,7 +338,7 @@ void setTasks(void) {
     case 4:
       break;
     case 5:
-      baro_startNewCycle = true;  // begin updating baro every 50ms on the 0th and 5th blocks
+      baro.startMeasurement();  // begin updating baro every 50ms on the 0th and 5th blocks
       // taskman_baro = 0;  // begin updating baro every 50ms on the 0th and 5th blocks
       break;
     case 6:
@@ -401,9 +396,8 @@ void taskManager(void) {
   // & read).  If other tasks delay the start of the baro prep step by >1ms, then next cycle when we
   // read ADC, the Baro won't be ready.
   if (taskman_baro) {
-    baro.update(baro_startNewCycle, doBaroTemp);
+    baro.update();
     taskman_baro = 0;
-    baro_startNewCycle = false;
   }
   if (taskman_buttons) {
     buttons_update();


### PR DESCRIPTION
This PR splits the functionality of the logical barometer (calculates altitudes, filters, estimates climb rate, etc) from the sensor that is delivering pressure information.  The connecting interface between these two pieces is IPressureSource defined in pressure_source.h -- the sensor implements this interface and the logical Barometer consumes this interface.  The sensor portions of baro.h and baro.cpp are moved to ms5611.h and ms5611.cpp, leaving baro.h and baro.cpp with the logical Barometer functionality.

Instead of having numerical "process steps", both the logical Barometer and the sensor now follow the state machine pattern, changing states on update when appropriate.

Not all of the debugging print statements are rewired correctly -- they will need to be called in the appropriate places if/when needed, but I'm not sure we would use the old patterns to debug the baro any more.

Testing performed:
* Built and uploaded 3.2.3 dev
* Enabled vario sound
* Moved vario up at differing rates, observed happy beep beeps
* Moved vario down quickly, observed less happy beeps