### PR TITLE
[Fanet] Moved to Rie's Fanet lib

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -52,7 +52,10 @@ lib_deps =
 	https://github.com/scottyob/IgcLogger.git#v0.0.3
 
 	; Fanet manager
-	https://github.com/scottyob/fanet-plus.git#9336a94a9085b8b235385b3a59a5dcb983bda6bd
+	; https://github.com/scottyob/fanet-plus.git#9336a94a9085b8b235385b3a59a5dcb983bda6bd
+
+	; Ries's Fanet Library
+	https://github.com/scottyob/FANET.git#f7c1e2fd4182bcd1271353eb4f50934b18a243ea
 
 	; RadioLib for LoRa / Fanet
 	jgromes/RadioLib@7.1.2

--- a/src/variants/leaf_3_2_2/variant.h
+++ b/src/variants/leaf_3_2_2/variant.h
@@ -18,7 +18,7 @@
 #define BUTTON_PIN_DOWN 5
 
 // This breadboard variant is intended to be used with a LoRa radio
-#define FANET
+#define HAS_FANET
 #define LORA_SX1262
 #define SX1262_NSS 0     // SPI Chip Select Pin
 #define SX1262_DIO1 46   // DIO1 pin

--- a/src/variants/leaf_3_2_5/variant.h
+++ b/src/variants/leaf_3_2_5/variant.h
@@ -4,7 +4,7 @@
 #define LEAF_FIRMWARE_NAME "leaf_3_2_5"
 
 // This breadboard variant is intended to be used with a LoRa radio
-#define FANET
+#define HAS_FANET
 #define LORA_SX1262
 #define SX1262_NSS 46   // SPI Chip Select Pin
 #define SX1262_DIO1 15  // DIO1 pin

--- a/src/vario/comms/fanet_neighbors.h
+++ b/src/vario/comms/fanet_neighbors.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <etl/map.h>
+#include <etl/message_router.h>
+#include <etl/optional.h>
+#include <etl/set.h>
+#include "comms/message_types.h"
+#include "fanet/groundTracking.hpp"
+#include "fanet/neighbourTable.hpp"
+#include "fanet/protocol.hpp"
+#include "instruments/gps.h"
+
+/// @brief A class to handle FANET neighbor statistics in addition to base Fanet neighbor table.
+struct FanetNeighbors : public etl::message_router<FanetNeighbors, FanetPacket> {
+ public:
+  struct Neighbor {
+    FANET::Address address;  // The address of the neighbor
+    uint32_t lastSeen;       // The last time this neighbor was seen
+    float rssi = 0;          // The RSSI of the last packet received from this neighbor
+    float snr = 0;           // The SNR of the last packet received from this neighbor
+    etl::optional<float> distanceKm = etl::nullopt;  // The distance to this neighbor in kilometers
+    etl::optional<FANET::GroundTrackingPayload::TrackingType> groundTrackingMode =
+        etl::nullopt;  // Tracking mode of this neighbor
+  };
+
+  using NeighborMap = etl::map<uint32_t, Neighbor, FANET::Protocol::FANET_MAX_NEIGHBORS>;
+
+ private:
+  NeighborMap neighbors_;
+
+ public:
+  const NeighborMap& get() const { return neighbors_; }
+
+  void updateFromTable(const FANET::NeighbourTable<FANET::Protocol::FANET_MAX_NEIGHBORS>& table) {
+    etl::set<uint32_t, FANET::Protocol::FANET_MAX_NEIGHBORS> seen;
+
+    auto libNeighbors = table.neighborTable();
+
+    for (auto& neighbor : libNeighbors) {
+      seen.insert(neighbor.address.asUint());
+    }
+
+    // Remove neighbors that are not in the given table
+    for (auto it = neighbors_.begin(); it != neighbors_.end();) {
+      if (seen.find(it->first) == seen.end()) {
+        it = neighbors_.erase(it);  // Remove neighbor if not found in the table
+      } else {
+        // Update lastSeen time for neighbors that are still in the table
+        it->second.lastSeen = table.lastSeen(FANET::Address(it->first));
+        ++it;  // Move to the next neighbor
+      }
+    }
+
+    // Insert neighbors in the given table not in the local table
+    for (const auto& neighbor : libNeighbors) {
+      if (neighbors_.find(neighbor.address.asUint()) == neighbors_.end()) {
+        neighbors_[neighbor.address.asUint()] = {neighbor.address, neighbor.lastSeen, 0, 0};
+      }
+    }
+  }
+
+  // Message bus operations.  Receives FanetPacket messages to update location
+  void on_receive(const FanetPacket& msg) {
+    // Only process FANET packets that are in our local neighbor table
+    if (!neighbors_.contains(msg.packet.source().asUint())) {
+      return;
+    }
+
+    auto& neighbor = neighbors_[msg.packet.source().asUint()];
+
+    // Update the RSSI and SNR values for this packet
+    neighbor.rssi = msg.rssi;
+    neighbor.snr = msg.snr;
+
+    // Update location for Tracking and GroundTracking modes
+    if (msg.packet.header().type() == FANET::Header::MessageType::TRACKING) {
+      const auto& trackingPayload = etl::get<FANET::TrackingPayload>(msg.packet.payload().value());
+
+      const auto& longitude = trackingPayload.longitude();
+      const auto& latitude = trackingPayload.latitude();
+
+      neighbor.distanceKm =
+          gps.distanceBetween(gps.location.lat(), gps.location.lng(), latitude, longitude) / 1000;
+      neighbor.groundTrackingMode = etl::nullopt;
+
+    } else if (msg.packet.header().type() == FANET::Header::MessageType::GROUND_TRACKING) {
+      const auto& trackingPayload =
+          etl::get<FANET::GroundTrackingPayload>(msg.packet.payload().value());
+
+      const auto& longitude = trackingPayload.longitude();
+      const auto& latitude = trackingPayload.latitude();
+
+      neighbor.distanceKm =
+          gps.distanceBetween(gps.location.lat(), gps.location.lng(), latitude, longitude) / 1000;
+      neighbor.groundTrackingMode = trackingPayload.groundType();
+    }
+  }
+
+  void on_receive_unknown(const etl::imessage& msg) {}
+};

--- a/src/vario/comms/message_types.h
+++ b/src/vario/comms/message_types.h
@@ -1,7 +1,16 @@
 #pragma once
+/*
+  Message Types
+
+  This file defines all of the message types that can be passed through
+  the ETL Message Bus between modules of the system
+*/
+
 #include "TinyGPSPlus.h"
 #include "etl/message.h"
-#include "fanetPacket.h"
+#include "fanet/packet.hpp"
+
+#define FANET_MAX_FRAME_SIZE 244  // Maximum size of a FANET frame
 
 enum MessageType {
   GPS_UPDATE,
@@ -16,9 +25,10 @@ struct GpsReading : public etl::message<GPS_UPDATE> {
 
 /// @brief A FANET packet received
 struct FanetPacket : public etl::message<FANET_PACKET> {
-  Fanet::Packet packet;
+  FANET::Packet<FANET_MAX_FRAME_SIZE> packet;
   float rssi;
   float snr;
 
-  FanetPacket(Fanet::Packet packet, float rssi, float snr) : packet(packet), rssi(rssi), snr(snr) {}
+  FanetPacket(FANET::Packet<FANET_MAX_FRAME_SIZE> packet, float rssi, float snr)
+      : packet(packet), rssi(rssi), snr(snr) {}
 };

--- a/src/vario/main.cpp
+++ b/src/vario/main.cpp
@@ -27,7 +27,7 @@ void setup() {
   spi_init();
   Serial.println(" - Finished SPI");
 
-#ifdef FANET
+#ifdef HAS_FANET
   // Initialize the Fanet Radio module.  Subscribe them for bus
   // updates
   FanetRadio::getInstance().setup(&bus);
@@ -53,9 +53,6 @@ void setup() {
   // Subscribe modules that need bus updates.
   // This should not exceed the bus router limit.
   bus.subscribe(BLE::get());
-#ifdef FANET
-  bus.subscribe(FanetRadio::getInstance());
-#endif
 
   Serial.println("Leaf Initialized");
 }

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -754,7 +754,7 @@ void display_GPS_icon(uint8_t x, uint8_t y) {
 }
 
 void display_fanet_icon(const uint8_t& x, const uint8_t& y) {
-#ifndef FANET
+#ifndef HAS_FANET
   return;
 #endif
 

--- a/src/vario/ui/display/pages/dialogs/page_menu_about.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_menu_about.cpp
@@ -52,7 +52,7 @@ void PageMenuAbout::draw_extra() {
   u8g2.print("Fanet Address: ");
   u8g2.setCursor(5, y += offset);
   u8g2.setFont(leaf_5x8);
-#ifndef FANET
+#ifndef HAS_FANET
   u8g2.print("N/A");
 #else
   u8g2.print(FanetRadio::getAddress());

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
@@ -36,19 +36,20 @@ void PageFanetGround::show(FanetGroundTrackingMode mode) {
   radio.begin(settings.fanet_region);
   switch (mode) {
     case FanetGroundTrackingMode::WALKING:
-      radio.setTrackingMode(Fanet::GroundTrackingType::Walking);
+      radio.setGroundTrackingMode(FANET::GroundTrackingPayload::TrackingType::WALKING);
       break;
     case FanetGroundTrackingMode::VEHICLE:
-      radio.setTrackingMode(Fanet::GroundTrackingType::Vehicle);
+      radio.setGroundTrackingMode(FANET::GroundTrackingPayload::TrackingType::VEHICLE);
       break;
     case FanetGroundTrackingMode::NEED_RIDE:
-      radio.setTrackingMode(Fanet::GroundTrackingType::Vehicle);
+      radio.setGroundTrackingMode(FANET::GroundTrackingPayload::TrackingType::NEED_A_RIDE);
       break;
     case FanetGroundTrackingMode::LANDED_OK:
-      radio.setTrackingMode(Fanet::GroundTrackingType::LandedWell);
+      radio.setGroundTrackingMode(FANET::GroundTrackingPayload::TrackingType::LANDED_WELL);
       break;
     case FanetGroundTrackingMode::TECH_SUP:
-      radio.setTrackingMode(Fanet::GroundTrackingType::NeedTechnicalSupport);
+      radio.setGroundTrackingMode(
+          FANET::GroundTrackingPayload::TrackingType::NEED_TECHNICAL_SUPPORT);
       break;
   };
 }

--- a/src/vario/ui/display/pages/fanet/page_fanet_neighbors.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_neighbors.cpp
@@ -10,7 +10,7 @@ void PageFanetNeighbors::show() {
 }
 
 void PageFanetNeighbors::draw_extra() {
-  auto neighbors = FanetRadio::getInstance().getNeighborTable();
+  const auto neighbors = FanetRadio::getInstance().getNeighborTable();
 
   constexpr auto x = 3;
   constexpr auto yOffset = 10;
@@ -21,27 +21,20 @@ void PageFanetNeighbors::draw_extra() {
   int i = 0;
   // For each neighbor (up to 2 max).  Render some basic stats
   for (auto it = neighbors.begin(); it != neighbors.end() && i++ < 2; it++) {
-    u8g2.print((String) "Address: " + MacToString(it->second.address));
+    u8g2.print((String) "Address: " + FanetAddressToString(it->second.address));
     u8g2.setCursor(x, y += yOffset);
     u8g2.print((String) "rssi: " + it->second.rssi);
     u8g2.setCursor(x, y += yOffset);
     u8g2.print((String) "snr: " + it->second.snr);
     u8g2.setCursor(x, y += yOffset);
 
-    if (it->second.location.has_value()) {
-      u8g2.print((String) "lat: " + it->second.location.value().latitude);
-      u8g2.setCursor(x, y += yOffset);
-      u8g2.print((String) "lng: " + it->second.location.value().longitude);
+    if (it->second.distanceKm.has_value()) {
+      u8g2.print((String) "Km : " + String(it->second.distanceKm.value(), 2));
       u8g2.setCursor(x, y += yOffset);
     }
 
-    if (it->second.altitude.has_value()) {
-      u8g2.print((String) "altitude: " + it->second.altitude.value());
-      u8g2.setCursor(x, y += yOffset);
-    }
-
-    if (it->second.groundTrackingType.has_value()) {
-      u8g2.print((String) "Gnd State: " + it->second.groundTrackingType.value().c_str());
+    if (it->second.groundTrackingMode.has_value()) {
+      u8g2.print((String) "Gnd State: " + it->second.groundTrackingMode.value().c_str());
       u8g2.setCursor(x, y += yOffset);
     }
 

--- a/src/vario/ui/display/pages/fanet/page_fanet_stats.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_stats.cpp
@@ -20,7 +20,7 @@ void PageFanetStats::draw_extra() {
       etl::pair{(String) "forwarded", String(radioStats.forwarded)},
       etl::pair{(String) "fwdMinRssiDrp", String(radioStats.fwdMinRssiDrp)},
       etl::pair{(String) "fwdNeighborDrp", String(radioStats.fwdNeighborDrp)},
-      etl::pair{(String) "fwdEnqueuedDrp", String(radioStats.fwdEnqueuedDrop)},
+      etl::pair{(String) "fwdDbBoostWeak", String(radioStats.fwdDbBoostWeak)},
       etl::pair{(String) "fwdDbBoostDrop", String(radioStats.fwdDbBoostDrop)},
       etl::pair{(String) "rxFromUsDrp", String(radioStats.rxFromUsDrp)},
       etl::pair{(String) "txAck", String(radioStats.txAck)},

--- a/src/vario/ui/display/pages/menu/page_menu_system.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_system.cpp
@@ -105,7 +105,7 @@ void SystemMenuPage::draw() {
 
         case cursor_system_fanet:
           u8g2.setCursor(setting_choice_x + 8, menu_items_y[i]);
-#ifndef FANET
+#ifndef HAS_FANET
           // If Fanet is not supported, we should show a warning
           u8g2.setFont(leaf_icons);
           u8g2.print((char)0x22);
@@ -173,7 +173,7 @@ void SystemMenuPage::setting_change(Button dir, ButtonState state, uint8_t count
       break;
     case cursor_system_fanet:
       if (state != RELEASED) break;
-#ifndef FANET
+#ifndef HAS_FANET
       PageMessage::show("Fanet",
                         "UNSUPPORTED\n"
                         "\n"


### PR DESCRIPTION
Moved FANET backend library to rvt/FANET

Speaking with Ries in Discord, he has prepared a bit more of a nicer implementation of FANET, which squishes a couple of bugs, and, would be better maintained going forward.  This change moves away from the scottyob/fanet library to Ries's.

NOTES:   Frees up memory and has a higher low water mark of free RAM.  This change also greatly improves backend RAM usage.

## Memory Improvements
```
Before:
=== Memory Stats ===
Total Heap: 274 KB
Free Heap: 52 KB
Used Heap: 221 KB
Largest Free Block: 30 KB
Minimum Free Heap Ever: 51 KB
Main Task Stack High Water Mark: 12 KB
Free PSRAM: 0 bytes
Largest Free PSRAM Block: 0 bytes
====================


After:
=== Memory Stats ===
Total Heap: 272 KB
Free Heap: 61 KB
Used Heap: 211 KB
Largest Free Block: 30 KB
Minimum Free Heap Ever: 61 KB
Main Task Stack High Water Mark: 12 KB
Free PSRAM: 0 bytes
Largest Free PSRAM Block: 0 bytes
====================
```

* Small behavior change in neighbor table, shows distance now.


## Demo of flight running:
![image](https://github.com/user-attachments/assets/8840618e-bf9f-4014-8df8-9ef1cd4a36b7)

## Testing
Tested with [standard test procedures](https://github.com/DangerMonkeys/leaf/blob/main/docs/dev-references/testing/test_procedure.md)

