### PR TITLE
Route UDP messages to bus

### DIFF
--- a/sim/play_buslog.py
+++ b/sim/play_buslog.py
@@ -99,6 +99,7 @@ def main() -> int:
 
     try:
         send_packet(f"#Starting playback of {args.logfile}")
+        send_packet("!Disconnect sensors")
         send_packet("!Reset reference time")
         with open(args.logfile, "r", encoding=args.encoding, errors="replace") as f:
             for raw_line in f:
@@ -132,6 +133,11 @@ def main() -> int:
         if args.verbose:
             print("\nInterrupted. Exiting.")
     finally:
+        try:
+            send_packet("!Reconnect sensors")
+        except Exception as e:
+            print(f"Error reconnecting sensors: {e}")
+            pass
         try:
             sock.close()
         except Exception as e:

--- a/src/vario/comms/udp_message_server.cpp
+++ b/src/vario/comms/udp_message_server.cpp
@@ -2,14 +2,25 @@
 
 #include <Arduino.h>
 #include <AsyncUDP.h>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 
 #include "diagnostics/fatal_error.h"
+#include "dispatch/message_types.h"
+#include "hardware/aht20.h"
+#include "hardware/icm_20948.h"
+#include "hardware/lc86g.h"
+#include "hardware/ms5611.h"
 
 AsyncUDP udp;
 UDPMessageServer udpMessageServer;
 
+const uint16_t UDP_PORT = 7431;
+
 void UDPMessageServer::init() {
-  if (!udp.listen(7431)) {
+  if (!udp.listen(UDP_PORT)) {
     fatalError("Could not start async UDP server");
     return;
   }
@@ -52,17 +63,89 @@ namespace {
     size_t litLen = strlen(literal);
     return (len == litLen) && (memcmp(buf, literal, litLen) == 0);
   }
+
+  // Advance to next comma or end; returns [tok_begin, tok_end) and moves pos to character AFTER the
+  // comma (or len).
+  inline void next_field(const char* s, size_t len, size_t& pos, size_t& out_begin,
+                         size_t& out_end) {
+    out_begin = pos;
+    while (pos < len && s[pos] != ',') ++pos;
+    out_end = pos;
+    if (pos < len && s[pos] == ',') ++pos;  // skip comma for next call
+  }
+
+  // Convert substring [b,e) to signed long using strtol. Returns true on success.
+  inline bool to_long(const char* s, size_t b, size_t e, long& out) {
+    char buf[32];
+    size_t n = e - b;
+    if (n >= sizeof(buf)) return false;
+    memcpy(buf, s + b, n);
+    buf[n] = '\0';
+    char* endp = nullptr;
+    out = std::strtol(buf, &endp, 10);
+    return endp && *endp == '\0';
+  }
+
+  // Convert substring [b,e) to unsigned long using strtoul. Returns true on success.
+  inline bool to_ulong(const char* s, size_t b, size_t e, unsigned long& out) {
+    char buf[32];
+    size_t n = e - b;
+    if (n >= sizeof(buf)) return false;
+    memcpy(buf, s + b, n);
+    buf[n] = '\0';
+    char* endp = nullptr;
+    out = std::strtoul(buf, &endp, 10);
+    return endp && *endp == '\0';
+  }
+
+  // Convert substring [b,e) to double using strtod. Returns true on success.
+  inline bool to_double(const char* s, size_t b, size_t e, double& out) {
+    char buf[48];
+    size_t n = e - b;
+    if (n >= sizeof(buf)) return false;
+    memcpy(buf, s + b, n);
+    buf[n] = '\0';
+    char* endp = nullptr;
+    out = std::strtod(buf, &endp);
+    return endp && *endp == '\0';
+  }
+
+  // Convert substring [b,e) to float (via double for portability).
+  inline bool to_float(const char* s, size_t b, size_t e, float& out) {
+    double d;
+    if (!to_double(s, b, e, d)) return false;
+    out = static_cast<float>(d);
+    return true;
+  }
 }  // namespace
+
+unsigned long UDPMessageServer::getAdjustedTime(unsigned long dt) {
+  if (tStart_ == 0) {
+    tStart_ = millis() - dt;
+  }
+  return tStart_ + dt;
+}
 
 void UDPMessageServer::onComment(const char* line, size_t len) {
   Serial.print("Comment via UDP: ");
   Serial.write(line + 1, len - 1);
   Serial.println();
+  Serial.flush();
 }
 
 void UDPMessageServer::onCommand(const char* line, size_t len) {
-  if (equals_const(line, len, "!Disable sensors")) {
-    Serial.println("Disable sensors via UDP");
+  if (equals_const(line, len, "!Disconnect sensors")) {
+    Serial.println("Disconnecting HW sensors via UDP");
+    AHT20::getInstance().stopPublishing();
+    ICM20948::getInstance().stopPublishing();
+    lc86g.stopPublishing();
+    ms5611.stopPublishing();
+  } else if (equals_const(line, len, "!Reconnect sensors")) {
+    Serial.println("Reconnecting HW sensors via UDP");
+    AHT20::getInstance().publishTo(bus_);
+    ICM20948::getInstance().publishTo(bus_);
+    lc86g.publishTo(bus_);
+    ms5611.publishTo(bus_);
   } else if (equals_const(line, len, "!Reset reference time")) {
     tStart_ = 0;
     Serial.println("UDP server reference time reset");
@@ -74,15 +157,130 @@ void UDPMessageServer::onCommand(const char* line, size_t len) {
 }
 
 void UDPMessageServer::onAmbientUpdate(const char* line, size_t len) {
-  Serial.println("UDP Ambient");
+  etl::imessage_bus* bus = bus_;
+  if (!bus || !line || len < 3) return;  // minimal: 'A0,'
+  size_t pos = 0;
+
+  // Expect leading 'A'
+  if (line[0] != 'A') return;
+  ++pos;  // skip 'A'
+
+  // Parse delta-t
+  size_t b, e;
+  next_field(line, len, pos, b, e);
+  unsigned long dt = 0;
+  (void)to_ulong(line, b, e, dt);
+  (void)dt;  // AmbientUpdate doesn't carry time; parsed for validation only
+
+  // Parse temperature (float)
+  next_field(line, len, pos, b, e);
+  float temp = 0.0f;
+  (void)to_float(line, b, e, temp);
+
+  // Parse relative humidity (float)
+  next_field(line, len, pos, b, e);
+  float rh = 0.0f;
+  (void)to_float(line, b, e, rh);
+
+  bus->receive(AmbientUpdate(temp, rh));
 }
 
-void UDPMessageServer::onGPSMessage(const char* line, size_t len) { Serial.println("UDP GPS"); }
+void UDPMessageServer::onGPSMessage(const char* line, size_t len) {
+  etl::imessage_bus* bus = bus_;
+  if (!bus || !line || len < 3) return;
+  size_t pos = 0;
+
+  // Expect leading 'G'
+  if (line[0] != 'G') return;
+  ++pos;  // skip 'G'
+
+  // Parse delta-t
+  size_t b, e;
+  next_field(line, len, pos, b, e);
+  unsigned long dt = 0;
+  (void)to_ulong(line, b, e, dt);
+  (void)dt;  // GpsMessage doesn't carry time; parsed for validation only
+
+  bus->receive(GpsMessage(NMEAString(line + pos, len - pos)));
+}
 
 void UDPMessageServer::onMotionUpdate(const char* line, size_t len) {
-  Serial.println("UDP Motion");
+  etl::imessage_bus* bus = bus_;
+  if (!bus || !line || len < 3) return;  // minimal: 'M0,'
+  size_t pos = 0;
+
+  // Expect leading 'M'
+  if (line[0] != 'M') return;
+  ++pos;  // skip 'M'
+
+  size_t b, e;
+
+  // 1) delta-t
+  next_field(line, len, pos, b, e);
+  unsigned long dt = 0;
+  (void)to_ulong(line, b, e, dt);
+  unsigned long t = getAdjustedTime(dt);
+
+  MotionUpdate m(t);
+
+  // 2) accel presence flag ('A' or 'a')
+  next_field(line, len, pos, b, e);
+  char accelFlag = (b < e) ? line[b] : 'a';
+  m.hasAcceleration = (accelFlag == 'A');
+
+  // 3) ax, ay, az
+  double d = 0.0;
+  next_field(line, len, pos, b, e);
+  to_double(line, b, e, d);
+  m.ax = d;
+  next_field(line, len, pos, b, e);
+  to_double(line, b, e, d);
+  m.ay = d;
+  next_field(line, len, pos, b, e);
+  to_double(line, b, e, d);
+  m.az = d;
+
+  // 4) orientation presence flag ('Q' or 'q')
+  next_field(line, len, pos, b, e);
+  char oriFlag = (b < e) ? line[b] : 'q';
+  m.hasOrientation = (oriFlag == 'Q');
+
+  // 5) qx, qy, qz
+  next_field(line, len, pos, b, e);
+  to_double(line, b, e, d);
+  m.qx = d;
+  next_field(line, len, pos, b, e);
+  to_double(line, b, e, d);
+  m.qy = d;
+  next_field(line, len, pos, b, e);
+  to_double(line, b, e, d);
+  m.qz = d;
+
+  bus->receive(m);
 }
 
 void UDPMessageServer::onPressureUpdate(const char* line, size_t len) {
-  Serial.println("UDP Pressure");
+  etl::imessage_bus* bus = bus_;
+  if (!bus || !line || len < 3) return;  // minimal: 'P0,'
+  size_t pos = 0;
+
+  // Expect leading 'P'
+  if (line[0] != 'P') return;
+  ++pos;  // skip 'P'
+
+  size_t b, e;
+
+  // delta-t
+  next_field(line, len, pos, b, e);
+  unsigned long dt = 0;
+  (void)to_ulong(line, b, e, dt);
+
+  // pressure (int32)
+  next_field(line, len, pos, b, e);
+  long pLong = 0;
+  (void)to_long(line, b, e, pLong);
+
+  unsigned long t = getAdjustedTime(dt);
+  int32_t p = static_cast<int32_t>(pLong);
+  bus->receive(PressureUpdate(t, p));
 }

--- a/src/vario/comms/udp_message_server.h
+++ b/src/vario/comms/udp_message_server.h
@@ -10,10 +10,13 @@ class UDPMessageServer : public IMessageSource {
   void init();
 
   // IMessageSource
-  void attach(etl::imessage_bus* bus) { bus_ = bus; }
+  void publishTo(etl::imessage_bus* bus) { bus_ = bus; }
+  void stopPublishing() { bus_ = nullptr; }
 
  private:
   void onPacket(AsyncUDPPacket& packet);
+
+  unsigned long getAdjustedTime(unsigned long dt);
 
   void onComment(const char* line, size_t len);
   void onCommand(const char* line, size_t len);

--- a/src/vario/dispatch/message_source.h
+++ b/src/vario/dispatch/message_source.h
@@ -4,9 +4,11 @@
 
 class IMessageSource {
  public:
-  // Attach this object to the specified message bus and this object will provide messages to the
-  // specified message bus.
-  virtual void attach(etl::imessage_bus* bus) = 0;
+  // Publish messages to the specified message bus.
+  virtual void publishTo(etl::imessage_bus* bus) = 0;
+
+  // Do not publish messages to message bus any more.
+  virtual void stopPublishing() = 0;
 
   virtual ~IMessageSource() = default;  // Always provide a virtual destructor
 };

--- a/src/vario/hardware/aht20.cpp
+++ b/src/vario/hardware/aht20.cpp
@@ -94,8 +94,9 @@ void AHT20::update() {
       Serial.print("  Humidity: ");
       Serial.println(rh);
     }
-    if (bus_) {
-      bus_->receive(AmbientUpdate(temperature, rh));
+    etl::imessage_bus* bus = bus_;
+    if (bus) {
+      bus->receive(AmbientUpdate(temperature, rh));
     }
   } else {
     if (DEBUG_TEMPRH) Serial.println("Temp_RH - missed values due to sensor busy");

--- a/src/vario/hardware/aht20.h
+++ b/src/vario/hardware/aht20.h
@@ -23,7 +23,8 @@ class AHT20 : public IPollable, IMessageSource {
   void update();
 
   // IMessageSource
-  void attach(etl::imessage_bus* bus) { bus_ = bus; }
+  void publishTo(etl::imessage_bus* bus) { bus_ = bus; }
+  void stopPublishing() { bus_ = nullptr; }
 
   /// @brief Get the singleton AHT20 instance
   static AHT20& getInstance() {

--- a/src/vario/hardware/icm_20948.cpp
+++ b/src/vario/hardware/icm_20948.cpp
@@ -91,8 +91,9 @@ void ICM20948::update() {
       update.az = ((double)data.Raw_Accel.Data.Z) / 8192.0;
       update.hasAcceleration = true;
     }
-    if (update.hasOrientation || update.hasAcceleration && bus_) {
-      bus_->receive(update);
+    etl::imessage_bus* bus = bus_;
+    if ((update.hasOrientation || update.hasAcceleration) && bus) {
+      bus->receive(update);
     }
   }
 }

--- a/src/vario/hardware/icm_20948.h
+++ b/src/vario/hardware/icm_20948.h
@@ -13,7 +13,8 @@ class ICM20948 : public IPollable, IMessageSource {
   void update();
 
   // IMessageSource
-  void attach(etl::imessage_bus* bus) { bus_ = bus; }
+  void publishTo(etl::imessage_bus* bus) { bus_ = bus; }
+  void stopPublishing() { bus_ = nullptr; }
 
   /// @brief Get the singleton ICM 20948 instance
   static ICM20948& getInstance() {

--- a/src/vario/hardware/lc86g.cpp
+++ b/src/vario/hardware/lc86g.cpp
@@ -89,8 +89,9 @@ bool LC86G::readLine() {
       newLine_[newLineIndex_] = '\0';
       if (newLineIndex_ > 0) {  // Ignore blank lines and second character in CR+LF
         newLine_.resize(newLineIndex_);
-        if (bus_) {
-          bus_->receive(GpsMessage(newLine_));  // Send the complete NMEA sentence to the bus
+        etl::imessage_bus* bus = bus_;
+        if (bus) {
+          bus->receive(GpsMessage(newLine_));  // Send the complete NMEA sentence to the bus
         }
         newLine_.resize(newLine_.capacity());
         newLineIndex_ = 0;

--- a/src/vario/hardware/lc86g.h
+++ b/src/vario/hardware/lc86g.h
@@ -22,7 +22,8 @@ class LC86G : IPowerControl, IMessageSource {
   void wake();
 
   // IMessageSource
-  void attach(etl::imessage_bus* bus) { bus_ = bus; }
+  void publishTo(etl::imessage_bus* bus) { bus_ = bus; }
+  void stopPublishing() { bus_ = nullptr; }
 
  private:
   HardwareSerial& gpsPort_;

--- a/src/vario/hardware/ms5611.cpp
+++ b/src/vario/hardware/ms5611.cpp
@@ -122,8 +122,9 @@ void MS5611::update() {
         state_ = MS5611State::MeasuringTemperature;
         return;
       } else {
-        if (bus_) {
-          bus_->receive(getUpdate());
+        etl::imessage_bus* bus = bus_;
+        if (bus) {
+          bus->receive(getUpdate());
         }
         state_ = MS5611State::Idle;
         return;
@@ -141,8 +142,9 @@ void MS5611::update() {
         D2_T_ = D2_Tlast_;  // use the last value if we get a misread
       else
         D2_Tlast_ = D2_T_;  // otherwise save this value for next time if needed
-      if (bus_) {
-        bus_->receive(getUpdate());
+      etl::imessage_bus* bus = bus_;
+      if (bus) {
+        bus->receive(getUpdate());
       }
       state_ = MS5611State::Idle;
       return;

--- a/src/vario/hardware/ms5611.h
+++ b/src/vario/hardware/ms5611.h
@@ -23,7 +23,8 @@ class MS5611 : public IMessageSource, IPollable {
   void init();
 
   // IMessageSource
-  void attach(etl::imessage_bus* bus) { bus_ = bus; }
+  void publishTo(etl::imessage_bus* bus) { bus_ = bus; }
+  void stopPublishing() { bus_ = nullptr; }
 
   // IPollable
   void update();

--- a/src/vario/instruments/gps.h
+++ b/src/vario/instruments/gps.h
@@ -60,7 +60,8 @@ class LeafGPS : public TinyGPSPlus,
   void update();
 
   // IMessageSource
-  void attach(etl::imessage_bus* bus) { bus_ = bus; }
+  void publishTo(etl::imessage_bus* bus) { bus_ = bus; }
+  void stopPublishing() { bus_ = nullptr; }
 
   // etl::message_router<LeafGPS, GpsMessage>
   void on_receive(const GpsMessage& msg);

--- a/src/vario/logbook/bus.cpp
+++ b/src/vario/logbook/bus.cpp
@@ -37,7 +37,7 @@ void Bus::on_receive(const AmbientUpdate& msg) {
 
 void Bus::on_receive(const GpsMessage& msg) {
   if (!file) return;
-  file.printf("G%d,%d,%s\n", millis() - tStart_, msg.nmea.length(), msg.nmea.c_str());
+  file.printf("G%d,%s\n", millis() - tStart_, msg.nmea.c_str());
 }
 
 void Bus::on_receive(const MotionUpdate& msg) {

--- a/src/vario/main.cpp
+++ b/src/vario/main.cpp
@@ -44,13 +44,13 @@ void setup() {
   FanetRadio::getInstance().setup(&bus);
 #endif
 
-  AHT20::getInstance().attach(&bus);
-  ICM20948::getInstance().attach(&bus);
-  lc86g.attach(&bus);
-  ms5611.attach(&bus);
+  AHT20::getInstance().publishTo(&bus);
+  ICM20948::getInstance().publishTo(&bus);
+  lc86g.publishTo(&bus);
+  ms5611.publishTo(&bus);
 
 #ifdef DEBUG_WIFI
-  udpMessageServer.attach(&bus);
+  udpMessageServer.publishTo(&bus);
 #endif
 
   baro.subscribe(&bus);
@@ -70,7 +70,7 @@ void setup() {
   // Connect GPS instrument to message bus sourcing lines of text that should be NMEA sentences
   gps.subscribe(&bus);
   // Publish parsed GPS messages to message bus
-  gps.attach(&bus);
+  gps.publishTo(&bus);
 
   // Connect ambient environment instrument to message bus sourcing ambient environment updates
   ambient.subscribe(&bus);


### PR DESCRIPTION
This PR finishes the MVP for sensor data injection via message bus -- with it, the user can now record messages using the BUS format Log (this will probably be moved somewhere else in the future), and then play the captured bus log file back from a PC over UDP to the leaf and leaf will behave as if it was seeing real sensor data.

This is primarily accomplished by adding parsing logic to UDPMessageServer for all four message types currently supported.  Some UDP commands are tweaked, and the most important precondition is implemented: the ability to disconnect the hardware sensors from the bus while playback is happening.  A reconnect UDP command is also implemented, and the Python playback script sends this command at the end of playback.

The IMessageSource interface is adjusted to include a `stopPublishing()` method, and that is used on the hardware sensors to stop them (so, the hardware sensors still get polled and still generate data, but that data is discarded rather than distributed through the message bus).  IMessageSource.attach is also renamed to publishTo for clarity.

Finally, a potential compare-write race condition is mitigated by grabbing the current `bus_` once and then performing both the comparison and write on the local reference.

294010217349835dc38e8439442d2346608f61a1 was tested on 3.2.7+radio hardware using leaf_3_2_7_dev via the standard test procedure.  Just before activating the flight timer, I started bus log playback.  I also had Log set to log to BUS, so I re-recorded the information played back to leaf.  Everything on leaf seemed to respond correctly qualitatively (showing climb initially, then descent -- like the real bus log I was playing back).  The flight summary looked good except the speed still indicated 0 (not a new problem).  I checked the SD card afterward and a new bus log was captured successfully.