### PR TITLE
Fix charging bug on <3.2.6 hardware

### DIFF
--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -85,18 +85,13 @@ void power_init() {
   if (!POWER_CHARGE_I2_IOEX) pinMode(POWER_CHARGE_I2, OUTPUT);
   if (!POWER_CHARGE_GOOD_IOEX) pinMode(POWER_CHARGE_GOOD, INPUT_PULLUP);
   // POWER_GOOD is only available on v3.2.6+ on IOexpander, so not set here
-  Serial.println("set Charge i pins");
+
+  // set default current limit for charger input
+  power_setInputCurrent(i500mA);
 
 #ifdef LED_PIN
   pinMode(LED_PIN, OUTPUT);  // LED power status indicator
-  Serial.println("set LED pin");
 #endif
-
-  // power_setInputCurrent(i500mA);  // set default current
-
-  // populate battery % and charging state
-  // power_readBatteryState();
-  Serial.println("read battery state");
 }
 
 void power_init_peripherals() {


### PR DESCRIPTION
Fixed bug that prevents adequate input current on 3.2.2-3.2.5 versions of hardware.  Bug was introduced when firmware support for 3.2.6+ was created.

Tested with 6 leaf units, 3 with the fix, 3 without.  Fixed units showed expected charging behavior;  un-fixed units showed no increase in battery capacity over ~30 minutes.

<img width="1999" height="1505" alt="image" src="https://github.com/user-attachments/assets/d5a5fa8b-e654-493a-87b7-f20f71922ba5" />
