### PR TITLE
Add Hidden Dev Menu

### DIFF
--- a/src/vario/ui/display/pages.cpp
+++ b/src/vario/ui/display/pages.cpp
@@ -1,6 +1,7 @@
 #include "ui/display/pages.h"
 
 #include "ui/display/pages/menu/page_menu_altimeter.h"
+#include "ui/display/pages/menu/page_menu_developer.h"
 #include "ui/display/pages/menu/page_menu_display.h"
 #include "ui/display/pages/menu/page_menu_gps.h"
 #include "ui/display/pages/menu/page_menu_log.h"
@@ -18,3 +19,4 @@ UnitsMenuPage unitsMenuPage;
 GPSMenuPage gpsMenuPage;
 LogMenuPage logMenuPage;
 SystemMenuPage systemMenuPage;
+DeveloperMenuPage developerMenuPage;

--- a/src/vario/ui/display/pages.h
+++ b/src/vario/ui/display/pages.h
@@ -2,6 +2,7 @@
 #define PAGES_H
 
 #include "ui/display/pages/menu/page_menu_altimeter.h"
+#include "ui/display/pages/menu/page_menu_developer.h"
 #include "ui/display/pages/menu/page_menu_display.h"
 #include "ui/display/pages/menu/page_menu_gps.h"
 #include "ui/display/pages/menu/page_menu_log.h"
@@ -19,5 +20,6 @@ extern UnitsMenuPage unitsMenuPage;
 extern GPSMenuPage gpsMenuPage;
 extern LogMenuPage logMenuPage;
 extern SystemMenuPage systemMenuPage;
+extern DeveloperMenuPage developerMenuPage;
 
 #endif

--- a/src/vario/ui/display/pages/menu/page_menu_developer.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_developer.cpp
@@ -1,0 +1,114 @@
+#include "ui/display/pages/menu/page_menu_developer.h"
+
+#include <Arduino.h>
+
+#include "logging/log.h"
+#include "ui/audio/sound_effects.h"
+#include "ui/audio/speaker.h"
+#include "ui/display/display.h"
+#include "ui/display/display_fields.h"
+#include "ui/display/fonts.h"
+#include "ui/display/pages.h"
+#include "ui/input/buttons.h"
+#include "ui/settings/settings.h"
+
+enum developer_menu_items {
+  cursor_developer_back,
+  cursor_developer_startupStart,
+  cursor_developer_startupDisconnect,
+  cursor_developer_busLogControl
+};
+
+void DeveloperMenuPage::draw() {
+  u8g2.firstPage();
+  do {
+    // Title
+    display_menuTitle("DEVELOPER");
+
+    // Menu Items
+    uint8_t start_y = 29;
+    uint8_t y_spacing = 16;
+    uint8_t setting_name_x = 2;
+    uint8_t setting_choice_x = 76;
+    uint8_t menu_items_y[] = {190, 60, 75, 135};
+
+    // first draw cursor selection box
+    uint8_t largerChoiceSize = 0;
+    if (cursor_position == cursor_developer_busLogControl) {
+      largerChoiceSize = 12;  // make the bus logger control button larger
+    }
+    u8g2.drawRBox(setting_choice_x - 4 - largerChoiceSize, menu_items_y[cursor_position] - 14,
+                  30 + largerChoiceSize, 16, 2);
+
+    // draw On Startup Category
+    u8g2.setCursor(0, 45);
+    u8g2.print("On Startup:");
+
+    // then draw all the menu items
+    for (int i = 0; i <= cursor_max; i++) {
+      u8g2.setCursor(setting_name_x, menu_items_y[i]);
+      u8g2.print(labels[i]);
+      u8g2.setCursor(setting_choice_x, menu_items_y[i]);
+      if (i == cursor_position)
+        u8g2.setDrawColor(0);
+      else
+        u8g2.setDrawColor(1);
+      switch (i) {
+        case cursor_developer_startupStart:
+          if (settings.dev_startLogAtBoot)
+            u8g2.print(char(125));
+          else
+            u8g2.print(char(123));
+          break;
+        case cursor_developer_startupDisconnect:
+          if (settings.dev_startDisconnected)
+            u8g2.print(char(125));
+          else
+            u8g2.print(char(123));
+          break;
+        case cursor_developer_busLogControl:
+          u8g2.setCursor(u8g2.getCursorX() - 18, u8g2.getCursorY());
+          if (0)  // if bus logger is running
+            u8g2.print("STOP");
+          else
+            u8g2.print("START");
+          break;
+        case cursor_developer_back:
+          u8g2.print((char)124);
+          break;
+      }
+      u8g2.setDrawColor(1);
+    }
+  } while (u8g2.nextPage());
+}
+
+void DeveloperMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
+  switch (cursor_position) {
+    case cursor_developer_startupStart: {
+      if (state == RELEASED) settings.toggleBoolOnOff(&settings.dev_startLogAtBoot);
+      break;
+    }
+    case cursor_developer_startupDisconnect: {
+      if (state == RELEASED) settings.toggleBoolOnOff(&settings.dev_startDisconnected);
+      break;
+    }
+    case cursor_developer_busLogControl: {
+      if (state == RELEASED) delay(1);
+      break;
+    }
+    case cursor_developer_back: {
+      if (state == RELEASED) {
+        speaker.playSound(fx::cancel);
+        settings.save();
+        mainMenuPage.backToMainMenu();
+      } else if (state == HELD) {
+        speaker.playSound(fx::exit);
+        settings.save();
+        mainMenuPage.quitMenu();
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}

--- a/src/vario/ui/display/pages/menu/page_menu_developer.h
+++ b/src/vario/ui/display/pages/menu/page_menu_developer.h
@@ -1,0 +1,24 @@
+#ifndef PageMenuDeveloper_h
+#define PageMenuDeveloper_h
+
+#include <Arduino.h>
+
+#include "ui/display/menu_page.h"
+#include "ui/input/buttons.h"
+
+class DeveloperMenuPage : public SettingsMenuPage {
+ public:
+  DeveloperMenuPage() {
+    cursor_position = 0;
+    cursor_max = 3;
+  }
+  void draw();
+
+ protected:
+  void setting_change(Button dir, ButtonState state, uint8_t count);
+
+ private:
+  static constexpr char* labels[8] = {"Back", "Start Log", "HW-Discon", "Log Now:"};
+};
+
+#endif

--- a/src/vario/ui/display/pages/menu/page_menu_system.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_system.cpp
@@ -253,6 +253,16 @@ void SystemMenuPage::setting_change(Button dir, ButtonState state, uint8_t count
       if (state == RELEASED) {
         speaker.playSound(fx::confirm);
         about_page.show();
+      } else if (state == HELD && count == 4) {
+        // toggle developer mode
+        settings.toggleBoolOnOff(&settings.dev_menu);
+
+        // ..and if dev mode is now off, turn off logger settings too
+        if (!settings.dev_menu) {
+          settings.dev_startLogAtBoot = false;
+          settings.dev_startDisconnected = false;
+          // TODO: stop bus log if it's running
+        }
       }
       break;
   }

--- a/src/vario/ui/display/pages/primary/page_menu_main.cpp
+++ b/src/vario/ui/display/pages/primary/page_menu_main.cpp
@@ -20,7 +20,8 @@ enum cursor_main_menu {
   cursor_units,
   cursor_gps,
   cursor_log,
-  cursor_system
+  cursor_system,
+  cursor_developer,
 };
 
 // all submenu pages and confirmation dialogs
@@ -33,6 +34,7 @@ enum display_menu_pages {
   page_menu_gps,
   page_menu_log,
   page_menu_system,
+  page_menu_developer,
   page_menu_resetConfirm,
 };
 
@@ -76,6 +78,8 @@ void MainMenuPage::draw() {
     case page_menu_system:
       systemMenuPage.draw();
       break;
+    case page_menu_developer:
+      developerMenuPage.draw();
   }
 }
 
@@ -89,13 +93,18 @@ void MainMenuPage::draw_main_menu() {
     uint8_t start_y = 29;
     uint8_t setting_name_x = 2;
     uint8_t setting_choice_x = 72;
-    uint8_t menu_items_y[] = {190, 45, 60, 75, 90, 105, 120, 135};
+    uint8_t menu_items_y[] = {190, 45, 60, 75, 90, 105, 120, 135, 150};
 
     // first draw cursor selection box
     u8g2.drawRBox(setting_choice_x - 10, menu_items_y[cursor_position] - 14, 34, 16, 2);
 
     // then draw all the menu items
     for (int i = 0; i <= cursor_max; i++) {
+      // hide developer menu if not in dev mode
+      if (i == cursor_developer && !settings.dev_menu) {
+        break;  // skip drawing this menu item
+      }
+
       u8g2.setCursor(setting_name_x, menu_items_y[i]);
       u8g2.print(labels[i]);
       u8g2.setCursor(setting_choice_x, menu_items_y[i]);
@@ -158,6 +167,11 @@ void MainMenuPage::menu_item_action(Button button) {
         menu_page = page_menu_system;
       }
       break;
+    case cursor_developer:
+      if (button == Button::RIGHT || button == Button::CENTER) {
+        menu_page = page_menu_developer;
+      }
+      break;
   }
 }
 
@@ -167,12 +181,18 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonState state, uint8_t
     case Button::UP:
       if (state == RELEASED) {
         cursor_prev();
+        if (cursor_position == cursor_developer && !settings.dev_menu) {
+          cursor_prev();  // skip developer menu if not in dev mode
+        }
         redraw = true;
       }
       break;
     case Button::DOWN:
       if (state == RELEASED) {
         cursor_next();
+        if (cursor_position == cursor_developer && !settings.dev_menu) {
+          cursor_next();  // skip developer menu if not in dev mode
+        }
         redraw = true;
       }
       break;
@@ -215,6 +235,9 @@ bool MainMenuPage::button_event(Button button, ButtonState state, uint8_t count)
       break;
     case page_menu_system:
       redraw = systemMenuPage.button_event(button, state, count);
+      break;
+    case page_menu_developer:
+      redraw = developerMenuPage.button_event(button, state, count);
       break;
   }
   return redraw;

--- a/src/vario/ui/display/pages/primary/page_menu_main.h
+++ b/src/vario/ui/display/pages/primary/page_menu_main.h
@@ -10,7 +10,7 @@ class MainMenuPage : public MenuPage {
  public:
   MainMenuPage() {
     cursor_position = 0;
-    cursor_max = 7;
+    cursor_max = 8;
   }
   bool button_event(Button button, ButtonState state, uint8_t count);
   void draw();
@@ -21,8 +21,8 @@ class MainMenuPage : public MenuPage {
   void draw_main_menu();
   bool mainMenuButtonEvent(Button button, ButtonState state, uint8_t count);
   void menu_item_action(Button dir);
-  static constexpr char* labels[8] = {"Back",  "Altimeter", "Vario",     "Display",
-                                      "Units", "GPS",       "Log/Timer", "System"};
+  static constexpr char* labels[9] = {"Back", "Altimeter", "Vario",  "Display",  "Units",
+                                      "GPS",  "Log/Timer", "System", "Developer"};
 };
 
 #endif

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -90,6 +90,11 @@ void Settings::loadDefaults() {
   system_bluetoothOn = DEF_BLUETOOTH_ON;
   system_showWarning = DEF_SHOW_WARNING;
 
+  // Developer Options
+  dev_menu = DEF_DEV_MENU;
+  dev_startLogAtBoot = DEF_DEV_START_LOG_AT_BOOT;
+  dev_startDisconnected = DEF_DEV_START_DISCONNECTED;
+
   // Boot Flags
   boot_enterBootloader = DEF_ENTER_BOOTLOAD;
   boot_toOnState = DEF_BOOT_TO_ON;
@@ -147,6 +152,9 @@ void Settings::retrieve() {
   system_wifiOn = leafPrefs.getBool("WIFI_ON");
   system_bluetoothOn = leafPrefs.getBool("BLUETOOTH_ON");
   system_showWarning = leafPrefs.getBool("SHOW_WARNING");
+  dev_menu = leafPrefs.getBool("DEVELOPER_MENU");
+  dev_startLogAtBoot = leafPrefs.getBool("DEV_STARTLOG");
+  dev_startDisconnected = leafPrefs.getBool("DEV_STARTDISCON");
 
   // Boot Flags
   boot_enterBootloader = leafPrefs.getBool("ENTER_BOOTLOAD");
@@ -216,6 +224,10 @@ void Settings::save() {
   leafPrefs.putBool("WIFI_ON", system_wifiOn);
   leafPrefs.putBool("BLUETOOTH_ON", system_bluetoothOn);
   leafPrefs.putBool("SHOW_WARNING", system_showWarning);
+  // Developer Options
+  leafPrefs.putBool("DEVELOPER_MENU", dev_menu);
+  leafPrefs.putBool("DEV_STARTLOG", dev_startLogAtBoot);
+  leafPrefs.putBool("DEV_STARTDISCON", dev_startDisconnected);
   // Boot Flags
   leafPrefs.putBool("ENTER_BOOTLOAD", boot_enterBootloader);
   leafPrefs.putBool("BOOT_TO_ON", boot_toOnState);

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -74,6 +74,11 @@ typedef uint8_t SettingLogFormat;
 #define DEF_BLUETOOTH_ON 0   // default bluetooth off
 #define DEF_SHOW_WARNING 1   // default show warning on startup
 
+// Developer Settings
+#define DEF_DEV_MENU 0                // default hide the dev menu
+#define DEF_DEV_START_LOG_AT_BOOT 0   // default do not start log at boot
+#define DEF_DEV_START_DISCONNECTED 0  // default do not disconnect hardware at boot
+
 // Boot Flags
 // Boot-to-ON Flag (when resetting from system updates,
 // reboot to "ON" even if not holding power button)
@@ -104,7 +109,6 @@ typedef uint8_t SettingLogFormat;
 
 class Settings {
  public:
-  // Global Variables for Current Settings
   // Vario Settings
   int8_t vario_sinkAlarm;
   /* Vario Sensitivity
@@ -141,6 +145,11 @@ class Settings {
   bool system_wifiOn;
   bool system_bluetoothOn;
   bool system_showWarning;
+
+  // developer options
+  bool dev_menu;
+  bool dev_startLogAtBoot;
+  bool dev_startDisconnected;
 
   // Boot Flags
   bool boot_enterBootloader;


### PR DESCRIPTION
Add top level menu for "Developer Options"

This menu is hidden by default, according to the settings.dev_menu flag.

To turn on/off the dev_menu, navigate to the System Menu, then highlight "About ->" and hold down for ~4 seconds. 