### PR TITLE
Improve Setting class for vario_sensitivity

### DIFF
--- a/src/vario/ui/settings/setting.h
+++ b/src/vario/ui/settings/setting.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <Preferences.h>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <type_traits>
+
+/// @brief Individual setting, regardless of data type.
+/// @tparam T Underlying data type of setting.
+/// @tparam DefaultValue Default value of setting.
+template <typename T, T DefaultValue>
+class Setting {
+ public:
+  using ChangeHandler = std::function<void(const T&)>;
+
+  // Constructor that captures a string literal or char array and enforces length at compile time
+  template <std::size_t N>
+  explicit Setting(const char (&key)[N]) : key_(key), value_(DefaultValue) {
+    static_assert(N > 0, "Key must not be empty");
+    static_assert(N - 1 <= 15, "Key must be at most 15 characters long");
+  }
+
+  // Fallback constructor for runtime-provided keys (kept for flexibility).
+  // We add a lightweight runtime check.
+  explicit Setting(const char* key) : key_(key), value_(DefaultValue) {
+    assert(key_ != nullptr && "Key pointer must not be null");
+    // Runtime guard (cheap). In production, replace with your own error handling if desired.
+    if (key_ && std::strlen(key_) > 15) {
+      // You can replace with fatalError("Preferences key too long") if you prefer.
+      assert(false && "Key must be at most 15 characters long");
+    }
+  }
+
+  static constexpr T defaultValue() { return DefaultValue; }
+
+  const char* key() const { return key_; }
+
+  // Set the value back to DefaultValue and fire onChange. Uses virtual operator=.
+  void loadDefault() { this->operator=(DefaultValue); }
+
+  // Virtual so derived classes can clamp/validate before storing
+  virtual Setting& operator=(const T& newValue) {
+    value_ = newValue;
+    if (onChangeHandler_) onChangeHandler_(value_);
+    return *this;
+  }
+
+  // Implicit conversion to the underlying type
+  operator T() const { return value_; }
+
+  void onChange(ChangeHandler handler) { onChangeHandler_ = std::move(handler); }
+
+  // Arduino Preferences is not const-correct; keep non-const refs
+  virtual void readFrom(Preferences& prefs) = 0;
+  virtual void putInto(Preferences& prefs) const = 0;
+
+ protected:
+  const char* const key_;
+  T value_;
+  ChangeHandler onChangeHandler_ = nullptr;
+};
+
+/// @brief Individual numeric setting with clamped assignment and ++/-- within bounds.
+/// @tparam T Underlying data type of setting.
+/// @tparam MinValue Minimum value setting may take on.
+/// @tparam DefaultValue Default value of setting.
+/// @tparam MaxValue Maximum value setting may take on.
+template <typename T, T MinValue, T DefaultValue, T MaxValue,
+          typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
+class NumericSetting : public Setting<T, DefaultValue> {
+  using Base = Setting<T, DefaultValue>;
+
+ public:
+  using Base::Base;  // inherit constructors (both compile-time and runtime key forms)
+
+  static constexpr T min() { return MinValue; }
+  static constexpr T max() { return MaxValue; }
+
+  static_assert(MinValue <= MaxValue, "NumericSetting: MinValue must be <= MaxValue");
+  static_assert(DefaultValue >= MinValue, "NumericSetting: DefaultValue must be >= MinValue");
+  static_assert(DefaultValue <= MaxValue, "NumericSetting: DefaultValue must be <= MaxValue");
+
+  // Override the base assignment to enforce bounds
+  Base& operator=(const T& newValue) override {
+    if (newValue >= MinValue && newValue <= MaxValue) {
+      return Base::operator=(newValue);
+    }
+    // Ignore out-of-range writes; keep existing value
+    return *this;
+  }
+
+  // Increment/decrement operators (prefix/postfix)
+  NumericSetting& operator++() {
+    if (this->value_ < MaxValue) Base::operator=(static_cast<T>(this->value_ + 1));
+    return *this;
+  }
+  NumericSetting operator++(int) {
+    auto tmp = *this;
+    ++(*this);
+    return tmp;
+  }
+
+  NumericSetting& operator--() {
+    if (this->value_ > MinValue) Base::operator=(static_cast<T>(this->value_ - 1));
+    return *this;
+  }
+  NumericSetting operator--(int) {
+    auto tmp = *this;
+    --(*this);
+    return tmp;
+  }
+};
+
+/// @brief Individual int8_t setting (stored as Preferences char).
+/// @tparam MinValue Minimum value setting may take on.
+/// @tparam DefaultValue Default value of setting.
+/// @tparam MaxValue Maximum value setting may take on.
+template <int8_t MinValue, int8_t DefaultValue, int8_t MaxValue>
+class CharSetting : public NumericSetting<int8_t, MinValue, DefaultValue, MaxValue> {
+  using Base = NumericSetting<int8_t, MinValue, DefaultValue, MaxValue>;
+
+ public:
+  using Base::Base;       // inherit constructor(s)
+  using Base::operator=;  // make Base::operator=(int8_t) visible
+
+  void readFrom(Preferences& prefs) override {
+    auto v = prefs.getChar(this->key(), Base::defaultValue());
+    Base::operator=(v);  // clamps/validates
+  }
+
+  void putInto(Preferences& prefs) const override {
+    prefs.putChar(this->key(), static_cast<char>(this->value_));
+  }
+};

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -63,7 +63,7 @@ void Settings::factoryResetVario() {
 void Settings::loadDefaults() {
   // Vario Settings
   vario_sinkAlarm = DEF_SINK_ALARM;
-  vario_sensitivity = vario_sensitivity.defaultValue();
+  vario_sensitivity.loadDefault();
   vario_climbAvg = DEF_CLIMB_AVERAGE;
   vario_climbStart = DEF_CLIMB_START;
   vario_volume = DEF_VOLUME_VARIO;
@@ -121,7 +121,7 @@ void Settings::retrieve() {
 
   // Vario Settings
   vario_sinkAlarm = leafPrefs.getChar("SINK_ALARM");
-  vario_sensitivity = leafPrefs.getChar("vario_sensitivity");
+  vario_sensitivity.readFrom(leafPrefs);
   vario_climbAvg = leafPrefs.getChar("CLIMB_AVERAGE");
   vario_climbStart = leafPrefs.getChar("CLIMB_START");
   vario_volume = leafPrefs.getChar("VOLUME_VARIO");
@@ -192,7 +192,7 @@ void Settings::save() {
 
   // Vario Settings
   leafPrefs.putChar("SINK_ALARM", vario_sinkAlarm);
-  leafPrefs.putChar("vario_sensitivity", vario_sensitivity);
+  vario_sensitivity.putInto(leafPrefs);
   leafPrefs.putChar("CLIMB_AVERAGE", vario_climbAvg);
   leafPrefs.putChar("CLIMB_START", vario_climbStart);
   leafPrefs.putChar("VOLUME_VARIO", vario_volume);

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -6,6 +6,7 @@
 
 #include "comms/fanet_radio_types.h"
 #include "ui/input/buttons.h"
+#include "ui/settings/setting.h"
 
 // Types for selections
 #define SETTING_LOG_FORMAT_ENTRIES 2  // How many log format entries there are
@@ -100,78 +101,6 @@ typedef uint8_t SettingLogFormat;
 #define DEF_UNITS_distance 0  // 0 (km, or m for <1km),	1 (miles, or ft for < 1000 feet)
 #define DEF_UNITS_hours 1     // 0 (24-hour time),  1 (12 hour time),
 
-/// @brief Individual setting.
-/// @tparam T Underlying data type of setting.
-/// @tparam MinValue Minimum value setting may take on.
-/// @tparam MaxValue Maximum value setting may take on.
-/// @tparam DefaultValue Default value of setting.
-template <typename T, T MinValue, T MaxValue, T DefaultValue>
-class Setting {
- public:
-  using ChangeHandler = std::function<void(const T&)>;
-
-  Setting() : value_(DefaultValue) {}
-
-  T min() { return MinValue; }
-  T max() { return MaxValue; }
-  T defaultValue() { return DefaultValue; }
-
-  // Assignment operator to set the value and trigger the callback
-  Setting& operator=(const T& newValue) {
-    if (value_ != newValue && newValue >= MinValue && newValue <= MaxValue) {
-      value_ = newValue;
-      if (onChangeHandler_) {
-        onChangeHandler_(value_);
-      }
-    }
-    return *this;
-  }
-
-  // Implicit conversion to the underlying type
-  operator T() const { return value_; }
-
-  // Attach a handler for value changes
-  void onChange(ChangeHandler handler) { onChangeHandler_ = handler; }
-
-  // Increment operator (prefix)
-  Setting& operator++() {
-    if (value_ + 1 <= MaxValue) {
-      *this = value_ + 1;
-    }
-    return *this;
-  }
-
-  // Increment operator (postfix)
-  Setting operator++(int) {
-    Setting temp = *this;
-    if (value_ + 1 <= MaxValue) {
-      *this = value_ + 1;
-    }
-    return temp;
-  }
-
-  // Decrement operator (prefix)
-  Setting& operator--() {
-    if (value_ - 1 >= MinValue) {
-      *this = value_ - 1;
-    }
-    return *this;
-  }
-
-  // Decrement operator (postfix)
-  Setting operator--(int) {
-    Setting temp = *this;
-    if (value_ - 1 >= MinValue) {
-      *this = value_ - 1;
-    }
-    return temp;
-  }
-
- private:
-  T value_;
-  ChangeHandler onChangeHandler_ = nullptr;
-};
-
 class Settings {
  public:
   // Global Variables for Current Settings
@@ -185,7 +114,7 @@ class Settings {
       4   |   3     |  3/20 second
       5   |   1     |  1/20 second (single sample -- instant)
   */
-  Setting<int8_t, 1, 5, 3> vario_sensitivity;
+  CharSetting<1, 3, 5> vario_sensitivity{"vSensitivity"};
   int8_t vario_climbAvg;
   int8_t vario_climbStart;
   int8_t vario_volume;


### PR DESCRIPTION
It turns out that ESP preferences fail to operate with keys longer than 15 characters, but the only indication of this is a message to the serial log (no false result, etc that is easily detectable by code).  Because of this, we have been failing to save and restore vario_sensitivity since I changed the key it uses to "vario_sensitivity".  This PR narrowly fixes that problem by changing the key to "vSensitivity" (keys can be anything as long as they're consistent).

While doing that, this PR also hardens and expands the Setting class (pulling it into a separate file for clarity) to prevent this kind of problem in the future for settings that use this family of classes.  This class set is also structured so that we can keep an array of generic settings and operate on that array rather than each setting individually (once settings have been migrated to use this class set).

Tested using the standard test procedure with 3.2.7+radio hardware using leaf_3_2_7_dev.  Also verified that changing vario sensitivity to a non-default value, turning unit off while not connected to USB, turning unit back on, and checking vario sensitivity shows the setting is retained (previously it was not retained in this procedure).