### PR TITLE
[Releases] Use leaf_3_2_3 as firmware.bin

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,37 +90,9 @@ jobs:
       - name: List artifacts files (debugging)
         run: ls -R artifacts
 
-      - name: Copy newest hardware firmware to firmware.bin
+      - name: Copy appropriate hardware firmware to firmware.bin
         # Backwards compatibility: Release 0.0.9 and earlier expect a file named "firmware.bin"
-        run: |
-          highest_version="0.0.0"
-          highest_file=""
-
-          # Iterate over firmware files
-          for file in artifacts/firmware-leaf_*.bin; do
-            # Extract XX, YY, and ZZ using regex
-            if [[ $file =~ firmware-leaf_([0-9]+)_([0-9]+)_([0-9]+)\.bin ]]; then
-              xx=${BASH_REMATCH[1]}
-              yy=${BASH_REMATCH[2]}
-              zz=${BASH_REMATCH[3]}
-              version="$xx.$yy.$zz"
-
-              # Compare versions
-              if [[ $(printf '%s\n' "$highest_version" "$version" | sort -V | tail -n1) == "$version" ]]; then
-                highest_version="$version"
-                highest_file="$file"
-              fi
-            fi
-          done
-
-          # Copy the highest version firmware to artifacts/firmware.bin
-          if [[ -n "$highest_file" ]]; then
-            cp "$highest_file" artifacts/firmware.bin
-            echo "Selected firmware: $highest_file (version $highest_version)"
-          else
-            echo "No firmware files found!" >&2
-            exit 1
-          fi
+        run: cp artifacts/firmware-leaf_3_2_3.bin artifacts/firmware.bin
 
       - name: Upload artifacts to GitHub Release
         uses: softprops/action-gh-release@v2

--- a/src/variants/README.md
+++ b/src/variants/README.md
@@ -4,17 +4,18 @@ Leaf supports building nominally the same firmware for different hardware varian
 
 ## Creating a new variant
 
-To create a new hardware variant, first identify the [hardware type](../README.md#hardware-type) (usually "leaf") and [hardware version](../README.md#hardware-version) (e.g., 3.2.5).  The name for this hardware variant must be: `{hardware type}_{underscored hardware version}` where `{underscored hardware version}` is the hardware version with periods replaced with underscores.  Create a folder with this name within this folder.  Add this variant name to the list of variants in [build.yaml](../../.github/workflows/build.yaml).  Change [platformio.ini](../../platformio.ini) to point `default_envs` at the appropriate environment (see below).
+To create a new hardware variant:
 
-In the new folder, add:
-
-### platformio.ini
-
-This partial platformio.ini should define `[env:{hardware variant}_dev]` and `[env:{hardware variant}_release]` which should extend `env:_dev`and `env:_release` respectively.  In each of these environments, `build_flags` must extend the build flags of the base environment to add `-Isrc/variants/{hardware variant}`.
-
-### variant.h
-
-This file must exist, and should define any differences inherent to this hardware variant.
+1. Identify the [hardware type](../README.md#hardware-type) (usually "leaf") and [hardware version](../README.md#hardware-version) (e.g., 3.2.5)
+2. Create the name for this hardware variant as: `{hardware type}_{underscored hardware version}` where `{underscored hardware version}` is the hardware version with periods replaced with underscores.
+3. Create a folder with the hardware variant's name within this (`variants`) folder.  In the new folder, add:
+    1. **platformio.ini**
+        1. This partial platformio.ini should define `[env:{hardware variant}_dev]` and `[env:{hardware variant}_release]` which should extend `env:_dev`and `env:_release` respectively.
+        2. In each of these environments, `build_flags` must extend the build flags of the base environment to add `-Isrc/variants/{hardware variant}`.
+    2. **variant.h**: This file must exist, and should define any differences inherent to this hardware variant.
+4. Add this variant name to the list of variants in [build.yaml](../../.github/workflows/build.yaml).
+5. If applicable, change the "Copy appropriate hardware firmware to firmware.bin" step in [build.yaml](../../.github/workflows/build.yaml) to use the new hardware variant as the backwards-compatible firmware.bin.
+6. If applicable, change [the main platformio.ini](../../platformio.ini) to point `default_envs` at the appropriate environment (see 3.1 above).
 
 ## Retiring a variant
 


### PR DESCRIPTION
This PR switches from using the latest hardware variant as the backwards-compatible firmware.bin to using a specifically-identified hardware variant (currently 3.2.3).  It also updates the variants documentation to be more like a checklist, and includes a new checklist item for changing this value when a new hardware variant is created.

Tested by pushing to main branch on my fork, creating a release, and observing that firmware.bin matched the size of firmware-leaf_3_2_3.bin rather than firmware-leaf_3_2_5.bin.