### PR TITLE
[BLE] Fix? pressure reading.

### DIFF
--- a/src/vario/baro.h
+++ b/src/vario/baro.h
@@ -12,6 +12,7 @@
 #include "buttons.h"
 #include "flags_enum.h"
 #include "pressure_source.h"
+#include "units/pressure.h"
 
 #define FILTER_VALS_MAX 20  // total array size max;
 
@@ -27,8 +28,8 @@ class Barometer {
  public:
   Barometer(IPressureSource* pressureSource) : pressureSource_(pressureSource) {}
 
-  int32_t pressure;
-  int32_t pressureFiltered;
+  Pressure pressure;
+  Pressure pressureFiltered;
   float altimeterSetting = 29.921;
   // cm raw pressure altitude calculated off standard altimeter setting (29.92)
   int32_t alt;

--- a/src/vario/ble.cpp
+++ b/src/vario/ble.cpp
@@ -187,14 +187,14 @@ void BLE::sendVarioUpdate() {
            // See https://raw.githubusercontent.com/LK8000/LK8000/master/Docs/LK8EX1.txt
            ("$LK8EX1,"  // Type of update
             "%u,"       // raw pressure in hPascal
-            "99999,"  // altitude in meters, relative to QNH 1013.25. 99999 if not available/needed
-            "%d,"     // Climb rate in cm/s.  Can be 99999 if not available
-            "99,"     // Temperature in C.  If not available, send 99
+            "%u,"   // altitude in meters, relative to QNH 1013.25. 99999 if not available/needed
+            "%d,"   // Climb rate in cm/s.  Can be 99999 if not available
+            "99,"   // Temperature in C.  If not available, send 99
             "999,"  // Battery voltage OR percentage.  If percentage, add 1000 (if 1014 is 14%). 999
                     // if unavailable
             "*"     // Checksum to follow
             ),
-           baro.pressureFiltered, baro.climbRateFiltered);
+           baro.pressure, static_cast<uint>(baro.altF), baro.climbRateFiltered);
   // Add checksum and delimeter with newline
   snprintf(stringified + strlen(stringified), sizeof(stringified), "%02X\n", checksum(stringified));
   pCharacteristic->setValue((const uint8_t*)stringified, sizeof(stringified));

--- a/src/vario/units/pressure.h
+++ b/src/vario/units/pressure.h
@@ -5,11 +5,46 @@
 
 #include "altitude.h"
 
+/// @brief Represents pressure (in 100ths of millibars hPa)
 struct Pressure {
   // Raw value in 100ths of millibars (hPa)
   int32_t raw_value;
 
   explicit Pressure(int32_t value) : raw_value(value) {}
+  explicit Pressure() : raw_value(0) {}
+
+  // Assignment operator to assign int32_t to Pressure
+  Pressure& operator=(int32_t value) {
+    raw_value = value;
+    return *this;
+  }
+
+  // Type conversion operator to convert Pressure to int32_t
+  operator int32_t() const { return raw_value; }
+
+  // Addition assignment operator
+  Pressure& operator+=(int32_t value) {
+    raw_value += value;
+    return *this;
+  }
+
+  // Subtraction assignment operator
+  Pressure& operator-=(int32_t value) {
+    raw_value -= value;
+    return *this;
+  }
+
+  // Multiplication assignment operator
+  Pressure& operator*=(int32_t value) {
+    raw_value *= value;
+    return *this;
+  }
+
+  // Division assignment operator
+  Pressure& operator/=(int32_t value) {
+    raw_value /= value;
+    return *this;
+  }
 
   /// @brief hPa
   /// @return


### PR DESCRIPTION
For bug: #95 

## Description

Noticed the altitude in Flyskyhy when flying paired with the device was often 0 or negative values :\. This is an attempt to fix it.

As figuring out units of pressure was very hard to understand, moved them to a Pressure struct to allow easy unit conversion.

## Test Plan

1.  Paired with the phone, observed lift moves with the device.
2.  Altitude is still interesting.  The leaf reports ft MSL as ~170 ft, Flyskyhy 25-75... 

<img width="397" alt="image" src="https://github.com/user-attachments/assets/36fc9d6a-b755-4f1e-ac53-adfbc21e0a0e" />

![image](https://github.com/user-attachments/assets/b27cd82e-c008-4076-b8e8-34f7b2b72b58)
