### PR TITLE
Add baro&IMU reset when turning on from charge state

### DIFF
--- a/src/vario/IMU.cpp
+++ b/src/vario/IMU.cpp
@@ -30,6 +30,7 @@ Kalmanvert kalmanvert;
 #define POSITION_MEASURE_STANDARD_DEVIATION 0.1f
 #define ACCELERATION_MEASURE_STANDARD_DEVIATION 0.3f
 #define IMU_STARTUP_CYCLES 80  // #samples to bypass at startup while accel calibrates
+uint8_t startupCycleCount;
 
 #define DEBUG_IMU 0
 
@@ -192,6 +193,8 @@ bool processQuaternion() {
  * Initialize IMU, Quaternions, and Kalman Filter *
  *************************************************/
 void imu_init() {
+  startupCycleCount = IMU_STARTUP_CYCLES;
+
   WIRE_PORT.begin();
   WIRE_PORT.setClock(400000);
 
@@ -250,8 +253,6 @@ void imu_init() {
   tPrev = millis();
 }
 
-uint8_t startupCycleCount = IMU_STARTUP_CYCLES;
-
 void imu_update() {
   /*
   String accelName = "accel,";
@@ -279,5 +280,7 @@ void imu_update() {
     Telemetry.writeText(kalmanEntryString);
   }
 }
+
+void imu_wake() { startupCycleCount = IMU_STARTUP_CYCLES; }
 
 float IMU_getAccel() { return accelTot; }

--- a/src/vario/IMU.h
+++ b/src/vario/IMU.h
@@ -24,6 +24,7 @@ extern Kalmanvert kalmanvert;
 #define select_bank_3 0b00110000       // bank 3
 
 void imu_init(void);
+void imu_wake(void);
 void imu_update(void);
 
 float IMU_getAccel(void);

--- a/src/vario/baro.cpp
+++ b/src/vario/baro.cpp
@@ -81,6 +81,13 @@ void Barometer::init(void) {
   pressureSource_->init();
 
   // after initialization, get first baro sensor reading to populate values
+  getFirstReading();
+
+  pressureSource_->startMeasurement();
+  task_ = BarometerTask::Measure;
+}
+
+void Barometer::getFirstReading(void) {
   pressureSource_->startMeasurement();
   PressureUpdateResult result = pressureSource_->update();
   while (!FLAG_SET(result, PressureUpdateResult::PressureReady)) {
@@ -122,15 +129,15 @@ void Barometer::init(void) {
   // save the starting value as launch altitude (Launch will
   // be updated when timer starts)
   altAtLaunch = altAdjusted;
-
-  pressureSource_->startMeasurement();
-  task_ = BarometerTask::Measure;
 }
 
 void Barometer::resetLaunchAlt() { altAtLaunch = altAdjusted; }
 
-void Barometer::wake() { sleeping_ = false; }
 void Barometer::sleep() { sleeping_ = true; }
+void Barometer::wake() {
+  sleeping_ = false;
+  getFirstReading();  // after waking, get first baro sensor reading to populate values
+}
 
 void Barometer::startMeasurement() { pressureSource_->startMeasurement(); }
 

--- a/src/vario/baro.h
+++ b/src/vario/baro.h
@@ -53,6 +53,7 @@ class Barometer {
   // == Device Management ==
   // Initialize the baro
   void init(void);
+  void getFirstReading(void);
 
   // Reset launcAlt to current Alt (when starting a new log file, for example)
   void resetLaunchAlt(void);

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -137,8 +137,9 @@ void power_wake_peripherals() {
                    // mode
   Serial.println(" - waking GPS");
   gps_wake();
-  Serial.println(" - waking baro");
+  Serial.println(" - waking baro and IMU");
   baro.wake();
+  imu_wake();
   Serial.println(" - waking speaker");
   speaker_unMute();
   Serial.println(" - DONE");


### PR DESCRIPTION
Previously, we would zero the IMU and Baro [only] when first booting up to avoid [artificial] spikes in climb rate while the sensor values stabilized.   This change repeats the same zeroing out of baro & IMU values when we turn on from the charge state (i.e., a 'wake up' rather than 'power on')
