### PR TITLE
Split IMU into instrument and hardware motion source

### DIFF
--- a/src/vario/hardware/icm_20948.cpp
+++ b/src/vario/hardware/icm_20948.cpp
@@ -1,0 +1,124 @@
+/*
+ * TDK InvenSense ICM-20498
+ * 6 DOF Gyro+Accel plus 3-axis mag
+ *
+ */
+
+#include "hardware/icm_20948.h"
+
+#include "hardware/motion_source.h"
+
+#define DEBUG_IMU 0
+
+#define WIRE_PORT Wire
+#define SERIAL_PORT Serial
+#define AD0_VAL 0  // I2C address bit
+
+void ICM20948::init() {
+  WIRE_PORT.begin();
+  WIRE_PORT.setClock(400000);
+
+  if (DEBUG_IMU) IMU_.enableDebugging();  // enable helpful debug messages on Serial
+
+  // TODO: Abort initialization attempt after some amount of time and show a fatal error
+  bool initialized = false;
+  while (!initialized) {
+    IMU_.begin(WIRE_PORT, AD0_VAL);
+    SERIAL_PORT.print(F("Initialization of the IMU returned: "));
+    SERIAL_PORT.println(IMU_.statusString());
+    if (IMU_.status != ICM_20948_Stat_Ok) {
+      SERIAL_PORT.println("Trying again...");
+      delay(500);
+    } else {
+      initialized = true;
+    }
+  }
+
+  // TODO: Trigger a fatal error if configuration fails
+  bool success = true;  // Use success to show if the DMP configuration was successful
+
+  // Initialize the DMP. initializeDMP is a weak function. You can overwrite it if you want to e.g.
+  // to change the sample rate
+  success &= (IMU_.initializeDMP() == ICM_20948_Stat_Ok);
+
+  // Enable the DMP orientation and accelerometer sensors
+  success &= (IMU_.enableDMPSensor(INV_ICM20948_SENSOR_ORIENTATION) == ICM_20948_Stat_Ok);
+  success &= (IMU_.enableDMPSensor(INV_ICM20948_SENSOR_ACCELEROMETER) == ICM_20948_Stat_Ok);
+
+  // Configuring DMP to output data at multiple ODRs:
+  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Quat9, 2) == ICM_20948_Stat_Ok);  // Set to the maximum
+  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Accel, 2) == ICM_20948_Stat_Ok);  // Set to the maximum
+
+  // Enable the FIFO
+  success &= (IMU_.enableFIFO() == ICM_20948_Stat_Ok);
+
+  // Enable the DMP
+  success &= (IMU_.enableDMP() == ICM_20948_Stat_Ok);
+
+  // Reset DMP
+  success &= (IMU_.resetDMP() == ICM_20948_Stat_Ok);
+
+  // Reset FIFO
+  success &= (IMU_.resetFIFO() == ICM_20948_Stat_Ok);
+
+  // Check success
+  if (success) {
+    SERIAL_PORT.println(F("DMP enabled!"));
+  } else {
+    SERIAL_PORT.println(F("Enable DMP failed!"));
+  }
+}
+
+MotionUpdateResult ICM20948::update() {
+  icm_20948_DMP_data_t data;
+  IMU_.readDMPdataFromFIFO(&data);  // TODO: consider rate-limiting this operation
+
+  bool hasQuat = false;
+  bool hasAccel = false;
+
+  if ((IMU_.status == ICM_20948_Stat_Ok) ||
+      (IMU_.status == ICM_20948_Stat_FIFOMoreDataAvail))  // Was valid data available?
+  {
+    if ((data.header & DMP_header_bitmap_Quat9) > 0) {
+      tQuaternion_ = millis();
+
+      // Scale to +/- 1
+      qx_ = ((double)data.Quat9.Data.Q1) / 1073741824.0;  // Convert to double. Divide by 2^30
+      qy_ = ((double)data.Quat9.Data.Q2) / 1073741824.0;  // Convert to double. Divide by 2^30
+      qz_ = ((double)data.Quat9.Data.Q3) / 1073741824.0;  // Convert to double. Divide by 2^30
+      hasQuat = true;
+    }
+    if ((data.header & DMP_header_bitmap_Accel) > 0) {
+      tAcceleration_ = millis();
+
+      // Scale to Gs
+      ax_ = ((double)data.Raw_Accel.Data.X) / 8192.0;
+      ay_ = ((double)data.Raw_Accel.Data.Y) / 8192.0;
+      az_ = ((double)data.Raw_Accel.Data.Z) / 8192.0;
+      hasAccel = true;
+    }
+  }
+  if (hasQuat && hasAccel) {
+    return MotionUpdateResult::AccelerationReady | MotionUpdateResult::QuaternionReady;
+  } else if (hasQuat) {
+    return MotionUpdateResult::QuaternionReady;
+  } else if (hasAccel) {
+    return MotionUpdateResult::AccelerationReady;
+  } else {
+    return MotionUpdateResult::NoChange;
+  }
+}
+
+void ICM20948::getOrientation(unsigned long* t, double* qx, double* qy, double* qz) {
+  *t = tQuaternion_;
+  *qx = qx_;
+  *qy = qy_;
+  *qz = qz_;
+}
+
+void ICM20948::getAcceleration(unsigned long* t, double* ax, double* ay, double* az) {
+  *t = tAcceleration_;
+  *ax = ax_;
+  *ay = ay_;
+  *az = az_;
+}

--- a/src/vario/hardware/icm_20948.h
+++ b/src/vario/hardware/icm_20948.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "hardware/motion_source.h"
+
+#include <ICM_20948.h>
+
+class ICM20948 : public IMotionSource {
+ public:
+  void init();
+  MotionUpdateResult update();
+  void getOrientation(unsigned long* t, double* qx, double* qy, double* qz);
+  void getAcceleration(unsigned long* t, double* ax, double* ay, double* az);
+
+ private:
+  ICM_20948_I2C IMU_;
+  unsigned long tQuaternion_;
+  unsigned long tAcceleration_;
+  double qx_, qy_, qz_;
+  double ax_, ay_, az_;
+};

--- a/src/vario/hardware/motion_source.h
+++ b/src/vario/hardware/motion_source.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "utils/flags_enum.h"
+
+// Resulting state change(s) for an update to an ISpatialMotionSource
+DEFINE_FLAGS_ENUM(MotionUpdateResult, uint8_t){
+    None = 0,
+    NoChange = 1 << 0,
+    QuaternionReady = 1 << 1,
+    AccelerationReady = 1 << 2,
+};
+
+class IMotionSource {
+ public:
+  // Initialize the motion source.  Before this method is called, none of the other
+  // methods are expected to behave correctly.  After this method completes, all of
+  // the other methods are expected to behave correctly.
+  virtual void init() = 0;
+
+  // Call this method as frequently as desired to perform motion acquisition tasks.
+  // The return result indicates when new motion information has been acquired.
+  virtual MotionUpdateResult update() = 0;
+
+  // Get orientation quaternion
+  virtual void getOrientation(unsigned long* t, double* qx, double* qy, double* qz) = 0;
+
+  // Get acceleration vector
+  virtual void getAcceleration(unsigned long* t, double* ax, double* ay, double* az) = 0;
+
+  virtual ~IMotionSource() = default;  // Always provide a virtual destructor
+};

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -26,9 +26,9 @@
 #define CLIMB_AVERAGE 4
 
 // Singleton sensor to use in barometer
-MS5611 sensor;
+MS5611 pressureSensor;
 // Singleton barometer instance for device
-Barometer baro(&sensor);
+Barometer baro(&pressureSensor);
 
 void Barometer::adjustAltSetting(int8_t dir, uint8_t count) {
   float increase = .001;  //
@@ -185,7 +185,7 @@ void Barometer::update() {
     // Filter after Baro_step_2 but before Baro_step_3
 
     // get instant climb rate
-    climbRate = (float)kalmanvert.getVelocity();  // in m/s
+    climbRate = imu.getVelocity();  // in m/s
     if (isnan(climbRate) || isinf(climbRate)) {
       fatalError("climbRate in Barometer::update was %g after kalmanvert.getVelocity()", climbRate);
     }

--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -1,19 +1,16 @@
-/*
- * IMU.cpp
- *
- * TDK InvenSense ICM-20498
- * 6 DOF Gyro+Accel plus 3-axis mag
- *
- */
 #include "instruments/imu.h"
 
-#include <ICM_20948.h>
-
 #include "hardware/Leaf_I2C.h"
+#include "hardware/icm_20948.h"
 #include "logging/log.h"
 #include "logging/telemetry.h"
 #include "math/kalman.h"
 #include "storage/sd_card.h"
+
+// Singleton sensor to use in IMU
+ICM20948 motionSensor;
+// Singleton IMU instance for device
+IMU imu(&motionSensor);
 
 // === What to display on the serial port
 // #define ALIGN_TEXT 3  // When set, puts values in equal-width columns with this many digits
@@ -24,27 +21,9 @@
 // #define SHOW_FIXED_BOUNDS 0.2  // When set, print fixed values to keep the Arduino serial plot in
 // a consistent range
 
-#define POSITION_MEASURE_STANDARD_DEVIATION 0.1f
-#define ACCELERATION_MEASURE_STANDARD_DEVIATION 0.3f
-
-// Kalman filter object for vertical climb rate and position
-KalmanFilterPA kalmanvert(pow(POSITION_MEASURE_STANDARD_DEVIATION, 2),
-                          pow(ACCELERATION_MEASURE_STANDARD_DEVIATION, 2));
-
 #define IMU_STARTUP_CYCLES 80  // #samples to bypass at startup while accel calibrates
-uint8_t startupCycleCount;
-
-#define DEBUG_IMU 0
-
-#define SERIAL_PORT Serial
-#define WIRE_PORT Wire
-#define AD0_VAL 0  // I2C address bit
-
-ICM_20948_I2C IMU;
 
 // == Estimation of constant gravity acceleration ==
-double zAvg = 1.0;                          // Best guess for strength of gravity
-uint32_t tPrev;                             // Last time gravity guess was updated
 const double NEW_MEASUREMENT_WEIGHT = 0.9;  // Weight given to new measurements...
 const double AFTER_SECONDS = 5.0;           // ...after this number of seconds
 const double K_UPDATE = log(1 - NEW_MEASUREMENT_WEIGHT) / AFTER_SECONDS;
@@ -76,185 +55,123 @@ inline void printFloat(double v) {
   Serial.print(v, digits);
 }
 
-double accelVert;
-double accelTot;
+bool IMU::processQuaternion() {
+  MotionUpdateResult result = motionSource_->update();
+  if (result == MotionUpdateResult::NoChange) {
+    return false;
+  }
 
-bool processQuaternion() {
-  bool success = false;
-  icm_20948_DMP_data_t data;
-  IMU.readDMPdataFromFIFO(&data);
+  unsigned long t;
+  double qx, qy, qz, ax, ay, az;
 
-  if ((IMU.status == ICM_20948_Stat_Ok) ||
-      (IMU.status == ICM_20948_Stat_FIFOMoreDataAvail))  // Was valid data available?
-  {
-    if ((data.header & DMP_header_bitmap_Quat9) > 0 &&
-        (data.header & DMP_header_bitmap_Accel) > 0) {
-      uint32_t t = millis();
-      double dt = ((double)t - tPrev) * 0.001;
-      double f = exp(K_UPDATE * dt);
-      tPrev = t;
+  motionSource_->getOrientation(&t, &qx, &qy, &qz);
 
-      // Scale to +/- 1
-      double qx = ((double)data.Quat9.Data.Q1) / 1073741824.0;  // Convert to double. Divide by 2^30
-      double qy = ((double)data.Quat9.Data.Q2) / 1073741824.0;  // Convert to double. Divide by 2^30
-      double qz = ((double)data.Quat9.Data.Q3) / 1073741824.0;  // Convert to double. Divide by 2^30
-      double magnitude = ((qx * qx) + (qy * qy) + (qz * qz));
-      if (magnitude >= 1.0) magnitude = 1.0;
-      double qw = sqrt(1.0 - magnitude);
+  // Scale to +/- 1
+  double magnitude = ((qx * qx) + (qy * qy) + (qz * qz));
+  if (magnitude >= 1.0) magnitude = 1.0;
+  double qw = sqrt(1.0 - magnitude);
 
-      bool needComma = false;
-      bool needNewline = false;
+  bool needComma = false;
+  bool needNewline = false;
 
 #ifdef SHOW_QUATERNION
-      Serial.print(F("Qw:"));
-      printFloat(qw);
-      Serial.print(F(",Qx:"));
-      printFloat(qx);
-      Serial.print(F(",Qy:"));
-      printFloat(qy);
-      Serial.print(F(",Qz:"));
-      printFloat(qz);
-      needComma = true;
-      needNewline = true;
-
+  Serial.print(F("Qw:"));
+  printFloat(qw);
+  Serial.print(F(",Qx:"));
+  printFloat(qx);
+  Serial.print(F(",Qy:"));
+  printFloat(qy);
+  Serial.print(F(",Qz:"));
+  printFloat(qz);
+  needComma = true;
+  needNewline = true;
 #endif
 
-      double ax = ((double)data.Raw_Accel.Data.X) / 8192.0;
-      double ay = ((double)data.Raw_Accel.Data.Y) / 8192.0;
-      double az = ((double)data.Raw_Accel.Data.Z) / 8192.0;
-
-      accelTot = sqrt(ax * ax + ay * ay + az * az);
+  motionSource_->getAcceleration(&t, &ax, &ay, &az);
+  accelTot_ = sqrt(ax * ax + ay * ay + az * az);
 
 #ifdef SHOW_DEVICE_ACCEL
-      if (needComma) {
-        Serial.print(',');
-      }
-      Serial.print(F("Ax:"));
-      printFloat(ax);
-      Serial.print(F(",Ay:"));
-      printFloat(ay);
-      Serial.print(F(",Az:"));
-      printFloat(az);
-      needComma = true;
-      needNewline = true;
+  if (needComma) {
+    Serial.print(',');
+  }
+  Serial.print(F("Ax:"));
+  printFloat(ax);
+  Serial.print(F(",Ay:"));
+  printFloat(ay);
+  Serial.print(F(",Az:"));
+  printFloat(az);
+  needComma = true;
+  needNewline = true;
 #endif
 
-      double awx, awy, awz;
-      rotateByQuaternion(ax, ay, az, qw, qx, qy, qz, &awx, &awy, &awz);
+  double awx, awy, awz;
+  rotateByQuaternion(ax, ay, az, qw, qx, qy, qz, &awx, &awy, &awz);
 
-      accelVert = awz - zAvg;
+  accelVert_ = awz - zAvg_;
 
 #ifdef SHOW_WORLD_ACCEL
-      if (needComma) {
-        Serial.print(',');
-      }
-      Serial.print("Wx:");
-      printFloat(awx);
-      Serial.print(",Wy:");
-      printFloat(awy);
-      Serial.print(",Wz:");
-      printFloat(awz);
-      needComma = true;
-      needNewline = true;
+  if (needComma) {
+    Serial.print(',');
+  }
+  Serial.print("Wx:");
+  printFloat(awx);
+  Serial.print(",Wy:");
+  printFloat(awy);
+  Serial.print(",Wz:");
+  printFloat(awz);
+  needComma = true;
+  needNewline = true;
 #endif
 
 #ifdef SHOW_VERTICAL_ACCEL
-      if (needComma) {
-        Serial.print(',');
-      }
-      Serial.print("dAz:");
-      printFloat(accelVert);
-      needComma = true;
-      needNewline = true;
+  if (needComma) {
+    Serial.print(',');
+  }
+  Serial.print("dAz:");
+  printFloat(accelVert);
+  needComma = true;
+  needNewline = true;
 #endif
 
 #ifdef SHOW_FIXED_BOUNDS
-      if (needComma) {
-        Serial.print(',');
-      }
-      Serial.print("min:");
-      printFloat(SHOW_FIXED_BOUNDS);
-      Serial.print(",max:");
-      printFloat(-SHOW_FIXED_BOUNDS);
-      needNewline = true;
+  if (needComma) {
+    Serial.print(',');
+  }
+  Serial.print("min:");
+  printFloat(SHOW_FIXED_BOUNDS);
+  Serial.print(",max:");
+  printFloat(-SHOW_FIXED_BOUNDS);
+  needNewline = true;
 #endif
 
-      zAvg = zAvg * f + awz * (1 - f);
+  double dt = ((double)t - tPrev_) * 0.001;
+  double f = exp(K_UPDATE * dt);
+  tPrev_ = t;
 
-      if (needNewline) {
-        Serial.println();
-      }
+  zAvg_ = zAvg_ * f + awz * (1 - f);
 
-      success = true;
-    }
+  if (needNewline) {
+    Serial.println();
   }
-  return success;
+
+  return true;
 }
 
 /*************************************************
- * Initialize IMU, Quaternions, and Kalman Filter *
+ * Initialize motion source and Kalman Filter *
  *************************************************/
-void imu_init() {
-  startupCycleCount = IMU_STARTUP_CYCLES;
+void IMU::init() {
+  startupCycleCount_ = IMU_STARTUP_CYCLES;
 
-  WIRE_PORT.begin();
-  WIRE_PORT.setClock(400000);
-
-  if (DEBUG_IMU) IMU.enableDebugging();  // enable helpful debug messages on Serial
-
-  bool initialized = false;
-  while (!initialized) {
-    IMU.begin(WIRE_PORT, AD0_VAL);
-    SERIAL_PORT.print(F("Initialization of the IMU returned: "));
-    SERIAL_PORT.println(IMU.statusString());
-    if (IMU.status != ICM_20948_Stat_Ok) {
-      SERIAL_PORT.println("Trying again...");
-      delay(500);
-    } else {
-      initialized = true;
-    }
-  }
-
-  bool success = true;  // Use success to show if the DMP configuration was successful
-
-  // Initialize the DMP. initializeDMP is a weak function. You can overwrite it if you want to e.g.
-  // to change the sample rate
-  success &= (IMU.initializeDMP() == ICM_20948_Stat_Ok);
-
-  // Enable the DMP orientation and accelerometer sensors
-  success &= (IMU.enableDMPSensor(INV_ICM20948_SENSOR_ORIENTATION) == ICM_20948_Stat_Ok);
-  success &= (IMU.enableDMPSensor(INV_ICM20948_SENSOR_ACCELEROMETER) == ICM_20948_Stat_Ok);
-
-  // Configuring DMP to output data at multiple ODRs:
-  success &= (IMU.setDMPODRrate(DMP_ODR_Reg_Quat9, 2) == ICM_20948_Stat_Ok);  // Set to the maximum
-  success &= (IMU.setDMPODRrate(DMP_ODR_Reg_Accel, 2) == ICM_20948_Stat_Ok);  // Set to the maximum
-
-  // Enable the FIFO
-  success &= (IMU.enableFIFO() == ICM_20948_Stat_Ok);
-
-  // Enable the DMP
-  success &= (IMU.enableDMP() == ICM_20948_Stat_Ok);
-
-  // Reset DMP
-  success &= (IMU.resetDMP() == ICM_20948_Stat_Ok);
-
-  // Reset FIFO
-  success &= (IMU.resetFIFO() == ICM_20948_Stat_Ok);
-
-  // Check success
-  if (success) {
-    SERIAL_PORT.println(F("DMP enabled!"));
-  } else {
-    SERIAL_PORT.println(F("Enable DMP failed!"));
-  }
+  motionSource_->init();
 
   // setup kalman filter
-  kalmanvert.init(millis() / 1000.0, baro.altF, 0.0);
+  kalmanvert_.init(millis() / 1000.0, baro.altF, 0.0);
 
-  tPrev = millis();
+  tPrev_ = millis();
 }
 
-void imu_update() {
+void IMU::update() {
   /*
   String accelName = "accel,";
   String accelEntry = accelName + String(at);
@@ -263,25 +180,27 @@ void imu_update() {
 
   if (processQuaternion()) {
     // if we're starting up, block accel values until it's stable
-    if (startupCycleCount > 0) {
-      startupCycleCount--;
+    if (startupCycleCount_ > 0) {
+      startupCycleCount_--;
       // submit accel = 0 to kalman filter and return
-      kalmanvert.update(millis() / 1000.0, baro.altF, 0.0f);
+      kalmanvert_.update(millis() / 1000.0, baro.altF, 0.0f);
       return;
     }
 
     // update kalman filter
-    kalmanvert.update(millis() / 1000.0, baro.altF, accelVert * 9.80665f);
+    kalmanvert_.update(millis() / 1000.0, baro.altF, accelVert_ * 9.80665f);
 
     String kalmanName = "kalman,";
-    String kalmanEntryString = kalmanName + String(kalmanvert.getPosition(), 8) + ',' +
-                               String(kalmanvert.getVelocity(), 8) + ',' +
-                               String(kalmanvert.getAcceleration(), 8);
+    String kalmanEntryString = kalmanName + String(kalmanvert_.getPosition(), 8) + ',' +
+                               String(kalmanvert_.getVelocity(), 8) + ',' +
+                               String(kalmanvert_.getAcceleration(), 8);
 
     Telemetry.writeText(kalmanEntryString);
   }
 }
 
-void imu_wake() { startupCycleCount = IMU_STARTUP_CYCLES; }
+void IMU::wake() { startupCycleCount_ = IMU_STARTUP_CYCLES; }
 
-float IMU_getAccel() { return accelTot; }
+float IMU::getAccel() { return accelTot_; }
+
+float IMU::getVelocity() { return (float)kalmanvert_.getVelocity(); }

--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -275,7 +275,7 @@ void log_captureValues() {
   logbook.climb = baro.climbRateFiltered;
   logbook.speed = gps.speed.mps();
   logbook.temperature = tempRH.getTemp();
-  logbook.accel = IMU_getAccel();
+  logbook.accel = imu.getAccel();
 }
 
 void log_checkMinMaxValues() {

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -104,7 +104,7 @@ void power_init_peripherals() {
   Serial.println(" - Finished display");
   baro.init();
   Serial.println(" - Finished Baro");
-  imu_init();
+  imu.init();
   Serial.println(" - Finished IMU");
   tempRH.init();
   Serial.println(" - Finished Temp Humid");
@@ -139,7 +139,7 @@ void power_wake_peripherals() {
   gps.wake();
   Serial.println(" - waking baro and IMU");
   baro.wake();
-  imu_wake();
+  imu.wake();
   Serial.println(" - waking speaker");
   speaker_unMute();
   Serial.println(" - DONE");

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -413,7 +413,7 @@ void taskManager(void) {
     taskman_estimateWind = 0;
   }
   if (taskman_imu) {
-    imu_update();
+    imu.update();
     taskman_imu = 0;
   }
   if (taskman_gps) {

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -152,7 +152,7 @@ void drawUserField(uint8_t x, uint8_t y, uint8_t field, bool selected) {
       u8g2.setCursor(x, y - 14);
       u8g2.setFont(leaf_5h);
       u8g2.print("ACCEL (G FORCE)");
-      display_accel(x + 20, y, IMU_getAccel());
+      display_accel(x + 20, y, imu.getAccel());
       break;
     case static_cast<int>(ThermalPageUserFields::DIST):
       // Distance

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -90,7 +90,7 @@ void thermalPageAdv_draw() {
 
     display_temp(varioBarWidth + 5, userFieldsMid - 1, (int16_t)tempRH.getTemp());
     display_humidity(userSecondColumn + 3, userFieldsMid - 1, (uint8_t)tempRH.getHumidity());
-    display_accel(varioBarWidth + 5, userFieldsBottom - 1, IMU_getAccel());
+    display_accel(varioBarWidth + 5, userFieldsBottom - 1, imu.getAccel());
     display_glide(userSecondColumn + 3, userFieldsBottom - 1, gps.getGlideRatio());
 
     // Footer Info ****************************************************


### PR DESCRIPTION
This PR follows the Barometer example in splitting the hardware portion of the IMU (the code that triggers and observes electrical pulses in order to obtain the motion information available from the hardware IMU device) from the processing of that "raw" data into usable motion information.  The IMU "instrument" performs the latter while the new ICM20948 class performs the former (continuing to use a lower-level ICM_20948_I2C class), and the two are connected by a new IMotionSource interface.  In the future, the hardware portion can be mocked out at the IMotionSource interface level, and telemetry can also be captured at this level.