### PR TITLE
Class-ify display

### DIFF
--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -62,7 +62,7 @@ void power_bootUp() {
 
     power.onState = POWER_ON;
 
-    display_showOnSplash();  // show the splash screen if user turned us on
+    display.showOnSplash();  // show the splash screen if user turned us on
 
   } else {
     // if not center button, then USB power turned us on, go into charge mode
@@ -122,7 +122,7 @@ void power_init_peripherals() {
   Serial.println(" - Finished GPS");
   wire_init();
   Serial.println(" - Finished I2C Wire");
-  display_init();
+  display.init();
   Serial.println(" - Finished display");
   baro.init();
   Serial.println(" - Finished Baro");
@@ -178,7 +178,7 @@ void power_switchToOnState() {
 void power_shutdown() {
   Serial.println("power_shutdown");
 
-  display_clear();
+  display.clear();
   display_off_splash();
   baro.sleep();  // stop getting climbrate updates so we don't hear vario beeps while shutting down
 
@@ -204,7 +204,7 @@ void power_shutdown() {
 
   // finally, turn off devices
   power_sleep_peripherals();
-  display_clear();
+  display.clear();
   delay(100);
   power_latch_off();  // turn off 3.3V regulator (if we're plugged into USB, we'll stay on)
   delay(100);

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -213,8 +213,8 @@ void main_CHARGE_loop() {
     */
 
     // Display Charging Page
-    display_setPage(page_charging);
-    display_update();  // update display based on battery charge state etc
+    display.setPage(page_charging);
+    display.update();  // update display based on battery charge state etc
 
     // Check SD Card State and remount if card was inserted
     sdcard.update();
@@ -430,7 +430,7 @@ void taskManager(void) {
     taskman_log = 0;
   }
   if (taskman_display) {
-    display_update();
+    display.update();
     taskman_display = 0;
   }
   if (taskman_tempRH) {

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -213,7 +213,7 @@ void main_CHARGE_loop() {
     */
 
     // Display Charging Page
-    display.setPage(page_charging);
+    display.setPage(MainPage::Charging);
     display.update();  // update display based on battery charge state etc
 
     // Check SD Card State and remount if card was inserted

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -31,6 +31,13 @@
 
 Display display;
 
+#define LCD_BACKLIGHT 21  // can be used for backlight if desired (also broken out to header)
+#define LCD_RS 17         // 16 on old V3.2.0
+#define LCD_RESET 18      // 17 on old V3.2.0
+
+void GLCD_inst(byte data);
+void GLCD_data(byte data);
+
 #ifndef WO256X128  // if not old hardare, use the latest:
 U8G2_ST75256_JLX19296_F_4W_HW_SPI u8g2(U8G2_R1,
                                        /* cs=*/SPI_SS_LCD,
@@ -123,12 +130,7 @@ void Display::setPage(uint8_t targetPage) {
   if (displayPage_ != tempPage) displayPagePrior_ = tempPage;
 }
 
-uint8_t Display::getPage() { return displayPage_; }
-
 void Display::showOnSplash() { showSplashScreenFrames_ = 3; }
-
-bool Display::displayingWarning() { return showWarning_; }
-void Display::dismissWarning() { showWarning_ = false; }
 
 //*********************************************************************
 // MAIN DISPLAY UPDATE FUNCTION

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -65,7 +65,7 @@ void Display::init(void) {
     Serial.println("u8g2 done. ");
   }
 
-  display.setContrast(settings.disp_contrast);
+  setContrast(settings.disp_contrast);
   Serial.print("u8g2 set contrast. ");
 }
 
@@ -135,7 +135,7 @@ void Display::update() {
   SpiLockGuard spiLock;  // Take out an SPI lock for the rending of the page
 
   if (displayPage_ == MainPage::Charging) {
-    display.showPageCharging();
+    showPageCharging();
     return;
   }
   if (showSplashScreenFrames_) {
@@ -148,7 +148,7 @@ void Display::update() {
     warningPage_draw();
     return;
   } else {
-    display.dismissWarning();
+    dismissWarning();
   }
 
   auto modalPage = mainMenuPage.get_modal_page();

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -81,39 +81,33 @@ void Display::setContrast(uint8_t contrast) {
 }
 
 void Display::turnPage(uint8_t action) {
-  uint8_t tempPage = displayPage_;
+  MainPage tempPage = displayPage_;
 
   switch (action) {
     case page_home:
-      displayPage_ = page_thermal;
+      displayPage_ = MainPage::Thermal;
       break;
 
     case page_next:
       displayPage_++;
 
       // skip past any pages not enabled for display
-      if (displayPage_ == page_thermal && !settings.disp_showThmPage) displayPage_++;
-      if (displayPage_ == page_thermalAdv && !settings.disp_showThmAdvPage) displayPage_++;
-      if (displayPage_ == page_nav && !settings.disp_showNavPage) displayPage_++;
+      if (displayPage_ == MainPage::Thermal && !settings.disp_showThmPage) displayPage_++;
+      if (displayPage_ == MainPage::ThermalAdv && !settings.disp_showThmAdvPage) displayPage_++;
+      if (displayPage_ == MainPage::Nav && !settings.disp_showNavPage) displayPage_++;
 
-      if (displayPage_ == page_last)
-        displayPage_ =
-            0;  // bound check if we fall off the right side, wrap around to the right side
       break;
 
     case page_prev:
       displayPage_--;
 
       // skip past any pages not enabled for display
-      if (displayPage_ == page_nav && !settings.disp_showNavPage) displayPage_--;
-      if (displayPage_ == page_thermalAdv && !settings.disp_showThmAdvPage) displayPage_--;
-      if (displayPage_ == page_thermal && !settings.disp_showThmPage) displayPage_--;
-      if (displayPage_ == page_debug && !settings.disp_showDebugPage)
+      if (displayPage_ == MainPage::Nav && !settings.disp_showNavPage) displayPage_--;
+      if (displayPage_ == MainPage::ThermalAdv && !settings.disp_showThmAdvPage) displayPage_--;
+      if (displayPage_ == MainPage::Thermal && !settings.disp_showThmPage) displayPage_--;
+      if (displayPage_ == MainPage::Debug && !settings.disp_showDebugPage)
         displayPage_ = tempPage;  // go back to the page we were on if we can't go further left
 
-      if (displayPage_ < 0)
-        displayPage_ = page_last - 1;  // bound check if we fall off the left side -- wrap around to
-                                       // the last page (usually the menu page)
       break;
 
     case page_back:
@@ -123,8 +117,8 @@ void Display::turnPage(uint8_t action) {
   if (displayPage_ != tempPage) displayPagePrior_ = tempPage;
 }
 
-void Display::setPage(uint8_t targetPage) {
-  uint8_t tempPage = displayPage_;
+void Display::setPage(MainPage targetPage) {
+  MainPage tempPage = displayPage_;
   displayPage_ = targetPage;
 
   if (displayPage_ != tempPage) displayPagePrior_ = tempPage;
@@ -140,7 +134,7 @@ void Display::showOnSplash() { showSplashScreenFrames_ = 3; }
 void Display::update() {
   SpiLockGuard spiLock;  // Take out an SPI lock for the rending of the page
 
-  if (displayPage_ == page_charging) {
+  if (displayPage_ == MainPage::Charging) {
     display.showPageCharging();
     return;
   }
@@ -164,19 +158,19 @@ void Display::update() {
   }
 
   switch (displayPage_) {
-    case page_thermal:
+    case MainPage::Thermal:
       thermalPage_draw();
       break;
-    case page_thermalAdv:
+    case MainPage::ThermalAdv:
       thermalPageAdv_draw();
       break;
-    case page_debug:
+    case MainPage::Debug:
       showPageDebug();
       break;
-    case page_nav:
+    case MainPage::Nav:
       navigatePage_draw();
       break;
-    case page_menu:
+    case MainPage::Menu:
       mainMenuPage.draw();
       break;
   }

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -80,15 +80,15 @@ void Display::setContrast(uint8_t contrast) {
 #endif
 }
 
-void Display::turnPage(uint8_t action) {
+void Display::turnPage(PageAction action) {
   MainPage tempPage = displayPage_;
 
   switch (action) {
-    case page_home:
+    case PageAction::Home:
       displayPage_ = MainPage::Thermal;
       break;
 
-    case page_next:
+    case PageAction::Next:
       displayPage_++;
 
       // skip past any pages not enabled for display
@@ -98,7 +98,7 @@ void Display::turnPage(uint8_t action) {
 
       break;
 
-    case page_prev:
+    case PageAction::Prev:
       displayPage_--;
 
       // skip past any pages not enabled for display
@@ -110,7 +110,7 @@ void Display::turnPage(uint8_t action) {
 
       break;
 
-    case page_back:
+    case PageAction::Back:
       displayPage_ = displayPagePrior_;
   }
 

--- a/src/vario/ui/display/display.h
+++ b/src/vario/ui/display/display.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <U8g2lib.h>
+
 #include "hardware/configuration.h"
+#include "utils/wrapping_enum.h"
 
 // Display settings loaded from configuration / variants
 #ifndef WO256X128                               // if not old hardare, use the latest:
@@ -19,15 +21,15 @@ enum display_page_actions {
              // page back to previous page)
 };
 
-enum display_main_pages {
-  page_debug,
-  page_thermal,
-  page_thermalAdv,
-  page_nav,
-  page_menu,
-  page_last,
-  page_charging
+enum class MainPage : uint8_t {
+  Debug = 0,
+  Thermal = 1,
+  ThermalAdv = 2,
+  Nav = 3,
+  Menu = 4,
+  Charging = 5
 };
+DEFINE_WRAPPING_BOUNDS(MainPage, MainPage::Debug, MainPage::Menu);
 
 class Display {
  public:
@@ -37,8 +39,8 @@ class Display {
   void setContrast(uint8_t contrast);
 
   void turnPage(uint8_t action);
-  void setPage(uint8_t targetPage);
-  uint8_t getPage() { return displayPage_; }
+  void setPage(MainPage targetPage);
+  MainPage getPage() { return displayPage_; }
 
   void showPageDebug();
   void showPageCharging();
@@ -48,11 +50,11 @@ class Display {
   void dismissWarning() { showWarning_ = false; }
 
  private:
-  int8_t displayPage_ = page_thermal;
+  MainPage displayPage_ = MainPage::Thermal;
 
   // track the page we used to be on, so we can "go back" if needed (like cancelling out of a menu
   // heirarchy)
-  uint8_t displayPagePrior_ = page_thermal;
+  MainPage displayPagePrior_ = MainPage::Thermal;
 
   uint8_t showSplashScreenFrames_ = 0;
 

--- a/src/vario/ui/display/display.h
+++ b/src/vario/ui/display/display.h
@@ -12,13 +12,12 @@ extern U8G2_ST75256_JLX19296_F_4W_HW_SPI u8g2;  // Leaf 3.2.3+  Alice Green HW
 extern U8G2_ST75256_WO256X128_F_4W_HW_SPI u8g2;  // Leaf 3.2.2 June Hung
 #endif
 
-// keep track of pages
-enum display_page_actions {
-  page_home,  // go to home screen (probably thermal page)
-  page_prev,  // go to page -1
-  page_next,  // go to page +1
-  page_back  // go to page we were just on before (i.e. step back in a menu tree, or cancel a dialog
-             // page back to previous page)
+enum class PageAction : uint8_t {
+  Home,  // go to home screen (probably thermal page)
+  Prev,  // go to page -1
+  Next,  // go to page +1
+  Back   // go to page we were just on before (i.e. step back in a menu tree, or cancel a dialog
+         // page back to previous page)
 };
 
 enum class MainPage : uint8_t {
@@ -38,7 +37,7 @@ class Display {
   void clear();
   void setContrast(uint8_t contrast);
 
-  void turnPage(uint8_t action);
+  void turnPage(PageAction action);
   void setPage(MainPage targetPage);
   MainPage getPage() { return displayPage_; }
 

--- a/src/vario/ui/display/display.h
+++ b/src/vario/ui/display/display.h
@@ -54,6 +54,17 @@ class Display {
 
   bool displayingWarning();
   void dismissWarning();
+
+ private:
+  int8_t displayPage_ = page_thermal;
+
+  // track the page we used to be on, so we can "go back" if needed (like cancelling out of a menu
+  // heirarchy)
+  uint8_t displayPagePrior_ = page_thermal;
+
+  uint8_t showSplashScreenFrames_ = 0;
+
+  bool showWarning_ = true;
 };
 
 extern Display display;

--- a/src/vario/ui/display/display.h
+++ b/src/vario/ui/display/display.h
@@ -1,5 +1,4 @@
-#ifndef display_h
-#define display_h
+#pragma once
 
 #include <U8g2lib.h>
 #include "hardware/configuration.h"
@@ -38,20 +37,23 @@ enum display_main_pages {
   page_charging
 };
 
-void display_turnPage(uint8_t action);
-void display_setPage(uint8_t targetPage);
-uint8_t display_getPage(void);
+class Display {
+ public:
+  void init();
+  void update();
+  void clear();
+  void setContrast(uint8_t contrast);
 
-void display_init(void);
-void display_update(void);
-void display_clear(void);
-void display_setContrast(uint8_t contrast);
+  void turnPage(uint8_t action);
+  void setPage(uint8_t targetPage);
+  uint8_t getPage();
 
-void display_page_debug(void);
-void display_page_charging(void);
+  void showPageDebug();
+  void showPageCharging();
+  void showOnSplash();
 
-void display_showOnSplash(void);
-bool displayingWarning(void);
-void displayDismissWarning(void);
+  bool displayingWarning();
+  void dismissWarning();
+};
 
-#endif
+extern Display display;

--- a/src/vario/ui/display/display.h
+++ b/src/vario/ui/display/display.h
@@ -10,14 +10,6 @@ extern U8G2_ST75256_JLX19296_F_4W_HW_SPI u8g2;  // Leaf 3.2.3+  Alice Green HW
 extern U8G2_ST75256_WO256X128_F_4W_HW_SPI u8g2;  // Leaf 3.2.2 June Hung
 #endif
 
-#define LCD_BACKLIGHT 21  // can be used for backlight if desired (also broken out to header)
-#define LCD_RS 17         // 16 on old V3.2.0
-#define LCD_RESET 18      // 17 on old V3.2.0
-
-void GLCD_inst(byte data);
-void GLCD_data(byte data);
-// void GLCD_init(void);
-
 // keep track of pages
 enum display_page_actions {
   page_home,  // go to home screen (probably thermal page)
@@ -46,14 +38,14 @@ class Display {
 
   void turnPage(uint8_t action);
   void setPage(uint8_t targetPage);
-  uint8_t getPage();
+  uint8_t getPage() { return displayPage_; }
 
   void showPageDebug();
   void showPageCharging();
   void showOnSplash();
 
-  bool displayingWarning();
-  void dismissWarning();
+  bool displayingWarning() { return showWarning_; }
+  void dismissWarning() { showWarning_ = false; }
 
  private:
   int8_t displayPage_ = page_thermal;

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -1026,7 +1026,7 @@ void display_headerAndFooter(bool timerSelected, bool showTurnArrows) {
     display_speed(78, 14);
     u8g2.setFont(leaf_5h);
     u8g2.setCursor(82, 21);
-    if (display.getPage() == page_nav) {
+    if (display.getPage() == MainPage::Nav) {
       u8g2.setDrawColor(0);  // draw white on black for nav page
     }
     if (settings.units_speed)

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -1026,7 +1026,7 @@ void display_headerAndFooter(bool timerSelected, bool showTurnArrows) {
     display_speed(78, 14);
     u8g2.setFont(leaf_5h);
     u8g2.setCursor(82, 21);
-    if (display_getPage() == page_nav) {
+    if (display.getPage() == page_nav) {
       u8g2.setDrawColor(0);  // draw white on black for nav page
     }
     if (settings.units_speed)

--- a/src/vario/ui/display/pages/dialogs/page_warning.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_warning.cpp
@@ -129,7 +129,7 @@ void warningPage_button(Button button, ButtonState state, uint8_t count) {
           warningPage_cursorPosition = cursor_warningPage_decline;
           speaker.playSound(fx::decrease);
         } else if (button == Button::CENTER) {
-          displayDismissWarning();
+          display.dismissWarning();
           speaker.playSound(fx::enter);
         }
       }

--- a/src/vario/ui/display/pages/primary/page_menu_main.cpp
+++ b/src/vario/ui/display/pages/primary/page_menu_main.cpp
@@ -47,7 +47,7 @@ void MainMenuPage::backToMainMenu() {
 void MainMenuPage::quitMenu() {
   cursor_position = cursor_back;
   menu_page = page_menu_main;
-  display_turnPage(page_back);
+  display.turnPage(page_back);
 }
 
 void MainMenuPage::draw() {
@@ -116,7 +116,7 @@ void MainMenuPage::menu_item_action(Button button) {
   switch (cursor_position) {
     case cursor_back:
       if (button == Button::LEFT || button == Button::CENTER) {
-        display_turnPage(page_back);
+        display.turnPage(page_back);
         speaker.playSound(fx::exit);
       } else if (button == Button::RIGHT) {
         // display_turnPage(page_next);  // maybe stop at menu, don't allow scrolling around back to

--- a/src/vario/ui/display/pages/primary/page_menu_main.cpp
+++ b/src/vario/ui/display/pages/primary/page_menu_main.cpp
@@ -47,7 +47,7 @@ void MainMenuPage::backToMainMenu() {
 void MainMenuPage::quitMenu() {
   cursor_position = cursor_back;
   menu_page = page_menu_main;
-  display.turnPage(page_back);
+  display.turnPage(PageAction::Back);
 }
 
 void MainMenuPage::draw() {
@@ -116,7 +116,7 @@ void MainMenuPage::menu_item_action(Button button) {
   switch (cursor_position) {
     case cursor_back:
       if (button == Button::LEFT || button == Button::CENTER) {
-        display.turnPage(page_back);
+        display.turnPage(PageAction::Back);
         speaker.playSound(fx::exit);
       } else if (button == Button::RIGHT) {
         // display_turnPage(page_next);  // maybe stop at menu, don't allow scrolling around back to

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -459,13 +459,13 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
           break;
         case Button::RIGHT:
           if (state == RELEASED) {
-            display.turnPage(page_next);
+            display.turnPage(PageAction::Next);
             speaker.playSound(fx::increase);
           }
           break;
         case Button::LEFT:
           if (state == RELEASED) {
-            display.turnPage(page_prev);
+            display.turnPage(PageAction::Prev);
             speaker.playSound(fx::decrease);
           }
           break;

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -459,13 +459,13 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
           break;
         case Button::RIGHT:
           if (state == RELEASED) {
-            display_turnPage(page_next);
+            display.turnPage(page_next);
             speaker.playSound(fx::increase);
           }
           break;
         case Button::LEFT:
           if (state == RELEASED) {
-            display_turnPage(page_prev);
+            display.turnPage(page_prev);
             speaker.playSound(fx::decrease);
           }
           break;

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -222,13 +222,13 @@ void thermalPage_button(Button button, ButtonState state, uint8_t count) {
           break;
         case Button::RIGHT:
           if (state == RELEASED) {
-            display.turnPage(page_next);
+            display.turnPage(PageAction::Next);
             speaker.playSound(fx::increase);
           }
           break;
         case Button::LEFT:
           if (state == RELEASED) {
-            display.turnPage(page_prev);
+            display.turnPage(PageAction::Prev);
             speaker.playSound(fx::decrease);
           }
           break;

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -222,13 +222,13 @@ void thermalPage_button(Button button, ButtonState state, uint8_t count) {
           break;
         case Button::RIGHT:
           if (state == RELEASED) {
-            display_turnPage(page_next);
+            display.turnPage(page_next);
             speaker.playSound(fx::increase);
           }
           break;
         case Button::LEFT:
           if (state == RELEASED) {
-            display_turnPage(page_prev);
+            display.turnPage(page_prev);
             speaker.playSound(fx::decrease);
           }
           break;

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -125,13 +125,13 @@ void thermalPageAdv_button(Button button, ButtonState state, uint8_t count) {
           break;
         case Button::RIGHT:
           if (state == RELEASED) {
-            display_turnPage(page_next);
+            display.turnPage(page_next);
             speaker.playSound(fx::increase);
           }
           break;
         case Button::LEFT:
           if (state == RELEASED) {
-            display_turnPage(page_prev);
+            display.turnPage(page_prev);
             speaker.playSound(fx::decrease);
           }
           break;

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -125,13 +125,13 @@ void thermalPageAdv_button(Button button, ButtonState state, uint8_t count) {
           break;
         case Button::RIGHT:
           if (state == RELEASED) {
-            display.turnPage(page_next);
+            display.turnPage(PageAction::Next);
             speaker.playSound(fx::increase);
           }
           break;
         case Button::LEFT:
           if (state == RELEASED) {
-            display.turnPage(page_prev);
+            display.turnPage(PageAction::Prev);
             speaker.playSound(fx::decrease);
           }
           break;

--- a/src/vario/ui/input/buttons.cpp
+++ b/src/vario/ui/input/buttons.cpp
@@ -95,15 +95,16 @@ Button buttons_update(void) {
   power_resetAutoOffCounter();  // pressing any button should reset the auto-off counter
                                 // TODO: we should probably have a counter for Auto-Timer-Off as
                                 // well, and button presses should reset that.
-  uint8_t currentPage = display.getPage();  // actions depend on which page we're on
+  MainPage currentPage = display.getPage();  // actions depend on which page we're on
 
-  if (currentPage == page_charging) {
+  if (currentPage == MainPage::Charging) {
     switch (which_button) {
       case Button::CENTER:
         if (button_state == HELD && button_hold_counter == 1) {
           display.clear();
           display.showOnSplash();
-          display.setPage(page_thermal);  // TODO: set initial page to the user's last used page
+          display.setPage(
+              MainPage::Thermal);  // TODO: set initial page to the user's last used page
           speaker.playSound(fx::enter);
           buttons_lockAfterHold();  // lock buttons until user lets go of power button
           power_switchToOnState();
@@ -148,24 +149,24 @@ Button buttons_update(void) {
     return which_button;
   }
 
-  if (currentPage == page_menu) {
+  if (currentPage == MainPage::Menu) {
     bool draw_now =
         mainMenuPage.button_event(which_button, buttons_get_state(), buttons_get_hold_count());
     if (draw_now) display.update();
 
-  } else if (currentPage == page_thermal) {
+  } else if (currentPage == MainPage::Thermal) {
     thermalPage_button(which_button, buttons_get_state(), buttons_get_hold_count());
     display.update();
 
-  } else if (currentPage == page_thermalAdv) {
+  } else if (currentPage == MainPage::ThermalAdv) {
     thermalPageAdv_button(which_button, buttons_get_state(), buttons_get_hold_count());
     display.update();
 
-  } else if (currentPage == page_nav) {
+  } else if (currentPage == MainPage::Nav) {
     navigatePage_button(which_button, buttons_get_state(), buttons_get_hold_count());
     display.update();
 
-  } else if (currentPage != page_charging) {  // NOT CHARGING PAGE (i.e., our debug test page)
+  } else if (currentPage != MainPage::Charging) {  // NOT CHARGING PAGE (i.e., our debug test page)
     switch (which_button) {
       case Button::CENTER:
         switch (button_state) {
@@ -174,7 +175,7 @@ Button buttons_update(void) {
               power_shutdown();
               while (buttons_inspectPins() == Button::CENTER) {
               }  // freeze here until user lets go of power button
-              display.setPage(page_charging);
+              display.setPage(MainPage::Charging);
             }
             break;
           case RELEASED:

--- a/src/vario/ui/input/buttons.cpp
+++ b/src/vario/ui/input/buttons.cpp
@@ -179,13 +179,13 @@ Button buttons_update(void) {
             }
             break;
           case RELEASED:
-            display.turnPage(page_home);
+            display.turnPage(PageAction::Home);
             break;
         }
         break;
       case Button::RIGHT:
         if (button_state == RELEASED) {
-          display.turnPage(page_next);
+          display.turnPage(PageAction::Next);
           speaker.playSound(fx::increase);
         }
         break;

--- a/src/vario/ui/input/buttons.cpp
+++ b/src/vario/ui/input/buttons.cpp
@@ -95,15 +95,15 @@ Button buttons_update(void) {
   power_resetAutoOffCounter();  // pressing any button should reset the auto-off counter
                                 // TODO: we should probably have a counter for Auto-Timer-Off as
                                 // well, and button presses should reset that.
-  uint8_t currentPage = display_getPage();  // actions depend on which page we're on
+  uint8_t currentPage = display.getPage();  // actions depend on which page we're on
 
   if (currentPage == page_charging) {
     switch (which_button) {
       case Button::CENTER:
         if (button_state == HELD && button_hold_counter == 1) {
-          display_clear();
-          display_showOnSplash();
-          display_setPage(page_thermal);  // TODO: set initial page to the user's last used page
+          display.clear();
+          display.showOnSplash();
+          display.setPage(page_thermal);  // TODO: set initial page to the user's last used page
           speaker.playSound(fx::enter);
           buttons_lockAfterHold();  // lock buttons until user lets go of power button
           power_switchToOnState();
@@ -133,9 +133,9 @@ Button buttons_update(void) {
     }
     return which_button;
   }
-  if (displayingWarning()) {
+  if (display.displayingWarning()) {
     warningPage_button(which_button, buttons_get_state(), buttons_get_hold_count());
-    display_update();
+    display.update();
     return which_button;
   }
 
@@ -144,26 +144,26 @@ Button buttons_update(void) {
   if (modal_page != NULL) {
     bool draw_now =
         modal_page->button_event(which_button, buttons_get_state(), buttons_get_hold_count());
-    if (draw_now) display_update();
+    if (draw_now) display.update();
     return which_button;
   }
 
   if (currentPage == page_menu) {
     bool draw_now =
         mainMenuPage.button_event(which_button, buttons_get_state(), buttons_get_hold_count());
-    if (draw_now) display_update();
+    if (draw_now) display.update();
 
   } else if (currentPage == page_thermal) {
     thermalPage_button(which_button, buttons_get_state(), buttons_get_hold_count());
-    display_update();
+    display.update();
 
   } else if (currentPage == page_thermalAdv) {
     thermalPageAdv_button(which_button, buttons_get_state(), buttons_get_hold_count());
-    display_update();
+    display.update();
 
   } else if (currentPage == page_nav) {
     navigatePage_button(which_button, buttons_get_state(), buttons_get_hold_count());
-    display_update();
+    display.update();
 
   } else if (currentPage != page_charging) {  // NOT CHARGING PAGE (i.e., our debug test page)
     switch (which_button) {
@@ -174,17 +174,17 @@ Button buttons_update(void) {
               power_shutdown();
               while (buttons_inspectPins() == Button::CENTER) {
               }  // freeze here until user lets go of power button
-              display_setPage(page_charging);
+              display.setPage(page_charging);
             }
             break;
           case RELEASED:
-            display_turnPage(page_home);
+            display.turnPage(page_home);
             break;
         }
         break;
       case Button::RIGHT:
         if (button_state == RELEASED) {
-          display_turnPage(page_next);
+          display.turnPage(page_next);
           speaker.playSound(fx::increase);
         }
         break;

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -270,7 +270,7 @@ void Settings::adjustContrast(Button dir) {
   else if (dir == Button::CENTER) {  // reset to default
     speaker.playSound(fx::confirm);
     disp_contrast = DEF_CONTRAST;
-    display_setContrast(disp_contrast);
+    display.setContrast(disp_contrast);
     return;
   }
 
@@ -283,7 +283,7 @@ void Settings::adjustContrast(Button dir) {
     disp_contrast = CONTRAST_MIN;
     sound = fx::doubleClick;
   }
-  display_setContrast(disp_contrast);
+  display.setContrast(disp_contrast);
   speaker.playSound(sound);
 }
 

--- a/src/vario/utils/wrapping_enum.h
+++ b/src/vario/utils/wrapping_enum.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+template <typename E>
+struct wrapping_bounds;  // to be specialized per-enum
+
+template <typename E, typename U = std::underlying_type_t<E>,
+          std::enable_if_t<std::is_enum_v<E>, int> = 0>
+inline E& operator++(E& e) {
+  constexpr E bot = wrapping_bounds<E>::bottom;
+  constexpr E top = wrapping_bounds<E>::top;
+  U v = static_cast<U>(e);
+  U vb = static_cast<U>(bot);
+  U vt = static_cast<U>(top);
+  e = static_cast<E>((v >= vt) ? vb : (v + 1));
+  return e;
+}
+
+template <typename E, typename U = std::underlying_type_t<E>,
+          std::enable_if_t<std::is_enum_v<E>, int> = 0>
+inline E operator++(E& e, int) {
+  E tmp = e;
+  ++e;
+  return tmp;
+}
+
+template <typename E, typename U = std::underlying_type_t<E>,
+          std::enable_if_t<std::is_enum_v<E>, int> = 0>
+inline E& operator--(E& e) {
+  constexpr E bot = wrapping_bounds<E>::bottom;
+  constexpr E top = wrapping_bounds<E>::top;
+  U v = static_cast<U>(e);
+  U vb = static_cast<U>(bot);
+  U vt = static_cast<U>(top);
+  e = static_cast<E>((v <= vb) ? vt : (v - 1));
+  return e;
+}
+
+template <typename E, typename U = std::underlying_type_t<E>,
+          std::enable_if_t<std::is_enum_v<E>, int> = 0>
+inline E operator--(E& e, int) {
+  E tmp = e;
+  --e;
+  return tmp;
+}
+
+#define DEFINE_WRAPPING_BOUNDS(EnumType, Bottom, Top) \
+  template <>                                         \
+  struct wrapping_bounds<EnumType> {                  \
+    static constexpr EnumType bottom = Bottom;        \
+    static constexpr EnumType top = Top;              \
+  }


### PR DESCRIPTION
This PR moves display-related functions and variables into a Display class and generally cleans up that content (removing unused content, strictly-typing enums, moving implementation information from .h to .cpp).

Tested using the [standard test procedure](https://github.com/DangerMonkeys/leaf/blob/main/docs/dev-references/testing/test_procedure.md) with 3.2.7+radio hardware and leaf_3_2_7_dev.