### PR TITLE
Fix startup delay waiting for Serial

### DIFF
--- a/src/vario/main.cpp
+++ b/src/vario/main.cpp
@@ -22,9 +22,11 @@ MessageBus<10> bus;
 void setup() {
   // Start USB Serial Debugging Port
   Serial.begin(115200);
-  delay(2000);
+  uint8_t counter = 0;
+  while (!Serial && counter < 10) {
+    delay(5 * counter++);
+  }
   Serial.println("Starting Setup");
-  delay(2000);
 
   // Initialize the shared bus
   spi_init();

--- a/src/vario/main.cpp
+++ b/src/vario/main.cpp
@@ -22,10 +22,6 @@ MessageBus<10> bus;
 void setup() {
   // Start USB Serial Debugging Port
   Serial.begin(115200);
-  uint8_t counter = 0;
-  while (!Serial && counter < 10) {
-    delay(5 * counter++);
-  }
   Serial.println("Starting Setup");
 
   // Initialize the shared bus


### PR DESCRIPTION
removed two delay(2000) statements waiting for serial to start in main.cpp
instead replaced with a while() loop checking for Serial to be ready, with a max timeout of approx 250ms.  (Thanks Ries!)

Tested boot and it's now back to near-instant initialization and "turn on" sound (except of course for the intentional delay of waiting for the button to be held down long enough to avoid accidental turn-ons)