### PR TITLE
Class-ify power

### DIFF
--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -40,6 +40,32 @@ Power power;  // struct for battery-state and on-state variables
 #define AUTO_OFF_MAX_ALT 400   // cm altitude change for timer auto-stop
 #define AUTO_OFF_MIN_SEC 20    // seconds of low speed / low accel for timer to auto-stop
 
+const char* nameOf(PowerState state) {
+  switch (state) {
+    case PowerState::Off:
+      return "Off";
+    case PowerState::On:
+      return "On";
+    case PowerState::OffUSB:
+      return "OffUSB";
+  }
+  return "Unknown";
+}
+
+const char* nameOf(PowerInputLevel level) {
+  switch (level) {
+    case PowerInputLevel::Standby:
+      return "Standby";
+    case PowerInputLevel::i100mA:
+      return "100mA";
+    case PowerInputLevel::i500mA:
+      return "500mA";
+    case PowerInputLevel::Max:
+      return "Max";
+  }
+  return "Unknown";
+}
+
 void Power::bootUp() {
   // Init Peripheral Busses
   wire_init();

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -8,7 +8,7 @@
 
 #include <Arduino.h>
 
-#include "utils/bounded_enum.h"
+#include "utils/clamped_enum.h"
 
 /// @details ... note: we enter PowerState::OffUSB either from Off and then plugging in to USB power
 /// (no power button detected during boot) or from On with USB plugged in, and user turning off
@@ -43,7 +43,7 @@ const char* nameOf(PowerState state) {
 // battery charging AND system load) Note: with this higher input limit, the battery charging will
 // then be limited by the ISET pin resistor value, to approximately 810mA charging current)
 enum class PowerInputLevel : uint8_t { Standby = 0, i100mA = 1, i500mA = 2, Max = 3 };
-DEFINE_MINMAX_BOUNDS(PowerInputLevel, PowerInputLevel::Standby, PowerInputLevel::Max);
+DEFINE_CLAMPED_BOUNDS(PowerInputLevel, PowerInputLevel::Standby, PowerInputLevel::Max);
 
 const char* nameOf(PowerInputLevel level) {
   switch (level) {

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -61,6 +61,18 @@ const char* nameOf(PowerInputLevel level) {
 
 class Power {
  public:
+  struct Info {
+    int8_t batteryPercent;  // battery percentage remaining from 0-100%
+    uint16_t batteryMV;     // milivolts battery voltage (typically between 3200 and 4200)
+    uint16_t batteryADC;    // ADC raw output from ESP32 input pin
+    bool charging = false;  // if system is being charged or not
+    bool USBinput = false;  // if system is plugged into USB power or not
+    PowerState onState = PowerState::Off;
+    PowerInputLevel inputCurrent = PowerInputLevel::i500mA;
+  };
+
+  const Info& info() { return info_; }
+
   void bootUp();
 
   void shutdown();
@@ -76,14 +88,6 @@ class Power {
 
   // Read battery voltage
   void readBatteryState();
-
-  int8_t batteryPercent;  // battery percentage remaining from 0-100%
-  uint16_t batteryMV;     // milivolts battery voltage (typically between 3200 and 4200)
-  uint16_t batteryADC;    // ADC raw output from ESP32 input pin
-  bool charging = false;  // if system is being charged or not
-  bool USBinput = false;  // if system is plugged into USB power or not
-  PowerState onState = PowerState::Off;
-  PowerInputLevel inputCurrent = PowerInputLevel::i500mA;
 
  private:
   // Initialize the power system itself (battery charger and 3.3V regulator etc)
@@ -106,6 +110,8 @@ class Power {
   bool autoOff();
 
   void setInputCurrent(PowerInputLevel current);
+
+  Info info_;
 
   // check if we should turn off from  inactivity
   uint8_t autoOffCounter_ = 0;

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -9,40 +9,57 @@
 
 #include <Arduino.h>
 
-// Pinout for Leaf V3.2.0+
-#define POWER_LATCH 48
-#define BATT_SENSE 1  // INPUT ADC
+#include "utils/bounded_enum.h"
 
-// Battery Threshold values
-#define BATT_FULL_MV 4080   // mV full battery on which to base % full (100%)
-#define BATT_EMPTY_MV 3250  // mV empty battery on which to base % full (0%)
-#define BATT_SHUTDOWN_MV 3200
-// mV at which to shutdown the system to prevent battery over-discharge
-// Note: the battery apparently also has over discharge protection, but we don't fully trust it,
-// plus we want to shutdown while we have power to save logs etc
+/// @details ... note: we enter PowerState::OffUSB either from Off and then plugging in to USB power
+/// (no power button detected during boot) or from On with USB plugged in, and user turning off
+/// power via pushbutton.
+enum class PowerState : uint8_t {
+  Off,  // power off we'll never use, because chip is unpowered and not running
 
-// Auto-Power-Off Threshold values
-#define AUTO_OFF_MAX_SPEED 3   // mph max -- must be below this speed for timer to auto-stop
-#define AUTO_OFF_MAX_ACCEL 10  // Max accelerometer signal
-#define AUTO_OFF_MAX_ALT 400   // cm altitude change for timer auto-stop
-#define AUTO_OFF_MIN_SEC 20    // seconds of low speed / low accel for timer to auto-stop
+  /// @brief system is ON by user input (pushbutton) and should function normally.
+  /// @details Display battery icon and charging state depending on what charger is doing (we can't
+  /// tell if USB is plugged in or not, only if battery is charging or not)
+  On,
 
-enum power_on_states {
-  POWER_OFF,  // power off we'll never use, because chip is unpowered and not running
-  POWER_ON,   // system is ON by user input (pushbutton) and should function normally.  Dislpay
-             // battery icon and charging state depending on what charger is doing (we can't tell if
-             // USB is plugged in or not, only if battery is charging or not)
-  POWER_OFF_USB  // system is OFF, but has USB power.  Keep power usage to a minimum, and just power
-                 // on display to show battery charge state (when charging) or turn display off and
-                 // have processor sleep (when not charging)
-};  //   ... note: we enter POWER_OFF_USB state either from POWER_OFF and then plugging in to USB
-    //   power (no power button detected during boot) or from POWER_ON with USB plugged in, and user
-    //   turning off power via pushbutton.
+  /// @brief system is OFF, but has USB power.
+  /// @details  Keep power usage to a minimum, and just power on display to show battery charge
+  /// state (when charging) or turn display off and have processor sleep (when not charging)
+  OffUSB
+};
+
+const char* nameOf(PowerState state) {
+  switch (state) {
+    case PowerState::Off:
+      return "Off";
+    case PowerState::On:
+      return "On";
+    case PowerState::OffUSB:
+      return "OffUSB";
+  }
+  return "Unknown";
+}
 
 // iMax set by ILIM pin resistor on battery charger chip. Results in 1.348Amps max input (for
 // battery charging AND system load) Note: with this higher input limit, the battery charging will
 // then be limited by the ISET pin resistor value, to approximately 810mA charging current)
-enum power_input_levels { iStandby, i100mA, i500mA, iMax };
+enum class PowerInputLevel : uint8_t { Standby = 0, i100mA = 1, i500mA = 2, Max = 3 };
+
+DEFINE_MINMAX_BOUNDS(PowerInputLevel, PowerInputLevel::Standby, PowerInputLevel::Max);
+
+const char* nameOf(PowerInputLevel level) {
+  switch (level) {
+    case PowerInputLevel::Standby:
+      return "Standby";
+    case PowerInputLevel::i100mA:
+      return "100mA";
+    case PowerInputLevel::i500mA:
+      return "500mA";
+    case PowerInputLevel::Max:
+      return "Max";
+  }
+  return "Unknown";
+}
 
 class Power {
  public:
@@ -56,7 +73,8 @@ class Power {
 
   void resetAutoOffCounter();
 
-  void adjustInputCurrent(int8_t offset);
+  void increaseInputCurrent();
+  void decreaseInputCurrent();
 
   void readBatteryState();
 
@@ -65,8 +83,8 @@ class Power {
   uint16_t batteryADC;    // ADC raw output from ESP32 input pin
   bool charging = false;  // if system is being charged or not
   bool USBinput = false;  // if system is plugged into USB power or not
-  power_on_states onState = POWER_OFF;
-  power_input_levels inputCurrent = i500mA;
+  PowerState onState = PowerState::Off;
+  PowerInputLevel inputCurrent = PowerInputLevel::i500mA;
 
  private:
   // Initialize the power system itself (battery charger and 3.3V regulator etc)
@@ -88,7 +106,7 @@ class Power {
 
   bool autoOff();
 
-  void setInputCurrent(power_input_levels current);
+  void setInputCurrent(PowerInputLevel current);
 };
 extern Power power;
 

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -27,17 +27,7 @@ enum class PowerState : uint8_t {
   OffUSB
 };
 
-const char* nameOf(PowerState state) {
-  switch (state) {
-    case PowerState::Off:
-      return "Off";
-    case PowerState::On:
-      return "On";
-    case PowerState::OffUSB:
-      return "OffUSB";
-  }
-  return "Unknown";
-}
+const char* nameOf(PowerState state);
 
 // iMax set by ILIM pin resistor on battery charger chip. Results in 1.348Amps max input (for
 // battery charging AND system load) Note: with this higher input limit, the battery charging will
@@ -45,19 +35,7 @@ const char* nameOf(PowerState state) {
 enum class PowerInputLevel : uint8_t { Standby = 0, i100mA = 1, i500mA = 2, Max = 3 };
 DEFINE_CLAMPED_BOUNDS(PowerInputLevel, PowerInputLevel::Standby, PowerInputLevel::Max);
 
-const char* nameOf(PowerInputLevel level) {
-  switch (level) {
-    case PowerInputLevel::Standby:
-      return "Standby";
-    case PowerInputLevel::i100mA:
-      return "100mA";
-    case PowerInputLevel::i500mA:
-      return "500mA";
-    case PowerInputLevel::Max:
-      return "Max";
-  }
-  return "Unknown";
-}
+const char* nameOf(PowerInputLevel level);
 
 class Power {
  public:

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -4,8 +4,7 @@
  * Battery Charging Chip BQ24073
  *
  */
-#ifndef power_h
-#define power_h
+#pragma once
 
 #include <Arduino.h>
 
@@ -44,7 +43,6 @@ const char* nameOf(PowerState state) {
 // battery charging AND system load) Note: with this higher input limit, the battery charging will
 // then be limited by the ISET pin resistor value, to approximately 810mA charging current)
 enum class PowerInputLevel : uint8_t { Standby = 0, i100mA = 1, i500mA = 2, Max = 3 };
-
 DEFINE_MINMAX_BOUNDS(PowerInputLevel, PowerInputLevel::Standby, PowerInputLevel::Max);
 
 const char* nameOf(PowerInputLevel level) {
@@ -76,6 +74,7 @@ class Power {
   void increaseInputCurrent();
   void decreaseInputCurrent();
 
+  // Read battery voltage
   void readBatteryState();
 
   int8_t batteryPercent;  // battery percentage remaining from 0-100%
@@ -107,7 +106,11 @@ class Power {
   bool autoOff();
 
   void setInputCurrent(PowerInputLevel current);
+
+  // check if we should turn off from  inactivity
+  uint8_t autoOffCounter_ = 0;
+  int32_t autoOffAltitude_ = 0;
+
+  uint16_t batteryPercentLast_;
 };
 extern Power power;
-
-#endif

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -44,7 +44,22 @@ enum power_on_states {
 // then be limited by the ISET pin resistor value, to approximately 810mA charging current)
 enum power_input_levels { iStandby, i100mA, i500mA, iMax };
 
-struct POWER {
+class Power {
+ public:
+  void bootUp();
+
+  void shutdown();
+
+  void switchToOnState();
+
+  void update();
+
+  void resetAutoOffCounter();
+
+  void adjustInputCurrent(int8_t offset);
+
+  void readBatteryState();
+
   int8_t batteryPercent;  // battery percentage remaining from 0-100%
   uint16_t batteryMV;     // milivolts battery voltage (typically between 3200 and 4200)
   uint16_t batteryADC;    // ADC raw output from ESP32 input pin
@@ -52,27 +67,29 @@ struct POWER {
   bool USBinput = false;  // if system is plugged into USB power or not
   power_on_states onState = POWER_OFF;
   power_input_levels inputCurrent = i500mA;
+
+ private:
+  // Initialize the power system itself (battery charger and 3.3V regulator etc)
+  void initPowerSystem();
+
+  /// @brief latch or unlatch 3.3V regulator.
+  /// @details 3.3V regulator may be 'on' due to USB power or user holding power switch down.  But
+  /// if Vario is in "ON" state, we need to latch so user can let go of power button and/or unplug
+  /// USB and have it stay on
+  void latchOn();
+
+  // If no USB power is available, systems will immediately lose power and shut down (after user
+  // lets go of center button)
+  void latchOff();
+
+  void initPeripherals();
+  void sleepPeripherals();
+  void wakePeripherals();
+
+  bool autoOff();
+
+  void setInputCurrent(power_input_levels current);
 };
-extern POWER power;
-
-void blinkLED(uint8_t count);
-void power_bootUp(void);
-void power_init(void);
-void power_latch_on(void);
-void power_latch_off(void);
-void power_shutdown(void);
-
-void power_init_peripherals(void);
-void power_sleep_peripherals(void);
-void power_wake_peripherals(void);
-void power_switchToOnState(void);
-
-void power_update(void);
-bool power_autoOff();
-void power_resetAutoOffCounter(void);
-
-void power_adjustInputCurrent(int8_t offset);
-void power_setInputCurrent(power_input_levels current);
-void power_readBatteryState(void);
+extern Power power;
 
 #endif

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -181,7 +181,7 @@ the pushbuttons, the GPS 1PPS signal, and perhaps others.
 */
 
 // LOOP NOTES:
-// when re-entering POWER_ON state, be sure to start from tasks #1, so baro ADC can be re-prepped
+// when re-entering PowerState::On, be sure to start from tasks #1, so baro ADC can be re-prepped
 // before reading
 
 void loop() {
@@ -189,9 +189,9 @@ void loop() {
   webserver_loop();
 #endif
 
-  if (power.onState == POWER_ON)
+  if (power.onState == PowerState::On)
     main_ON_loop();
-  else if (power.onState == POWER_OFF_USB)
+  else if (power.onState == PowerState::OffUSB)
     main_CHARGE_loop();
   else
     Serial.print("FAILED MAIN LOOP HANDLER");

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -189,9 +189,10 @@ void loop() {
   webserver_loop();
 #endif
 
-  if (power.onState == PowerState::On)
+  const auto& info = power.info();
+  if (info.onState == PowerState::On)
     main_ON_loop();
-  else if (power.onState == PowerState::OffUSB)
+  else if (info.onState == PowerState::OffUSB)
     main_CHARGE_loop();
   else
     Serial.print("FAILED MAIN LOOP HANDLER");

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -120,7 +120,7 @@ void taskmanSetup() {
   vTaskPrioritySet(NULL, 10);
 
   // turn on and handle all device initialization
-  power_bootUp();
+  power.bootUp();
 
   // Start Main System Timer for Interrupt Events (this will tell Main Loop to set tasks every
   // interrupt cycle)
@@ -220,7 +220,7 @@ void main_CHARGE_loop() {
     sdcard.update();
 
     // update battery level and charge state
-    power_readBatteryState();
+    power.readBatteryState();
 
     // Check Buttons
     auto buttonPushed =
@@ -422,7 +422,7 @@ void taskManager(void) {
     taskman_gps = 0;
   }
   if (taskman_power) {
-    power_update();
+    power.update();
     taskman_power = 0;
   }
   if (taskman_log) {

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -259,31 +259,32 @@ void display_update_temp_vars() {
 **   CHARGING PAGE    ************************************************************
 *********************************************************************************/
 void display_page_charging() {
+  const auto& info = power.info();
   u8g2.firstPage();
   do {
     // Battery Percent
     uint8_t fontOffset = 3;
-    if (power.batteryPercent == 100) fontOffset = 0;
+    if (info.batteryPercent == 100) fontOffset = 0;
     u8g2.setFont(leaf_6x12);
     u8g2.setCursor(36 + fontOffset, 12);
-    u8g2.print(power.batteryPercent);
+    u8g2.print(info.batteryPercent);
     u8g2.print('%');
 
     display_batt_charging_fullscreen(48, 17);
 
     u8g2.setFont(leaf_6x12);
     u8g2.setCursor(5, 157);
-    if (power.inputCurrent == PowerInputLevel::i100mA)
+    if (info.inputCurrent == PowerInputLevel::i100mA)
       u8g2.print("100mA");
-    else if (power.inputCurrent == PowerInputLevel::i500mA)
+    else if (info.inputCurrent == PowerInputLevel::i500mA)
       u8g2.print("500mA");
-    else if (power.inputCurrent == PowerInputLevel::Max)
+    else if (info.inputCurrent == PowerInputLevel::Max)
       u8g2.print("810mA");
-    else if (power.inputCurrent == PowerInputLevel::Standby)
+    else if (info.inputCurrent == PowerInputLevel::Standby)
       u8g2.print(" OFF");
 
     u8g2.print(" ");
-    u8g2.print(power.batteryMV);
+    u8g2.print(info.batteryMV);
     u8g2.print("mV");
 
     // Display the current version
@@ -342,13 +343,14 @@ void display_page_debug() {
 
     uint8_t x = 56;
     uint8_t y = 12;
+    const auto& info = power.info();
     u8g2.setFont(leaf_6x12);
     u8g2.setCursor(x, y);
-    u8g2.print(power.batteryPercent);
+    u8g2.print(info.batteryPercent);
     u8g2.print('%');
     u8g2.setCursor(x, y += 6);
     u8g2.setFont(leaf_5h);
-    u8g2.print((float)power.batteryMV / 1000, 3);
+    u8g2.print((float)info.batteryMV / 1000, 3);
     u8g2.print("v");
 
     // Altimeter Setting

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -273,13 +273,13 @@ void display_page_charging() {
 
     u8g2.setFont(leaf_6x12);
     u8g2.setCursor(5, 157);
-    if (power.inputCurrent == i100mA)
+    if (power.inputCurrent == PowerInputLevel::i100mA)
       u8g2.print("100mA");
-    else if (power.inputCurrent == i500mA)
+    else if (power.inputCurrent == PowerInputLevel::i500mA)
       u8g2.print("500mA");
-    else if (power.inputCurrent == iMax)
+    else if (power.inputCurrent == PowerInputLevel::Max)
       u8g2.print("810mA");
-    else if (power.inputCurrent == iStandby)
+    else if (power.inputCurrent == PowerInputLevel::Standby)
       u8g2.print(" OFF");
 
     u8g2.print(" ");

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -624,11 +624,11 @@ void display_battIcon(uint8_t x, uint8_t y, bool vertical) {
       : batt at 100%
       ; batt charging (full)
   */
+  const auto& info = power.info();
+  char battIcon = '0' + (info.batteryPercent + 5) / 10;
 
-  char battIcon = '0' + (power.batteryPercent + 5) / 10;
-
-  if (power.charging) {
-    if (power.batteryPercent >= 100)
+  if (info.charging) {
+    if (info.batteryPercent >= 100)
       battIcon = ';';
     else
       battIcon = '/';
@@ -661,6 +661,8 @@ void display_battIcon(uint8_t x, uint8_t y, bool vertical) {
 }
 
 void display_batt_charging_fullscreen(uint8_t x, uint8_t y) {
+  const auto& info = power.info();
+
   // size of battery
   uint8_t w = 60;   // 60;
   uint8_t h = 120;  // 140;
@@ -675,7 +677,7 @@ void display_batt_charging_fullscreen(uint8_t x, uint8_t y) {
                 w / 15 - t);  // empty internal volume
 
   // Battery Capacity Fill
-  uint8_t fill_h = (h - 4 * t) * power.batteryPercent / 100;
+  uint8_t fill_h = (h - 4 * t) * info.batteryPercent / 100;
   uint8_t fill_y = (y + w / 20 + 2 * t) +
                    ((h - 4 * t) - fill_h);  // (starting position to allow for line thickness etc) +
                                             // ( (100% height) - (actual height) )
@@ -683,7 +685,7 @@ void display_batt_charging_fullscreen(uint8_t x, uint8_t y) {
   u8g2.drawBox(x - (w / 2) + 2 * t, fill_y, w - 4 * t, fill_h);  //, w/8-t/2);
 
   // Charging bolt
-  if (power.charging) {
+  if (info.charging) {
     uint8_t bolt_x1 = w * 6 / 100;   //  4
     uint8_t bolt_x2 = w * 7 / 100;   //  6
     uint8_t bolt_x3 = w * 21 / 100;  // 17

--- a/src/vario/ui/display/pages/dialogs/page_warning.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_warning.cpp
@@ -92,7 +92,7 @@ void warningPage_draw() {
 void warningPage_button(Button button, ButtonState state, uint8_t count) {
   // allow turning off in all states
   if (state == HELD && button == Button::CENTER) {
-    power_shutdown();
+    power.shutdown();
     return;
   }
 
@@ -119,7 +119,7 @@ void warningPage_button(Button button, ButtonState state, uint8_t count) {
           warningPage_cursorPosition = cursor_warningPage_accept;
           speaker.playSound(fx::increase);
         } else if (button == Button::CENTER) {
-          power_shutdown();
+          power.shutdown();
         }
       }
       break;

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -471,7 +471,7 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
           break;
         case Button::CENTER:
           if (state == HELD && count == 2) {
-            power_shutdown();
+            power.shutdown();
           }
           break;
       }

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -234,7 +234,7 @@ void thermalPage_button(Button button, ButtonState state, uint8_t count) {
           break;
         case Button::CENTER:
           if (state == HELD && count == 2) {
-            power_shutdown();
+            power.shutdown();
           }
           break;
       }

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -137,7 +137,7 @@ void thermalPageAdv_button(Button button, ButtonState state, uint8_t count) {
           break;
         case Button::CENTER:
           if (state == HELD && count == 2) {
-            power_shutdown();
+            power.shutdown();
           }
           break;
       }

--- a/src/vario/ui/input/buttons.cpp
+++ b/src/vario/ui/input/buttons.cpp
@@ -114,7 +114,7 @@ Button buttons_update(void) {
           case RELEASED:
             break;
           case HELD:
-            power.adjustInputCurrent(1);
+            power.increaseInputCurrent();
 
             speaker.playSound(fx::enter);
             break;
@@ -125,7 +125,7 @@ Button buttons_update(void) {
           case RELEASED:
             break;
           case HELD:
-            power.adjustInputCurrent(-1);
+            power.decreaseInputCurrent();
             speaker.playSound(fx::exit);
             break;
         }

--- a/src/vario/ui/input/buttons.cpp
+++ b/src/vario/ui/input/buttons.cpp
@@ -92,7 +92,7 @@ Button buttons_update(void) {
     return which_button;  // don't take any action if no button
   // TODO: not jumping out of this function on NO_STATE was causing speaker issues... investigate!
 
-  power_resetAutoOffCounter();  // pressing any button should reset the auto-off counter
+  power.resetAutoOffCounter();  // pressing any button should reset the auto-off counter
                                 // TODO: we should probably have a counter for Auto-Timer-Off as
                                 // well, and button presses should reset that.
   uint8_t currentPage = display_getPage();  // actions depend on which page we're on
@@ -106,7 +106,7 @@ Button buttons_update(void) {
           display_setPage(page_thermal);  // TODO: set initial page to the user's last used page
           speaker.playSound(fx::enter);
           buttons_lockAfterHold();  // lock buttons until user lets go of power button
-          power_switchToOnState();
+          power.switchToOnState();
         }
         break;
       case Button::UP:
@@ -114,7 +114,7 @@ Button buttons_update(void) {
           case RELEASED:
             break;
           case HELD:
-            power_adjustInputCurrent(1);
+            power.adjustInputCurrent(1);
 
             speaker.playSound(fx::enter);
             break;
@@ -125,7 +125,7 @@ Button buttons_update(void) {
           case RELEASED:
             break;
           case HELD:
-            power_adjustInputCurrent(-1);
+            power.adjustInputCurrent(-1);
             speaker.playSound(fx::exit);
             break;
         }
@@ -171,7 +171,7 @@ Button buttons_update(void) {
         switch (button_state) {
           case HELD:
             if (button_hold_counter == 2) {
-              power_shutdown();
+              power.shutdown();
               while (buttons_inspectPins() == Button::CENTER) {
               }  // freeze here until user lets go of power button
               display_setPage(page_charging);

--- a/src/vario/utils/bounded_enum.h
+++ b/src/vario/utils/bounded_enum.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+template <typename E>
+struct minmax_bounds;  // to be specialized per-enum
+
+template <typename E, typename U = std::underlying_type_t<E>,
+          std::enable_if_t<std::is_enum_v<E>, int> = 0>
+inline E& operator++(E& e) {
+  constexpr E bot = minmax_bounds<E>::bottom;
+  constexpr E top = minmax_bounds<E>::top;
+  U v = static_cast<U>(e);
+  U vb = static_cast<U>(bot);
+  U vt = static_cast<U>(top);
+  e = static_cast<E>((v >= vt) ? vt : (v + 1));
+  return e;
+}
+
+template <typename E, typename U = std::underlying_type_t<E>,
+          std::enable_if_t<std::is_enum_v<E>, int> = 0>
+inline E operator++(E& e, int) {
+  E tmp = e;
+  ++e;
+  return tmp;
+}
+
+template <typename E, typename U = std::underlying_type_t<E>,
+          std::enable_if_t<std::is_enum_v<E>, int> = 0>
+inline E& operator--(E& e) {
+  constexpr E bot = minmax_bounds<E>::bottom;
+  constexpr E top = minmax_bounds<E>::top;
+  U v = static_cast<U>(e);
+  U vb = static_cast<U>(bot);
+  U vt = static_cast<U>(top);
+  e = static_cast<E>((v <= vb) ? vb : (v - 1));
+  return e;
+}
+
+template <typename E, typename U = std::underlying_type_t<E>,
+          std::enable_if_t<std::is_enum_v<E>, int> = 0>
+inline E operator--(E& e, int) {
+  E tmp = e;
+  --e;
+  return tmp;
+}
+
+#define DEFINE_MINMAX_BOUNDS(EnumType, Bottom, Top) \
+  template <>                                       \
+  struct minmax_bounds<EnumType> {                  \
+    static constexpr EnumType bottom = Bottom;      \
+    static constexpr EnumType top = Top;            \
+  }

--- a/src/vario/utils/clamped_enum.h
+++ b/src/vario/utils/clamped_enum.h
@@ -4,13 +4,13 @@
 #include <type_traits>
 
 template <typename E>
-struct minmax_bounds;  // to be specialized per-enum
+struct clamped_bounds;  // to be specialized per-enum
 
 template <typename E, typename U = std::underlying_type_t<E>,
           std::enable_if_t<std::is_enum_v<E>, int> = 0>
 inline E& operator++(E& e) {
-  constexpr E bot = minmax_bounds<E>::bottom;
-  constexpr E top = minmax_bounds<E>::top;
+  constexpr E bot = clamped_bounds<E>::bottom;
+  constexpr E top = clamped_bounds<E>::top;
   U v = static_cast<U>(e);
   U vb = static_cast<U>(bot);
   U vt = static_cast<U>(top);
@@ -29,8 +29,8 @@ inline E operator++(E& e, int) {
 template <typename E, typename U = std::underlying_type_t<E>,
           std::enable_if_t<std::is_enum_v<E>, int> = 0>
 inline E& operator--(E& e) {
-  constexpr E bot = minmax_bounds<E>::bottom;
-  constexpr E top = minmax_bounds<E>::top;
+  constexpr E bot = clamped_bounds<E>::bottom;
+  constexpr E top = clamped_bounds<E>::top;
   U v = static_cast<U>(e);
   U vb = static_cast<U>(bot);
   U vt = static_cast<U>(top);
@@ -46,9 +46,9 @@ inline E operator--(E& e, int) {
   return tmp;
 }
 
-#define DEFINE_MINMAX_BOUNDS(EnumType, Bottom, Top) \
-  template <>                                       \
-  struct minmax_bounds<EnumType> {                  \
-    static constexpr EnumType bottom = Bottom;      \
-    static constexpr EnumType top = Top;            \
+#define DEFINE_CLAMPED_BOUNDS(EnumType, Bottom, Top) \
+  template <>                                        \
+  struct clamped_bounds<EnumType> {                  \
+    static constexpr EnumType bottom = Bottom;       \
+    static constexpr EnumType top = Top;             \
   }


### PR DESCRIPTION
This PR moves power-related functions and variables into a Power class and generally cleans up that content a little (strictly-typing enums, moving implementation information from .h to .cpp).  The PowerInputLevel enum is made into a bounded enum which supports ++ and --, but is clamped between min and max values.  Functions are added to translate enum values to strings for better debugability.  The variables (now class fields) that were previously vulnerable to being modified outside the power code are now read-only through Power::info().

Tested using the [standard test procedure](https://github.com/DangerMonkeys/leaf/blob/main/docs/dev-references/testing/test_procedure.md) with 3.2.7+radio hardware and leaf_3_2_7_dev.