### PR TITLE
Track and use Ambient state

### DIFF
--- a/src/vario/instruments/ambient.cpp
+++ b/src/vario/instruments/ambient.cpp
@@ -2,11 +2,49 @@
 
 #include "etl/message_bus.h"
 
+#include "diagnostics/fatal_error.h"
 #include "dispatch/message_types.h"
+
+namespace {
+  constexpr unsigned long MAXIMUM_FRESH_DURATION_MS = 15000;
+}
 
 void Ambient::on_receive(const AmbientUpdate& msg) {
   temperature_ = msg.temperature;
   relativeHumidity_ = msg.relativeHumidity;
+  lastMeasurement_ = millis();
+}
+
+Ambient::State Ambient::state() const {
+  if (lastMeasurement_ == 0) {
+    return State::NoData;
+  } else if (millis() - lastMeasurement_ > MAXIMUM_FRESH_DURATION_MS) {
+    return State::Stale;
+  } else {
+    return State::Ready;
+  }
+}
+
+void Ambient::onUnexpectedState(const char* action, State actual) const {
+  if (actual == State::NoData) {
+    fatalError("%s without data", action);
+  } else if (actual == State::Ready) {
+    fatalError("%s while ready", action);
+  } else if (actual == State::Stale) {
+    fatalError("%s with %lums stale data", action, millis() - lastMeasurement_);
+  } else {
+    fatalError("%s in unknown state %d", action, actual);
+  }
+}
+
+float Ambient::temp() const {
+  assertState("Ambient::temp() called", State::Ready, State::Stale);
+  return temperature_;
+}
+
+float Ambient::humidity() const {
+  assertState("Ambient::humidity() called", State::Ready, State::Stale);
+  return relativeHumidity_;
 }
 
 Ambient ambient;

--- a/src/vario/instruments/ambient.h
+++ b/src/vario/instruments/ambient.h
@@ -3,24 +3,34 @@
 #include "etl/message_bus.h"
 
 #include "dispatch/message_types.h"
+#include "utils/state_assert_mixin.h"
 
-class Ambient : public etl::message_router<Ambient, AmbientUpdate> {
+class Ambient : public etl::message_router<Ambient, AmbientUpdate>,
+                private StateAssertMixin<Ambient> {
  public:
+  enum class State : uint8_t { NoData, Ready, Stale };
+
+  State state() const;
+
   void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
 
   // Get the most recent temperature in degrees Celsius
-  float getTemp() { return relativeHumidity_; }
+  float temp() const;
 
   // Get the most recent relative humidity in percent
-  float getHumidity() { return temperature_; }
+  float humidity() const;
 
   // etl::message_router<Ambient, AmbientUpdate>
   void on_receive(const AmbientUpdate& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
 
  private:
+  void onUnexpectedState(const char* c, State s) const;
+  friend struct StateAssertMixin<Ambient>;
+
   float temperature_;
   float relativeHumidity_;
+  unsigned long lastMeasurement_ = 0;
 };
 
 extern Ambient ambient;

--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -282,7 +282,9 @@ void log_captureValues() {
   logbook.alt_above_launch = baro.altAboveLaunch;
   logbook.climb = baro.climbRateFiltered;
   logbook.speed = gps.speed.mps();
-  logbook.temperature = ambient.getTemp();
+  if (ambient.state() == Ambient::State::Ready) {
+    logbook.temperature = ambient.temp();
+  }
   logbook.accel = imu.getAccel();
 }
 
@@ -309,11 +311,13 @@ void log_checkMinMaxValues() {
   }
 
   // check temperature values for log records
-  logbook.temperature = ambient.getTemp();
-  if (logbook.temperature > logbook.temperature_max) {
-    logbook.temperature_max = logbook.temperature;
-  } else if (logbook.temperature < logbook.temperature_min) {
-    logbook.temperature_min = logbook.temperature;
+  if (ambient.state() == Ambient::State::Ready) {
+    logbook.temperature = ambient.temp();
+    if (logbook.temperature > logbook.temperature_max) {
+      logbook.temperature_max = logbook.temperature;
+    } else if (logbook.temperature < logbook.temperature_min) {
+      logbook.temperature_min = logbook.temperature;
+    }
   }
 
   // check accel / g-force for log records

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -4,6 +4,7 @@
 #include <U8g2lib.h>
 
 #include "comms/fanet_radio.h"
+#include "instruments/ambient.h"
 #include "instruments/baro.h"
 #include "instruments/gps.h"
 #include "leaf_version.h"
@@ -590,28 +591,38 @@ void display_glide(uint8_t x, uint8_t y, float glide) {
   }
 }
 
-void display_temp(uint8_t x, uint8_t y, int16_t temperature) {
+void display_temp(uint8_t x, uint8_t y, const Ambient& ambient) {
   u8g2.setCursor(x, y);
   u8g2.setDrawColor(1);
   u8g2.setFont(leaf_6x12);
 
-  if (settings.units_temp) {
-    temperature = temperature * 9 / 5 + 32;
-    u8g2.print(temperature);
-    u8g2.print((char)134);
+  if (ambient.state() == Ambient::State::Ready) {
+    int16_t temperature = ambient.temp();
+    if (settings.units_temp) {
+      temperature = temperature * 9 / 5 + 32;
+      u8g2.print(temperature);
+      u8g2.print((char)134);
+    } else {
+      u8g2.print(temperature);
+      u8g2.print((char)133);
+    }
   } else {
-    u8g2.print(temperature);
-    u8g2.print((char)133);
+    u8g2.print("--");
   }
 }
 
-void display_humidity(uint8_t x, uint8_t y, uint8_t humidity) {
+void display_humidity(uint8_t x, uint8_t y, const Ambient& ambient) {
   u8g2.setCursor(x, y);
   u8g2.setDrawColor(1);
   u8g2.setFont(leaf_6x12);
 
-  u8g2.print(humidity);
-  u8g2.print('%');
+  if (ambient.state() == Ambient::State::Ready) {
+    uint8_t humidity = (uint8_t)ambient.humidity();
+    u8g2.print(humidity);
+    u8g2.print('%');
+  } else {
+    u8g2.print("--%");
+  }
 }
 
 void display_battIcon(uint8_t x, uint8_t y, bool vertical) {

--- a/src/vario/ui/display/display_fields.h
+++ b/src/vario/ui/display/display_fields.h
@@ -3,6 +3,8 @@
 
 #include <Arduino.h>
 
+#include "instruments/ambient.h"
+
 void display_selectionBox(uint8_t x, uint8_t y, uint8_t w, uint8_t h, uint8_t tri);
 
 void display_clockTime(uint8_t x, uint8_t y, bool show_ampm);
@@ -48,8 +50,8 @@ void display_unsignedClimbRate_short(uint8_t x, uint8_t y, int16_t displayClimbR
 
 void display_accel(uint8_t x, uint8_t y, float accel);
 void display_glide(uint8_t x, uint8_t y, float glide);
-void display_temp(uint8_t x, uint8_t y, int16_t temperature);
-void display_humidity(uint8_t x, uint8_t y, uint8_t temperature);
+void display_temp(uint8_t x, uint8_t y, const Ambient& ambient);
+void display_humidity(uint8_t x, uint8_t y, const Ambient& ambient);
 
 void display_battIcon(uint8_t x, uint8_t y, bool vertical);
 void display_batt_charging_fullscreen(uint8_t x, uint8_t y);

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -141,12 +141,12 @@ void drawUserField(uint8_t x, uint8_t y, uint8_t field, bool selected) {
       u8g2.setCursor(x, y - 14);
       u8g2.setFont(leaf_5h);
       u8g2.print("TEMP");
-      display_temp(x + 2, y, (int16_t)ambient.getTemp());
+      display_temp(x + 2, y, ambient);
       // Humidity
       u8g2.setCursor(x + 32, y - 14);
       u8g2.setFont(leaf_5h);
       u8g2.print("HUMID");
-      display_humidity(x + 34, y, (uint8_t)ambient.getHumidity());
+      display_humidity(x + 34, y, ambient);
       break;
     case static_cast<int>(ThermalPageUserFields::ACCEL):
       // Acceleration

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -89,8 +89,8 @@ void thermalPageAdv_draw() {
     u8g2.drawHLine(varioBarWidth - 1, userFieldsBottom, 96 - varioBarWidth + 1);
     u8g2.drawVLine(userSecondColumn, userFieldsTop, userFieldsHeight * 2);
 
-    display_temp(varioBarWidth + 5, userFieldsMid - 1, (int16_t)ambient.getTemp());
-    display_humidity(userSecondColumn + 3, userFieldsMid - 1, (uint8_t)ambient.getHumidity());
+    display_temp(varioBarWidth + 5, userFieldsMid - 1, ambient);
+    display_humidity(userSecondColumn + 3, userFieldsMid - 1, ambient);
     display_accel(varioBarWidth + 5, userFieldsBottom - 1, imu.getAccel());
     display_glide(userSecondColumn + 3, userFieldsBottom - 1, gps.getGlideRatio());
 

--- a/src/vario/utils/state_assert_mixin.h
+++ b/src/vario/utils/state_assert_mixin.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <type_traits>
+#include <utility>
+
+/// @brief Apply to a class to provide an assertState(caller, ... expected states) method.
+/// @tparam Derived Name of class being mixed into.
+/// @details The class to which this mixin is applied must provide:
+/// void onUnexpectedState(const char* action, TState actual)
+///   Method defining what to do when an unexpected state is encountered while attempting to perform
+///   the specified action.  This method must be marked with:
+///     friend struct StateAssertMixin<Derived>;
+/// void TState state()
+///   Method returning current state of object.
+/// @example As applied to a Foo class:
+/// class Foo : StateAssertMixin<Foo> {
+///  public:
+///   enum class State : uint8_t { State1, State2, State3}
+///   State state() const { ... }
+///   void doThing() {
+///     assertState("doThing", State2, State3);  // Ensures Foo is in State2 or State3 here
+///     ...
+///   }
+///  private:
+///   void onUnexpectedState(const char* action, State actual) {
+///     fatalError("Attempted to %s while state was %d", action, actual);
+///   }
+///   friend struct StateAssertMixin<Ambient>;
+/// };
+template <class Derived>
+struct StateAssertMixin {
+ protected:
+  template <typename... OK>
+  void assertState(const char* caller, OK... ok_states) const {
+    using TState = decltype(std::declval<const Derived&>().state());
+    static_assert(std::is_enum_v<TState>, "Derived::state() must return an enum");
+    static_assert(sizeof...(OK) > 0, "Provide at least one acceptable state");
+    static_assert((std::is_same_v<OK, TState> && ...),
+                  "All acceptable states must match Derived::state()'s enum type");
+
+    // Optional signature check
+    using Sig = void (Derived::*)(const char*, TState) const;
+    (void)static_cast<Sig>(&Derived::onUnexpectedState);
+
+    const auto& self = *static_cast<const Derived*>(this);
+    TState actual = self.state();
+    if (((actual == ok_states) || ...)) return;
+    self.onUnexpectedState(caller, actual);
+  }
+};


### PR DESCRIPTION
Currently, the Ambient instrument (the thing that keeps track of the most recent AmbientUpdate information and makes it available at any time to other various subsystems) begins its life after construction in an undefined state: it will happily report that the temperature is 0 and the relative humidity is 0 when, in fact, that information is incorrect because Ambient actually hasn't received any data yet.  This is an extremely minor problem with little practical impact, but fixing it illustrates the benefits of #192.

This PR gives the Ambient instrument a state which starts in NoData and moves to Ready (and sometimes Stale).  This state is recognized when consuming the information and allows the display routines to correctly indicate a lack of data rather than display incorrect (uninitialized) numbers or stale information.  The Stale state is really not likely to be necessary for this instrument, but providing this feature allows this PR to illustrate the power and potential benefits of explicit state management which can be applied to places where it is more important.

The state_assert_mixin.h tool introduced in this PR allows us to easily make expected state assertions in other classes in the future (if a user is trying to read field X, we have to be in one of these states where reading X is valid).

Tested by:
* Artificially causing no AmbientUpdates to be delivered to Ambient, verifying the display shows this lack of data
    * ...and, separately, also causing the display routine to attempt to access temperature, verifying that a fatal error is produced
* Artificially causing only a single AmbientUpdate to be delivered to Ambient, verifying display shows data for 15 seconds then shows a lack of data
* Operating normally and physically changing the relative humidity (blowing on device), verifying the value changes on the display