### PR TITLE
Add fatal error behavior

### DIFF
--- a/src/vario/diagnostics/fatal_error.cpp
+++ b/src/vario/diagnostics/fatal_error.cpp
@@ -6,7 +6,15 @@
 
 #include "FS.h"
 
+#include "ui/audio/speaker.h"
+#include "ui/display/display.h"
+#include "ui/display/fonts.h"
+#include "ui/input/buttons.h"
+#include "ui/settings/settings.h"
+
 File fatal_error_file;
+
+constexpr size_t BUFFER_SIZE = 512;
 
 bool useFile() {
   if (fatal_error_file) {
@@ -38,12 +46,11 @@ bool useFile() {
 }
 
 void fatalErrorInfo(const char* msg, ...) {
-  constexpr size_t bufferSize = 512;
-  char buffer[bufferSize];
+  char buffer[BUFFER_SIZE];
 
   va_list args;
   va_start(args, msg);
-  vsnprintf(buffer, bufferSize, msg, args);
+  vsnprintf(buffer, BUFFER_SIZE, msg, args);
   va_end(args);
 
   Serial.println(buffer);
@@ -52,28 +59,87 @@ void fatalErrorInfo(const char* msg, ...) {
   }
 }
 
+void displayFatalError(char* msg) {
+  u8g2.firstPage();
+  do {
+    // TODO: Add skull and cross bones icon
+
+    u8g2.setFont(leaf_6x12);
+    u8g2.setCursor(0, 12);
+    u8g2.print("FATAL ERROR");
+
+    u8g2.setFont(leaf_5x8);
+    u8g2.setCursor(0, 36);
+    u8g2.print(msg);  // TODO: wrap words to multiple lines
+
+    u8g2.setFont(leaf_5x8);
+    u8g2.setCursor(0, 163);
+    u8g2.print("Please report this");
+    u8g2.setCursor(0, 172);
+    u8g2.print("error.");
+    u8g2.setCursor(0, 186);
+    u8g2.print("Hold button to reboot");
+  } while (u8g2.nextPage());
+
+  // TODO: Add QR code linking to error reporting instructions
+}
+
+void rebootOnKeyPress() {
+  Button which_button;
+  ButtonState button_state;
+
+  // Wait until no buttons are pressed
+  do {
+    which_button = buttons_check();
+  } while (which_button == Button::NONE);
+
+  // Wait until a button is held
+  do {
+    which_button = buttons_check();
+    button_state = buttons_get_state();
+  } while (button_state != ButtonState::HELD);
+
+  speaker_playSound(fx_off);
+  while (onSpeakerTimer()) {
+    delay(10);
+  }
+
+  ESP.restart();
+}
+
 void fatalError(const char* msg, ...) {
   Serial.print("FATAL ERROR: ");
 
-  constexpr size_t bufferSize = 512;
-  char buffer[bufferSize];
-
+  // Construct final error message
+  char buffer[BUFFER_SIZE];
   va_list args;
   va_start(args, msg);
-  vsnprintf(buffer, bufferSize, msg, args);
+  vsnprintf(buffer, BUFFER_SIZE, msg, args);
   va_end(args);
 
   Serial.println(buffer);
+
+  // Try to write final error message to file
   if (useFile()) {
     fatal_error_file.println(buffer);
   }
 
+  // Close file if open
   if (fatal_error_file) {
     fatal_error_file.close();
   }
 
-  // TODO: when possible, show death icon on LCD along with message
-  // TODO: when possible, play death sound
+  // Show fatal error info on screen
+  u8g2.clear();
+  displayFatalError(buffer);
 
-  while (true);
+  // Play fatal error sound
+  speaker_unMute();
+  settings.system_volume = 3;
+  speaker_playSound(fx_fatalerror);
+  while (onSpeakerTimer()) {
+    delay(10);
+  }
+
+  rebootOnKeyPress();
 }

--- a/src/vario/diagnostics/fatal_error.cpp
+++ b/src/vario/diagnostics/fatal_error.cpp
@@ -1,0 +1,79 @@
+#include "fatal_error.h"
+
+#include <Arduino.h>
+#include <SD_MMC.h>
+#include <stdarg.h>
+
+#include "FS.h"
+
+File fatal_error_file;
+
+bool useFile() {
+  if (fatal_error_file) {
+    return true;
+  }
+
+  unsigned int i = 1;
+  char fileName[32];
+
+  while (true) {
+    snprintf(fileName, sizeof(fileName), "/fatal_error_%u.txt", i);
+
+    fs::File f = SD_MMC.open(fileName, "r");
+    if (!f) {
+      // If the error was that the file doesn't exist, break and use this name
+      break;
+    }
+
+    f.close();  // File exists, close and try next
+    i++;
+    if (i > 1000) {
+      // Avoid infinite loop in case of filesystem issues
+      return false;
+    }
+  }
+
+  fatal_error_file = SD_MMC.open(fileName, "w", true);  // open for writing, create if doesn't exist
+  return fatal_error_file;
+}
+
+void fatalErrorInfo(const char* msg, ...) {
+  constexpr size_t bufferSize = 512;
+  char buffer[bufferSize];
+
+  va_list args;
+  va_start(args, msg);
+  vsnprintf(buffer, bufferSize, msg, args);
+  va_end(args);
+
+  Serial.println(buffer);
+  if (useFile()) {
+    fatal_error_file.println(buffer);
+  }
+}
+
+void fatalError(const char* msg, ...) {
+  Serial.print("FATAL ERROR: ");
+
+  constexpr size_t bufferSize = 512;
+  char buffer[bufferSize];
+
+  va_list args;
+  va_start(args, msg);
+  vsnprintf(buffer, bufferSize, msg, args);
+  va_end(args);
+
+  Serial.println(buffer);
+  if (useFile()) {
+    fatal_error_file.println(buffer);
+  }
+
+  if (fatal_error_file) {
+    fatal_error_file.close();
+  }
+
+  // TODO: when possible, show death icon on LCD along with message
+  // TODO: when possible, play death sound
+
+  while (true);
+}

--- a/src/vario/diagnostics/fatal_error.h
+++ b/src/vario/diagnostics/fatal_error.h
@@ -1,5 +1,10 @@
 #pragma once
 
+// Provide information about an upcoming fatal error before triggering the final fatal error.
+// Arguments follow the printf pattern.
 void fatalErrorInfo(const char* msg, ...);
 
+// Trigger a fatal error that ends normal program execution.  Additional information
+// can be provided by calling fatalErrorInfo before calling this function.
+// Arguments follow the printf pattern for the final fatal error message.
 void fatalError(const char* msg, ...);

--- a/src/vario/diagnostics/fatal_error.h
+++ b/src/vario/diagnostics/fatal_error.h
@@ -1,0 +1,5 @@
+#pragma once
+
+void fatalErrorInfo(const char* msg, ...);
+
+void fatalError(const char* msg, ...);

--- a/src/vario/hardware/ms5611.cpp
+++ b/src/vario/hardware/ms5611.cpp
@@ -142,6 +142,8 @@ PressureUpdateResult MS5611::update() {
 void MS5611::startMeasurement() { startMeasurement_ = true; }
 
 int32_t MS5611::getPressure() {
+  // TODO: replace division by powers of 2 with >> and multiplication by powers of 2 with <<
+
   // calculate temperature (in 100ths of degrees C, from -4000 to 8500)
   dT_ = D2_T_ - ((int32_t)C_TREF_) * 256;
   int32_t TEMP = 2000 + (((int64_t)dT_) * ((int64_t)C_TEMPSENS_)) / pow(2, 23);

--- a/src/vario/math/linear_regression.h
+++ b/src/vario/math/linear_regression.h
@@ -3,6 +3,8 @@
 #include <Arduino.h>
 #include <stdint.h>
 
+#include "diagnostics/fatal_error.h"
+
 double linear_value(const struct LinearFit* fit, double x);
 double linear_derivative(const struct LinearFit* fit, double x);
 
@@ -105,31 +107,15 @@ LinearFit LinearRegression<n>::fit() {
     double numerator = _count * sum_xiyi - sum_xi * sum_yi;
 
     if (denominator == 0) {
-      Serial.println("OH NO DENOMINATOR IS 0!!!");
-      Serial.print("_count=");
-      Serial.print(_count);
-      Serial.print(", _sumXi2=");
-      Serial.print(_sumXi2);
-      Serial.print(", _sumXi=");
-      Serial.print(_sumXi);
-      Serial.println();
-      Serial.print("_Xi = {");
+      fatalErrorInfo("_count=%d, _sumXi2=%g, _sumXi=%g, _Xi:", _count, _sumXi2, _sumXi);
       for (uint8_t i = 0; i < _count; i++) {
-        Serial.print(_Xi[i]);
-        Serial.print(", ");
+        fatalErrorInfo("%g", _Xi[i]);
       }
-      Serial.println("}");
-      Serial.print("_Yi = {");
+      fatalErrorInfo("_Yi:");
       for (uint8_t i = 0; i < _count; i++) {
-        Serial.print(_Yi[i]);
-        Serial.print(", ");
+        fatalErrorInfo("%g", _Yi[i]);
       }
-      Serial.println("}");
-      // die();
-      while (true) {
-        delay(1);
-      }
-      // TODO: safer end state here
+      fatalError("denominator was 0 in linear_regression");
     }
     result.m = numerator / denominator;
     result.b = (_sumYi - result.m * _sumXi) / _count;

--- a/src/vario/math/running_average.h
+++ b/src/vario/math/running_average.h
@@ -18,6 +18,7 @@ class RunningAverage {
   }
 
   void update(TValue value) {
+    // Note: average will become NaN if value is NaN
     if (count < sampleCount) {
       sum += value;
       samples[count++] = value;
@@ -45,11 +46,15 @@ class RunningAverage {
  private:
   void recomputeSum() {
     sum = 0;
-    count = (count > sampleCount) ? sampleCount : count;
+    if (count > sampleCount) {
+      count = sampleCount;
+      index = 0;
+    } else {
+      index = count;
+    }
     for (size_t i = 0; i < count; ++i) {
       sum += samples[i];
     }
-    index = count % sampleCount;
   }
 
   std::array<TValue, MaxSamples> samples;

--- a/src/vario/math/running_average.h
+++ b/src/vario/math/running_average.h
@@ -46,15 +46,11 @@ class RunningAverage {
  private:
   void recomputeSum() {
     sum = 0;
-    if (count > sampleCount) {
-      count = sampleCount;
-      index = 0;
-    } else {
-      index = count;
-    }
+    count = (count > sampleCount) ? sampleCount : count;
     for (size_t i = 0; i < count; ++i) {
       sum += samples[i];
     }
+    index = count % sampleCount;
   }
 
   std::array<TValue, MaxSamples> samples;

--- a/src/vario/ui/audio/speaker.cpp
+++ b/src/vario/ui/audio/speaker.cpp
@@ -39,6 +39,8 @@ uint16_t fx_goingdown[] = {31, 31, 32, 33, 34, 35, 36, 38, 41, 46, NOTE_END};
 uint16_t fx_octavesup[] = {45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, NOTE_END};
 uint16_t fx_octavesdown[] = {31, 31, 40, 40, 45, 45, 65, 65, 90, 90, NOTE_END};
 
+uint16_t fx_fatalerror[] = {50, 250, 50, 250, 50, 250, 50, 250, 50, 250, NOTE_END};
+
 uint16_t single_note[] = {
     0, NOTE_END};  // this is to allow playing single notes by changing random_note[0], while still
                    // having a NOTE_END terminator following.

--- a/src/vario/ui/audio/speaker.h
+++ b/src/vario/ui/audio/speaker.h
@@ -199,6 +199,8 @@ extern uint16_t fx_goingdown[];
 extern uint16_t fx_octavesup[];
 extern uint16_t fx_octavesdown[];
 
+extern uint16_t fx_fatalerror[];
+
 extern uint16_t single_note[];
 
 /*

--- a/src/vario/utils/lock_guard.cpp
+++ b/src/vario/utils/lock_guard.cpp
@@ -2,9 +2,11 @@
 
 #include <SD_MMC.h>
 
+#include "diagnostics/fatal_error.h"
+
 LockGuard::LockGuard(SemaphoreHandle_t mutex) : mutex_(mutex) {
   // Try to take the lock out
   if (xSemaphoreTake(mutex_, pdMS_TO_TICKS(10000)) == pdTRUE) return;
 
-  assert(0);  // Create a core dump if the lock fails
+  fatalError("Lock acquisition failed in LockGuard constructor");
 }


### PR DESCRIPTION
Sometimes there are, or will be, situations where something that shouldn't have happened did happen and now leaf is in an undefined state.  We don't want to continue in those situations since now its behavior will be undefined.  This PR adds a fatal error capability to fail fast in those situations while providing an indication of what happened to the user and recording associated information to help in later debugging.

The fatal error functionality is exercised by adding checks to state estimates so we can determine why state estimates switch to Nan or Inf sometimes.  Error information is recorded to fatal_eror_[N].txt on the SD card.

I tested fatal error behavior by adding the following code in page_menu_altimeter.cpp and navigating to the altimeter menu option:
```cpp
void AltimeterMenuPage::draw() {
  float asdf = 12.34f;
  double ghjk = 56.78;
  fatalErrorInfo("This is info %g", asdf);
  fatalError("Final fatal error %g", ghjk);
```
I verified 31 separate errors (to fatal_error_31.txt).

I tested normal operation with the debug code above removed (as in PR) and followed the [test procedure](https://github.com/DangerMonkeys/leaf/blob/main/docs/dev-references/testing/test_procedure.md).