### PR TITLE
[tooling] Update auto-formatting task to use clang-format from C++ extension

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,13 @@
       "label": "Format Leaf C++ files",
       "type": "shell",
       "windows": {
-        "command": "Get-ChildItem -Path src/vario, src/variants -Recurse -Include *.cpp, *.h | ForEach-Object { clang-format -i $_.FullName }",
+        "command": "powershell.exe",
+        "args": [
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "${workspaceFolder}/src/scripts/format_all_files.ps1"
+        ],
         "options": {
           "shell": {
             "executable": "powershell.exe"
@@ -13,10 +19,10 @@
         }
       },
       "osx": {
-        "command": "find src/vario src/variants -type f \\( -name \"*.cpp\" -o -name \"*.h\" \\) -exec clang-format -i {} +"
+        "command": "${workspaceFolder}/src/scripts/format_all_files.sh"
       },
       "linux": {
-        "command": "find src/vario src/variants -type f \\( -name \"*.cpp\" -o -name \"*.h\" \\) -exec clang-format -i {} +"
+        "command": "${workspaceFolder}/src/scripts/format_all_files.sh"
       },
       "problemMatcher": [],
       "group": "build",

--- a/src/scripts/format_all_files.ps1
+++ b/src/scripts/format_all_files.ps1
@@ -1,0 +1,30 @@
+# Get the VS Code extensions directory
+$VSCodeExtDir = "$env:USERPROFILE\.vscode\extensions"
+
+# Find the latest installed clang-format in the VS Code extensions folder
+$ClangFormatPath = Get-ChildItem -Path $VSCodeExtDir -Recurse -Filter "clang-format.exe" | 
+                   Sort-Object FullName -Descending | 
+                   Select-Object -First 1 -ExpandProperty FullName
+
+# Check if clang-format was found
+if (-not $ClangFormatPath) {
+    Write-Host "clang-format not found in VS Code extensions. Please install the C/C++ extension." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Using clang-format: $ClangFormatPath" -ForegroundColor Cyan
+
+# Process each file and check if changes were made
+$Files = Get-ChildItem -Path src/vario, src/variants -Recurse -Include *.cpp, *.h
+
+foreach ($File in $Files) {
+    $OriginalHash = Get-FileHash -Path $File.FullName -Algorithm SHA256
+    & $ClangFormatPath -i $File.FullName
+    $NewHash = Get-FileHash -Path $File.FullName -Algorithm SHA256
+
+    if ($OriginalHash.Hash -ne $NewHash.Hash) {
+        Write-Host "Formatted: $($File.FullName)" -ForegroundColor Green
+    }
+}
+
+Write-Host "Formatting complete."

--- a/src/scripts/format_all_files.sh
+++ b/src/scripts/format_all_files.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Find the VS Code C++ extension path
+VSCODE_EXT_DIR="$HOME/.vscode/extensions"
+CLANG_FORMAT_PATH=$(find "$VSCODE_EXT_DIR" -type f -path "*/LLVM/bin/clang-format" | sort -V | tail -n 1)
+
+# Check if clang-format was found
+if [[ -z "$CLANG_FORMAT_PATH" ]]; then
+    echo -e "\e[31mclang-format not found in VS Code extensions. Please install the C/C++ extension.\e[0m"
+    exit 1
+fi
+
+echo -e "\e[36mUsing clang-format: $CLANG_FORMAT_PATH\e[0m"
+
+# Process each file and check if changes were made
+find src/vario src/variants -type f \( -name "*.cpp" -o -name "*.h" \) | while read -r file; do
+    original_hash=$(sha256sum "$file" | awk '{print $1}')
+    "$CLANG_FORMAT_PATH" -i "$file"
+    new_hash=$(sha256sum "$file" | awk '{print $1}')
+
+    if [[ "$original_hash" != "$new_hash" ]]; then
+        echo -e "\e[32mFormatted: $file\e[0m"
+    fi
+done
+
+echo -e "\e[36mFormatting complete.\e[0m"


### PR DESCRIPTION
Previously, [auto-formatting](https://github.com/DangerMonkeys/leaf/tree/main/src#formatting) assumed `clang-format` was available on the user's path, but this is not generally the case.  Instead, `clang-format` is provided by the C/C++ extension.  This PR updates the auto-formatting task to work in environments where `clang-format` is only available via the extension (most environments, likely).

Tested by modifying a file outside VS Code, running the task, and observing the formatting was correctly re-applied.  Linux and Mac version untested, unfortunately.  But, at least there will be a starting point if/when we [edit] gain contributors who use Linux and/or Mac.