### PR TITLE
Move SDcard functions into class

### DIFF
--- a/src/vario/comms/debug_webserver.cpp
+++ b/src/vario/comms/debug_webserver.cpp
@@ -162,7 +162,7 @@ void webserver_setup() {
 
   server.on("/mass_storage", HTTP_GET, []() {
     // Serial.end();
-    SDCard_SetupMassStorage();
+    sdcard.setupMassStorage();
     server.send(200, "text/html", "OK!");
   });
 

--- a/src/vario/logbook/flight.cpp
+++ b/src/vario/logbook/flight.cpp
@@ -9,7 +9,7 @@
 
 bool Flight::startFlight() {
   // Short circuit if the card is not mounted or reading properly
-  if (!SDcard_present()) return false;
+  if (!sdcard.isMounted()) return false;
   Serial.printf("Sectors: %d\n", SD_MMC.numSectors());
   File trackLogsDir = SD_MMC.open(this->desiredFilePath());
 

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -115,7 +115,7 @@ void power_init_peripherals() {
   }
 
   // then initialize the rest of the devices
-  SDcard_init();
+  sdcard.init();
   Serial.println(" - Finished SDcard");
   gps.init();
   Serial.println(" - Finished GPS");
@@ -155,7 +155,7 @@ void power_sleep_peripherals() {
 
 void power_wake_peripherals() {
   Serial.println("wake_peripherals: ");
-  SDcard_mount();  // re-initialize SD card in case card state was changed while in charging/USB
+  sdcard.mount();  // re-initialize SD card in case card state was changed while in charging/USB
                    // mode
   Serial.println(" - waking GPS");
   gps.wake();

--- a/src/vario/storage/sd_card.cpp
+++ b/src/vario/storage/sd_card.cpp
@@ -1,198 +1,33 @@
+#include "storage/sd_card.h"
+
 #include <Arduino.h>
 #include <FS.h>
 #include <SD_MMC.h>
-// #include <PinChangeInterrupt.h>
+#include "FirmwareMSC.h"
+#include "USB.h"
+#include "USBMSC.h"
 #include "hardware/configuration.h"
 #include "hardware/io_pins.h"
 #include "instruments/gps.h"
 #include "logging/log.h"
-#include "storage/sd_card.h"
 
 #define DEBUG_SDCARD true
 
-// save state of SD card present (used to compare against the SD_DETECT
-// pin so we can tell if a card has been inserted or removed)
-bool SDcardPresentSavedState = false;
+// Pinout for Leaf V3.2.0
+// These should be default pins for ESP32S3, so technically no need to use these and set them.  But
+// here for completeness
+#define SDIO_D2 33
+#define SDIO_D3 34
+#define SDIO_CMD 35
+#define SDIO_CLK 36
+#define SDIO_D0 37
+#define SDIO_D1 38
 
-#include "FirmwareMSC.h"
-#include "USB.h"
-#include "USBMSC.h"
+SDCard sdcard;
 
-FirmwareMSC MSC_FirmwareUpdate;
-USBMSC MSC;
+bool SDCard::isCardPresent() { return !ioexDigitalRead(SD_DETECT_IOEX, SD_DETECT); }
 
-void listDir(fs::FS& fs, const char* dirname, uint8_t levels) {
-  Serial.printf("Listing directory: %s\n", dirname);
-
-  File root = fs.open(dirname);
-  if (!root) {
-    Serial.println("Failed to open directory");
-    return;
-  }
-  if (!root.isDirectory()) {
-    Serial.println("Not a directory");
-    return;
-  }
-
-  File file = root.openNextFile();
-  while (file) {
-    if (file.isDirectory()) {
-      Serial.print("  DIR : ");
-      Serial.println(file.name());
-      if (levels) {
-        listDir(fs, file.path(), levels - 1);
-      }
-    } else {
-      Serial.print("  FILE: ");
-      Serial.print(file.name());
-      Serial.print("  SIZE: ");
-      Serial.println(file.size());
-    }
-    file = root.openNextFile();
-  }
-}
-
-void createDir(fs::FS& fs, const char* path) {
-  Serial.printf("Creating Dir: %s\n", path);
-  if (fs.mkdir(path)) {
-    Serial.println("Dir created");
-  } else {
-    Serial.println("mkdir failed");
-  }
-}
-
-void removeDir(fs::FS& fs, const char* path) {
-  Serial.printf("Removing Dir: %s\n", path);
-  if (fs.rmdir(path)) {
-    Serial.println("Dir removed");
-  } else {
-    Serial.println("rmdir failed");
-  }
-}
-
-void readFile(fs::FS& fs, const char* path) {
-  Serial.printf("Reading file: %s\n", path);
-
-  File file = fs.open(path);
-  if (!file) {
-    Serial.println("Failed to open file for reading");
-    return;
-  }
-
-  Serial.print("Read from file: ");
-  while (file.available()) {
-    Serial.write(file.read());
-  }
-}
-
-void writeFile(fs::FS& fs, const char* path, const char* message) {
-  Serial.printf("Writing file: %s\n", path);
-
-  File file = fs.open(path, FILE_WRITE);
-  if (!file) {
-    Serial.println("Failed to open file for writing");
-    return;
-  }
-  if (file.print(message)) {
-    Serial.println("File written");
-  } else {
-    Serial.println("Write failed");
-  }
-}
-
-void appendFile(fs::FS& fs, const char* path, const char* message) {
-  uint32_t append_time = micros();
-
-  // Serial.print("startAppend:   ");
-  // Serial.println(append_time);
-
-  // Serial.printf("Appending to file: %s\n", path);
-
-  // uint32_t time = micros();
-
-  File file = fs.open(path, FILE_APPEND);
-
-  // time = micros()-time;
-
-  // Serial.print("FileOpen: ");
-  // Serial.println(time);
-
-  if (!file) {
-    Serial.println("Failed to open file for appending");
-    return;
-  }
-}
-
-void appendOpenFile(File& file, const char* message) {
-  if (file.print(message)) {
-    // Serial.println("Message appended");
-  } else {
-    Serial.println("Append failed");
-  }
-}
-
-void renameFile(fs::FS& fs, const char* path1, const char* path2) {
-  Serial.printf("Renaming file %s to %s\n", path1, path2);
-  if (fs.rename(path1, path2)) {
-    Serial.println("File renamed");
-  } else {
-    Serial.println("Rename failed");
-  }
-}
-
-void deleteFile(fs::FS& fs, const char* path) {
-  Serial.printf("Deleting file: %s\n", path);
-  if (fs.remove(path)) {
-    Serial.println("File deleted");
-  } else {
-    Serial.println("Delete failed");
-  }
-}
-
-void testFileIO(fs::FS& fs, const char* path) {
-  File file = fs.open(path);
-  static uint8_t buf[512];
-  size_t len = 0;
-  uint32_t start = millis();
-  uint32_t end = start;
-  if (file) {
-    len = file.size();
-    size_t flen = len;
-    start = millis();
-    while (len) {
-      size_t toRead = len;
-      if (toRead > 512) {
-        toRead = 512;
-      }
-      file.read(buf, toRead);
-      len -= toRead;
-    }
-    end = millis() - start;
-    Serial.printf("%u bytes read for %u ms\n", flen, end);
-    file.close();
-  } else {
-    Serial.println("Failed to open file for reading");
-  }
-
-  file = fs.open(path, FILE_WRITE);
-  if (!file) {
-    Serial.println("Failed to open file for writing");
-    return;
-  }
-
-  size_t i;
-  start = millis();
-  for (i = 0; i < 2048; i++) {
-    file.write(buf, 512);
-  }
-  end = millis() - start;
-  Serial.printf("%u bytes written for %u ms\n", 2048 * 512, end);
-  file.close();
-}
-
-bool SDcard_checkIfPresent() { return !ioexDigitalRead(SD_DETECT_IOEX, SD_DETECT); }
-
-void SDcard_init(void) {
+void SDCard::init(void) {
   // Shouldn't need to call set pins since we're using the default pins
   // TODO: try removing this setPins call
   if (!SD_MMC.setPins(SDIO_CLK, SDIO_CMD, SDIO_D0, SDIO_D1, SDIO_D2, SDIO_D3)) {
@@ -204,76 +39,81 @@ void SDcard_init(void) {
   if (!SD_DETECT_IOEX) pinMode(SD_DETECT, INPUT_PULLUP);
 
   // If SDcard present, mount and save state so we can track changes
-  if (SDcard_checkIfPresent()) {
-    SDcardPresentSavedState = true;
-    SDcard_mount();
+  if (isCardPresent()) {
+    mounted_ = true;
+    sdcard.mount();
   }
 }
 
-void SDcard_update() {
+void SDCard::update() {
+  bool cardPresentNow = isCardPresent();
   // if we have a card when we didn't before...
-  if (SDcard_checkIfPresent() && !SDcardPresentSavedState) {
+  if (cardPresentNow && !mounted_) {
     // then mount it!
-    if (SDcard_mount()) {
-      SDcardPresentSavedState = true;  // save that we have a successfully mounted card
+    if (sdcard.mount()) {
+      mounted_ = true;  // save that we have a successfully mounted card
+    } else {
+      // TODO: Indicate the failure to mount to the user in some way
+      Serial.println("WARNING: SD card is present but failed to mount");
     }
 
     // or if we don't have a card when we DID before, "unmount"
-  } else if (!SDcard_checkIfPresent() && SDcardPresentSavedState) {
+  } else if (!cardPresentNow && mounted_) {
     SD_MMC.end();
-    SDcardPresentSavedState = false;  // save that we have a successfully unmounted card
+    mounted_ = false;  // save that we have a successfully unmounted card
   }
 }
 
-static int32_t onRead(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
-  // Check bufSize is a multiple of block size
-  if (bufsize % 512) {
-    return -1;
-  }
-
-  auto bufferOffset = 0;
-  for (int sector = lba; sector < lba + bufsize / 512; sector++) {
-    if (!SD_MMC.readRAW((uint8_t*)buffer + bufferOffset, sector)) {
+namespace {
+  int32_t onRead(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
+    // Check bufSize is a multiple of block size
+    if (bufsize % 512) {
       return -1;
     }
-    bufferOffset += 512;
+
+    auto bufferOffset = 0;
+    for (int sector = lba; sector < lba + bufsize / 512; sector++) {
+      if (!SD_MMC.readRAW((uint8_t*)buffer + bufferOffset, sector)) {
+        return -1;
+      }
+      bufferOffset += 512;
+    }
+
+    return bufsize;
   }
 
-  return bufsize;
-}
-
-static int32_t onWrite(uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
-  // Check bufSize is a multiple of block size
-  if (bufsize % 512) {
-    return -1;
-  }
-
-  auto bufferOffset = 0;
-  for (int sector = lba; sector < lba + bufsize / 512; sector++) {
-    if (!SD_MMC.writeRAW(buffer + bufferOffset, sector)) {
+  int32_t onWrite(uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
+    // Check bufSize is a multiple of block size
+    if (bufsize % 512) {
       return -1;
     }
-    bufferOffset += 512;
+
+    auto bufferOffset = 0;
+    for (int sector = lba; sector < lba + bufsize / 512; sector++) {
+      if (!SD_MMC.writeRAW(buffer + bufferOffset, sector)) {
+        return -1;
+      }
+      bufferOffset += 512;
+    }
+
+    return bufsize;
   }
+}  // namespace
 
-  return bufsize;
-}
-
-bool SDCard_SetupMassStorage() {
-  // Serial.setDebugOutput(true);
-  MSC.vendorID("Leaf");
-  MSC.productID("Leaf_Vario");
-  MSC.productRevision("1.0");
-  MSC.onRead(onRead);
-  MSC.onWrite(onWrite);
-  MSC.isWritable(true);
-  MSC.mediaPresent(true);
-  MSC.begin(SD_MMC.numSectors(), 512);
-  MSC_FirmwareUpdate.begin();
+bool SDCard::setupMassStorage() {
+  msc_.vendorID("Leaf");
+  msc_.productID("Leaf_Vario");
+  msc_.productRevision("1.0");
+  msc_.onRead(onRead);
+  msc_.onWrite(onWrite);
+  msc_.isWritable(true);
+  msc_.mediaPresent(true);
+  msc_.begin(SD_MMC.numSectors(), 512);
+  firmwareMSC_.begin();
   return USB.begin();
 }
 
-bool SDcard_mount() {
+bool SDCard::mount() {
   bool success = false;
 
   if (!SD_MMC.begin()) {
@@ -284,7 +124,7 @@ bool SDcard_mount() {
     success = true;
 
 #ifndef DISABLE_MASS_STORAGE
-    if (SDCard_SetupMassStorage()) {
+    if (sdcard.setupMassStorage()) {
       if (DEBUG_SDCARD) Serial.println("Mass Storage Success");
     } else {
       if (DEBUG_SDCARD) Serial.println("Mass Storage Failed");
@@ -294,5 +134,3 @@ bool SDcard_mount() {
 
   return success;
 }
-
-bool SDcard_present() { return SDcardPresentSavedState; }

--- a/src/vario/storage/sd_card.h
+++ b/src/vario/storage/sd_card.h
@@ -1,46 +1,27 @@
-#ifndef SDcard_h
-#define SDcard_h
+#pragma once
 
-#include <Arduino.h>
-#include <FS.h>
-#include <SD_MMC.h>
+#include "FirmwareMSC.h"
+#include "USBMSC.h"
 
-// Pinout for Leaf V3.2.0
-// These should be default pins for ESP32S3, so technically no need to use these and set them.  But
-// here for completeness
-#define SDIO_D2 33
-#define SDIO_D3 34
-#define SDIO_CMD 35
-#define SDIO_CLK 36
-#define SDIO_D0 37
-#define SDIO_D1 38
+class SDCard {
+ public:
+  void init();
+  void update();
 
-void listDir(fs::FS& fs, const char* dirname, uint8_t levels);
-void createDir(fs::FS& fs, const char* path);
-void removeDir(fs::FS& fs, const char* path);
-void readFile(fs::FS& fs, const char* path);
-void writeFile(fs::FS& fs, const char* path, const char* message);
-void appendFile(fs::FS& fs, const char* path, const char* message);
-void renameFile(fs::FS& fs, const char* path1, const char* path2);
-void deleteFile(fs::FS& fs, const char* path);
-void testFileIO(fs::FS& fs, const char* path);
+  bool mount();
+  bool isMounted() { return mounted_; }
 
-void SDcard_init(void);
-void SDcard_update(void);
+  bool setupMassStorage();
 
-bool SDcard_mount(void);
-bool SDcard_present(void);
+ private:
+  static bool isCardPresent();
 
-bool SDcard_createTrackFile(String filename);
-void SDcard_writeLogData(String coordinates);
-void appendOpenFile(File& file, const char* message);
-void SDcard_writeLogHeader(void);
-void SDcard_writeLogFooter(String trackName, String trackDescription);
+  // Whether the SD card is currently mounted (used to compare against the SD_DETECT
+  // pin so we can tell if a card has been inserted or removed)
+  bool mounted_ = false;
 
-bool SDcard_createDataFile(String filename);
-void SDcard_writeData(String data);
-void SDcard_closeDataFile(void);
+  FirmwareMSC firmwareMSC_;
+  USBMSC msc_;
+};
 
-bool SDCard_SetupMassStorage(void);
-
-#endif
+extern SDCard sdcard;

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -217,7 +217,7 @@ void main_CHARGE_loop() {
     display_update();  // update display based on battery charge state etc
 
     // Check SD Card State and remount if card was inserted
-    SDcard_update();
+    sdcard.update();
 
     // update battery level and charge state
     power_readBatteryState();
@@ -438,7 +438,7 @@ void taskManager(void) {
     taskman_tempRH = 0;
   }
   if (taskman_SDCard) {
-    SDcard_update();
+    sdcard.update();
     taskman_SDCard = 0;
   }
 #ifdef MEMORY_PROFILING

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -292,10 +292,10 @@ void display_page_charging() {
     u8g2.print("v");
     u8g2.print(FIRMWARE_VERSION);
 
-    // SD Card Present
+    // SD Card Mounted
     u8g2.setCursor(12, 191);
     u8g2.setFont(leaf_icons);
-    if (!SDcard_present()) {
+    if (!sdcard.isMounted()) {
       u8g2.print((char)61);
       u8g2.setFont(leaf_6x12);
       u8g2.print(" NO SD!");

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -1041,9 +1041,9 @@ void display_headerAndFooter(bool timerSelected, bool showTurnArrows) {
   // battery
   display_battIcon(0, 192, true);
 
-  // SD Card Present
+  // SD Card Mounted
   char SDicon = 60;
-  if (!SDcard_present()) SDicon = 61;
+  if (!sdcard.isMounted()) SDicon = 61;
   u8g2.setCursor(10, 192);
   u8g2.setFont(leaf_icons);
   u8g2.print((char)SDicon);


### PR DESCRIPTION
This PR moves SD card routines into an SDCard class which encapsulates functionality and state.

A number of unused functions are removed as they only performed basic operations wrapped in Serial messages (not something we would want to use in the future).

The language around the card being "present" and "mounted" is clarified.

Tested in leaf_3_2_7_release environment on 3.2.7+radio hardware using the [standard test procedure](https://github.com/DangerMonkeys/leaf/blob/main/docs/dev-references/testing/test_procedure.md) plus confirming the firmware + general storage drives mount correctly and a flight log is written to the general storage drive (readable on PC when connected via USB).