### PR TITLE
Fix speed in flight summary dialog

### DIFF
--- a/src/vario/utils/string_utils.cpp
+++ b/src/vario/utils/string_utils.cpp
@@ -104,7 +104,7 @@ String formatSpeed(float speed, bool units, bool showUnits) {
   else
     speed *= 3.6f;  // convert to kph
 
-  snprintf(buffer, sizeof(buffer), "%3d", speed);
+  snprintf(buffer, sizeof(buffer), "%.0f", speed);
 
   String result = String(buffer);
   if (showUnits) result += String(unitSymbol);


### PR DESCRIPTION
Previously, the max speed shown in the flight summary dialog was always 0.  This PR fixes that problem.

Tested by getting a fix, starting a flight, running around, stopping the flight, and verifying the dialog showed >0 max speed.