### PR TITLE
Use magic_enum to get enum value names

### DIFF
--- a/src/libraries/magic_enum/README.md
+++ b/src/libraries/magic_enum/README.md
@@ -1,0 +1,1 @@
+See [magic_enum.hpp](./magic_enum.hpp) for license and origin information for the content of this folder.

--- a/src/libraries/magic_enum/magic_enum.hpp
+++ b/src/libraries/magic_enum/magic_enum.hpp
@@ -1,0 +1,1508 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.7
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_HPP
+#define NEARGYE_MAGIC_ENUM_HPP
+
+#define MAGIC_ENUM_VERSION_MAJOR 0
+#define MAGIC_ENUM_VERSION_MINOR 9
+#define MAGIC_ENUM_VERSION_PATCH 7
+
+#ifndef MAGIC_ENUM_USE_STD_MODULE
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <type_traits>
+#include <utility>
+#endif
+
+#if defined(MAGIC_ENUM_CONFIG_FILE)
+#  include MAGIC_ENUM_CONFIG_FILE
+#endif
+
+#ifndef MAGIC_ENUM_USE_STD_MODULE
+#if !defined(MAGIC_ENUM_USING_ALIAS_OPTIONAL)
+#  include <optional>
+#endif
+#if !defined(MAGIC_ENUM_USING_ALIAS_STRING)
+#  include <string>
+#endif
+#if !defined(MAGIC_ENUM_USING_ALIAS_STRING_VIEW)
+#  include <string_view>
+#endif
+#endif
+
+#if defined(MAGIC_ENUM_NO_ASSERT)
+#  define MAGIC_ENUM_ASSERT(...) static_cast<void>(0)
+#elif !defined(MAGIC_ENUM_ASSERT)
+#  include <cassert>
+#  define MAGIC_ENUM_ASSERT(...) assert((__VA_ARGS__))
+#endif
+
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wunknown-warning-option"
+#  pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
+#  pragma clang diagnostic ignored "-Wuseless-cast" // suppresses 'static_cast<char_type>('\0')' for char_type = char (common on Linux).
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized" // May be used uninitialized 'return {};'.
+#  pragma GCC diagnostic ignored "-Wuseless-cast" // suppresses 'static_cast<char_type>('\0')' for char_type = char (common on Linux).
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 26495) // Variable 'static_str<N>::chars_' is uninitialized.
+#  pragma warning(disable : 28020) // Arithmetic overflow: Using operator '-' on a 4 byte value and then casting the result to a 8 byte value.
+#  pragma warning(disable : 26451) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call.
+#  pragma warning(disable : 4514) // Unreferenced inline function has been removed.
+#endif
+
+// Checks magic_enum compiler compatibility.
+#if defined(__clang__) && __clang_major__ >= 5 || defined(__GNUC__) && __GNUC__ >= 9 || defined(_MSC_VER) && _MSC_VER >= 1910 || defined(__RESHARPER__)
+#  undef  MAGIC_ENUM_SUPPORTED
+#  define MAGIC_ENUM_SUPPORTED 1
+#endif
+
+// Checks magic_enum compiler aliases compatibility.
+#if defined(__clang__) && __clang_major__ >= 5 || defined(__GNUC__) && __GNUC__ >= 9 || defined(_MSC_VER) && _MSC_VER >= 1920
+#  undef  MAGIC_ENUM_SUPPORTED_ALIASES
+#  define MAGIC_ENUM_SUPPORTED_ALIASES 1
+#endif
+
+// Enum value must be greater or equals than MAGIC_ENUM_RANGE_MIN. By default MAGIC_ENUM_RANGE_MIN = -128.
+// If need another min range for all enum types by default, redefine the macro MAGIC_ENUM_RANGE_MIN.
+#if !defined(MAGIC_ENUM_RANGE_MIN)
+#  define MAGIC_ENUM_RANGE_MIN -128
+#endif
+
+// Enum value must be less or equals than MAGIC_ENUM_RANGE_MAX. By default MAGIC_ENUM_RANGE_MAX = 127.
+// If need another max range for all enum types by default, redefine the macro MAGIC_ENUM_RANGE_MAX.
+#if !defined(MAGIC_ENUM_RANGE_MAX)
+#  define MAGIC_ENUM_RANGE_MAX 127
+#endif
+
+// Improve ReSharper C++ intellisense performance with builtins, avoiding unnecessary template instantiations.
+#if defined(__RESHARPER__)
+#  undef MAGIC_ENUM_GET_ENUM_NAME_BUILTIN
+#  undef MAGIC_ENUM_GET_TYPE_NAME_BUILTIN
+#  if __RESHARPER__ >= 20230100
+#    define MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V) __rscpp_enumerator_name(V)
+#    define MAGIC_ENUM_GET_TYPE_NAME_BUILTIN(T) __rscpp_type_name<T>()
+#  else
+#    define MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V) nullptr
+#    define MAGIC_ENUM_GET_TYPE_NAME_BUILTIN(T) nullptr
+#  endif
+#endif
+
+namespace magic_enum {
+
+// If need another optional type, define the macro MAGIC_ENUM_USING_ALIAS_OPTIONAL.
+#if defined(MAGIC_ENUM_USING_ALIAS_OPTIONAL)
+MAGIC_ENUM_USING_ALIAS_OPTIONAL
+#else
+using std::optional;
+#endif
+
+// If need another string_view type, define the macro MAGIC_ENUM_USING_ALIAS_STRING_VIEW.
+#if defined(MAGIC_ENUM_USING_ALIAS_STRING_VIEW)
+MAGIC_ENUM_USING_ALIAS_STRING_VIEW
+#else
+using std::string_view;
+#endif
+
+// If need another string type, define the macro MAGIC_ENUM_USING_ALIAS_STRING.
+#if defined(MAGIC_ENUM_USING_ALIAS_STRING)
+MAGIC_ENUM_USING_ALIAS_STRING
+#else
+using std::string;
+#endif
+
+using char_type = string_view::value_type;
+static_assert(std::is_same_v<string_view::value_type, string::value_type>, "magic_enum::customize requires same string_view::value_type and string::value_type");
+static_assert([] {
+  if constexpr (std::is_same_v<char_type, wchar_t>) {
+    constexpr const char     c[] =  "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789|";
+    constexpr const wchar_t wc[] = L"abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789|";
+    static_assert(std::size(c) == std::size(wc), "magic_enum::customize identifier characters are multichars in wchar_t.");
+
+    for (std::size_t i = 0; i < std::size(c); ++i) {
+      if (c[i] != wc[i]) {
+        return false;
+      }
+    }
+  }
+  return true;
+} (), "magic_enum::customize wchar_t is not compatible with ASCII.");
+
+namespace customize {
+
+// Enum value must be in range [MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX]. By default MAGIC_ENUM_RANGE_MIN = -128, MAGIC_ENUM_RANGE_MAX = 127.
+// If need another range for all enum types by default, redefine the macro MAGIC_ENUM_RANGE_MIN and MAGIC_ENUM_RANGE_MAX.
+// If need another range for specific enum type, add specialization enum_range for necessary enum type.
+template <typename E>
+struct enum_range {
+  static constexpr int min = MAGIC_ENUM_RANGE_MIN;
+  static constexpr int max = MAGIC_ENUM_RANGE_MAX;
+};
+
+static_assert(MAGIC_ENUM_RANGE_MAX > MAGIC_ENUM_RANGE_MIN, "MAGIC_ENUM_RANGE_MAX must be greater than MAGIC_ENUM_RANGE_MIN.");
+
+namespace detail {
+
+enum class customize_tag {
+  default_tag,
+  invalid_tag,
+  custom_tag
+};
+
+} // namespace magic_enum::customize::detail
+
+class customize_t : public std::pair<detail::customize_tag, string_view> {
+ public:
+  constexpr customize_t(string_view srt) : std::pair<detail::customize_tag, string_view>{detail::customize_tag::custom_tag, srt} {}
+  constexpr customize_t(const char_type* srt) : customize_t{string_view{srt}} {}
+  constexpr customize_t(detail::customize_tag tag) : std::pair<detail::customize_tag, string_view>{tag, string_view{}} {
+    MAGIC_ENUM_ASSERT(tag != detail::customize_tag::custom_tag);
+  }
+};
+
+// Default customize.
+inline constexpr auto default_tag = customize_t{detail::customize_tag::default_tag};
+// Invalid customize.
+inline constexpr auto invalid_tag = customize_t{detail::customize_tag::invalid_tag};
+
+// If need custom names for enum, add specialization enum_name for necessary enum type.
+template <typename E>
+constexpr customize_t enum_name(E) noexcept {
+  return default_tag;
+}
+
+// If need custom type name for enum, add specialization enum_type_name for necessary enum type.
+template <typename E>
+constexpr customize_t enum_type_name() noexcept {
+  return default_tag;
+}
+
+} // namespace magic_enum::customize
+
+namespace detail {
+
+template <typename T>
+struct supported
+#if defined(MAGIC_ENUM_SUPPORTED) && MAGIC_ENUM_SUPPORTED || defined(MAGIC_ENUM_NO_CHECK_SUPPORT)
+  : std::true_type {};
+#else
+  : std::false_type {};
+#endif
+
+template <auto V, typename E = std::decay_t<decltype(V)>, std::enable_if_t<std::is_enum_v<E>, int> = 0>
+using enum_constant = std::integral_constant<E, V>;
+
+template <typename... T>
+inline constexpr bool always_false_v = false;
+
+template <typename T, typename = void>
+struct has_is_flags : std::false_type {};
+
+template <typename T>
+struct has_is_flags<T, std::void_t<decltype(customize::enum_range<T>::is_flags)>> : std::bool_constant<std::is_same_v<bool, std::decay_t<decltype(customize::enum_range<T>::is_flags)>>> {};
+
+template <typename T, typename = void>
+struct range_min : std::integral_constant<int, MAGIC_ENUM_RANGE_MIN> {};
+
+template <typename T>
+struct range_min<T, std::void_t<decltype(customize::enum_range<T>::min)>> : std::integral_constant<decltype(customize::enum_range<T>::min), customize::enum_range<T>::min> {};
+
+template <typename T, typename = void>
+struct range_max : std::integral_constant<int, MAGIC_ENUM_RANGE_MAX> {};
+
+template <typename T>
+struct range_max<T, std::void_t<decltype(customize::enum_range<T>::max)>> : std::integral_constant<decltype(customize::enum_range<T>::max), customize::enum_range<T>::max> {};
+
+struct str_view {
+  const char* str_ = nullptr;
+  std::size_t size_ = 0;
+};
+
+template <std::uint16_t N>
+class static_str {
+ public:
+  constexpr explicit static_str(str_view str) noexcept : static_str{str.str_, std::make_integer_sequence<std::uint16_t, N>{}} {
+    MAGIC_ENUM_ASSERT(str.size_ == N);
+  }
+
+  constexpr explicit static_str(string_view str) noexcept : static_str{str.data(), std::make_integer_sequence<std::uint16_t, N>{}} {
+    MAGIC_ENUM_ASSERT(str.size() == N);
+  }
+
+  constexpr const char_type* data() const noexcept { return chars_; }
+
+  constexpr std::uint16_t size() const noexcept { return N; }
+
+  constexpr operator string_view() const noexcept { return {data(), size()}; }
+
+ private:
+  template <std::uint16_t... I>
+  constexpr static_str(const char* str, std::integer_sequence<std::uint16_t, I...>) noexcept : chars_{static_cast<char_type>(str[I])..., static_cast<char_type>('\0')} {}
+
+  template <std::uint16_t... I>
+  constexpr static_str(string_view str, std::integer_sequence<std::uint16_t, I...>) noexcept : chars_{str[I]..., static_cast<char_type>('\0')} {}
+
+  char_type chars_[static_cast<std::size_t>(N) + 1];
+};
+
+template <>
+class static_str<0> {
+ public:
+  constexpr explicit static_str() = default;
+
+  constexpr explicit static_str(str_view) noexcept {}
+
+  constexpr explicit static_str(string_view) noexcept {}
+
+  constexpr const char_type* data() const noexcept { return nullptr; }
+
+  constexpr std::uint16_t size() const noexcept { return 0; }
+
+  constexpr operator string_view() const noexcept { return {}; }
+};
+
+template <typename Op = std::equal_to<>>
+class case_insensitive {
+  static constexpr char_type to_lower(char_type c) noexcept {
+    return (c >= static_cast<char_type>('A') && c <= static_cast<char_type>('Z')) ? static_cast<char_type>(c + (static_cast<char_type>('a') - static_cast<char_type>('A'))) : c;
+  }
+
+ public:
+  template <typename L, typename R>
+  constexpr auto operator()(L lhs, R rhs) const noexcept -> std::enable_if_t<std::is_same_v<std::decay_t<L>, char_type> && std::is_same_v<std::decay_t<R>, char_type>, bool> {
+    return Op{}(to_lower(lhs), to_lower(rhs));
+  }
+};
+
+constexpr std::size_t find(string_view str, char_type c) noexcept {
+#if defined(__clang__) && __clang_major__ < 9 && defined(__GLIBCXX__) || defined(_MSC_VER) && _MSC_VER < 1920 && !defined(__clang__)
+// https://stackoverflow.com/questions/56484834/constexpr-stdstring-viewfind-last-of-doesnt-work-on-clang-8-with-libstdc
+// https://developercommunity.visualstudio.com/content/problem/360432/vs20178-regression-c-failed-in-test.html
+  constexpr bool workaround = true;
+#else
+  constexpr bool workaround = false;
+#endif
+
+  if constexpr (workaround) {
+    for (std::size_t i = 0; i < str.size(); ++i) {
+      if (str[i] == c) {
+        return i;
+      }
+    }
+
+    return string_view::npos;
+  } else {
+    return str.find(c);
+  }
+}
+
+template <typename BinaryPredicate>
+constexpr bool is_default_predicate() noexcept {
+  return std::is_same_v<std::decay_t<BinaryPredicate>, std::equal_to<string_view::value_type>> ||
+         std::is_same_v<std::decay_t<BinaryPredicate>, std::equal_to<>>;
+}
+
+template <typename BinaryPredicate>
+constexpr bool is_nothrow_invocable() {
+  return is_default_predicate<BinaryPredicate>() ||
+         std::is_nothrow_invocable_r_v<bool, BinaryPredicate, char_type, char_type>;
+}
+
+template <typename BinaryPredicate>
+constexpr bool cmp_equal(string_view lhs, string_view rhs, [[maybe_unused]] BinaryPredicate&& p) noexcept(is_nothrow_invocable<BinaryPredicate>()) {
+#if defined(_MSC_VER) && _MSC_VER < 1920 && !defined(__clang__)
+  // https://developercommunity.visualstudio.com/content/problem/360432/vs20178-regression-c-failed-in-test.html
+  // https://developercommunity.visualstudio.com/content/problem/232218/c-constexpr-string-view.html
+  constexpr bool workaround = true;
+#else
+  constexpr bool workaround = false;
+#endif
+
+  if constexpr (!is_default_predicate<BinaryPredicate>() || workaround) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+
+    const auto size = lhs.size();
+    for (std::size_t i = 0; i < size; ++i) {
+      if (!p(lhs[i], rhs[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  } else {
+    return lhs == rhs;
+  }
+}
+
+template <typename L, typename R>
+constexpr bool cmp_less(L lhs, R rhs) noexcept {
+  static_assert(std::is_integral_v<L> && std::is_integral_v<R>, "magic_enum::detail::cmp_less requires integral type.");
+
+  if constexpr (std::is_signed_v<L> == std::is_signed_v<R>) {
+    // If same signedness (both signed or both unsigned).
+    return lhs < rhs;
+  } else if constexpr (std::is_same_v<L, bool>) { // bool special case
+      return static_cast<R>(lhs) < rhs;
+  } else if constexpr (std::is_same_v<R, bool>) { // bool special case
+      return lhs < static_cast<L>(rhs);
+  } else if constexpr (std::is_signed_v<R>) {
+    // If 'right' is negative, then result is 'false', otherwise cast & compare.
+    return rhs > 0 && lhs < static_cast<std::make_unsigned_t<R>>(rhs);
+  } else {
+    // If 'left' is negative, then result is 'true', otherwise cast & compare.
+    return lhs < 0 || static_cast<std::make_unsigned_t<L>>(lhs) < rhs;
+  }
+}
+
+template <typename I>
+constexpr I log2(I value) noexcept {
+  static_assert(std::is_integral_v<I>, "magic_enum::detail::log2 requires integral type.");
+
+  if constexpr (std::is_same_v<I, bool>) { // bool special case
+    return MAGIC_ENUM_ASSERT(false), value;
+  } else {
+    auto ret = I{0};
+    for (; value > I{1}; value >>= I{1}, ++ret) {}
+
+    return ret;
+  }
+}
+
+#if defined(__cpp_lib_array_constexpr) && __cpp_lib_array_constexpr >= 201603L
+#  define MAGIC_ENUM_ARRAY_CONSTEXPR 1
+#else
+template <typename T, std::size_t N, std::size_t... I>
+constexpr std::array<std::remove_cv_t<T>, N> to_array(T (&a)[N], std::index_sequence<I...>) noexcept {
+  return {{a[I]...}};
+}
+#endif
+
+template <typename T>
+inline constexpr bool is_enum_v = std::is_enum_v<T> && std::is_same_v<T, std::decay_t<T>>;
+
+template <typename E>
+constexpr auto n() noexcept {
+  static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
+
+  if constexpr (supported<E>::value) {
+#if defined(MAGIC_ENUM_GET_TYPE_NAME_BUILTIN)
+    constexpr auto name_ptr = MAGIC_ENUM_GET_TYPE_NAME_BUILTIN(E);
+    constexpr auto name = name_ptr ? str_view{name_ptr, std::char_traits<char>::length(name_ptr)} : str_view{};
+#elif defined(__clang__)
+    str_view name;
+    if constexpr (sizeof(__PRETTY_FUNCTION__) == sizeof(__FUNCTION__)) {
+      static_assert(always_false_v<E>, "magic_enum::detail::n requires __PRETTY_FUNCTION__.");
+      return str_view{};
+    } else {
+      name.size_ = sizeof(__PRETTY_FUNCTION__) - 36;
+      name.str_ = __PRETTY_FUNCTION__ + 34;
+    }
+#elif defined(__GNUC__)
+    auto name = str_view{__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1};
+    if constexpr (sizeof(__PRETTY_FUNCTION__) == sizeof(__FUNCTION__)) {
+      static_assert(always_false_v<E>, "magic_enum::detail::n requires __PRETTY_FUNCTION__.");
+      return str_view{};
+    } else if (name.str_[name.size_ - 1] == ']') {
+      name.size_ -= 50;
+      name.str_ += 49;
+    } else {
+      name.size_ -= 40;
+      name.str_ += 37;
+    }
+#elif defined(_MSC_VER)
+    // CLI/C++ workaround (see https://github.com/Neargye/magic_enum/issues/284).
+    str_view name;
+    name.str_ = __FUNCSIG__;
+    name.str_ += 40;
+    name.size_ += sizeof(__FUNCSIG__) - 57;
+#else
+    auto name = str_view{};
+#endif
+    std::size_t p = 0;
+    for (std::size_t i = name.size_; i > 0; --i) {
+      if (name.str_[i] == ':') {
+        p = i + 1;
+        break;
+      }
+    }
+    if (p > 0) {
+      name.size_ -= p;
+      name.str_ += p;
+    }
+    return name;
+  } else {
+    return str_view{}; // Unsupported compiler or Invalid customize.
+  }
+}
+
+template <typename E>
+constexpr auto type_name() noexcept {
+  [[maybe_unused]] constexpr auto custom = customize::enum_type_name<E>();
+  static_assert(std::is_same_v<std::decay_t<decltype(custom)>, customize::customize_t>, "magic_enum::customize requires customize_t type.");
+  if constexpr (custom.first == customize::detail::customize_tag::custom_tag) {
+    constexpr auto name = custom.second;
+    static_assert(!name.empty(), "magic_enum::customize requires not empty string.");
+    return static_str<name.size()>{name};
+  } else if constexpr (custom.first == customize::detail::customize_tag::invalid_tag) {
+    return static_str<0>{};
+  } else if constexpr (custom.first == customize::detail::customize_tag::default_tag) {
+    constexpr auto name = n<E>();
+    return static_str<name.size_>{name};
+  } else {
+    static_assert(always_false_v<E>, "magic_enum::customize invalid.");
+  }
+}
+
+template <typename E>
+inline constexpr auto type_name_v = type_name<E>();
+
+template <auto V>
+constexpr auto n() noexcept {
+  static_assert(is_enum_v<decltype(V)>, "magic_enum::detail::n requires enum type.");
+
+  if constexpr (supported<decltype(V)>::value) {
+#if defined(MAGIC_ENUM_GET_ENUM_NAME_BUILTIN)
+    constexpr auto name_ptr = MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V);
+    auto name = name_ptr ? str_view{name_ptr, std::char_traits<char>::length(name_ptr)} : str_view{};
+#elif defined(__clang__)
+    str_view name;
+    if constexpr (sizeof(__PRETTY_FUNCTION__) == sizeof(__FUNCTION__)) {
+      static_assert(always_false_v<decltype(V)>, "magic_enum::detail::n requires __PRETTY_FUNCTION__.");
+      return str_view{};
+    } else {
+      name.size_ = sizeof(__PRETTY_FUNCTION__) - 36;
+      name.str_ = __PRETTY_FUNCTION__ + 34;
+    }
+    if (name.size_ > 22 && name.str_[0] == '(' && name.str_[1] == 'a' && name.str_[10] == ' ' && name.str_[22] == ':') {
+      name.size_ -= 23;
+      name.str_ += 23;
+    }
+    if (name.str_[0] == '(' || name.str_[0] == '-' || (name.str_[0] >= '0' && name.str_[0] <= '9')) {
+      name = str_view{};
+    }
+#elif defined(__GNUC__)
+    auto name = str_view{__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1};
+    if constexpr (sizeof(__PRETTY_FUNCTION__) == sizeof(__FUNCTION__)) {
+      static_assert(always_false_v<decltype(V)>, "magic_enum::detail::n requires __PRETTY_FUNCTION__.");
+      return str_view{};
+    } else if (name.str_[name.size_ - 1] == ']') {
+      name.size_ -= 55;
+      name.str_ += 54;
+    } else {
+      name.size_ -= 40;
+      name.str_ += 37;
+    }
+    if (name.str_[0] == '(') {
+      name = str_view{};
+    }
+#elif defined(_MSC_VER)
+    str_view name;
+    if ((__FUNCSIG__[5] == '_' && __FUNCSIG__[35] != '(') || (__FUNCSIG__[5] == 'c' && __FUNCSIG__[41] != '(')) {
+      // CLI/C++ workaround (see https://github.com/Neargye/magic_enum/issues/284).
+      name.str_ = __FUNCSIG__;
+      name.str_ += 35;
+      name.size_ = sizeof(__FUNCSIG__) - 52;
+    }
+#else
+    auto name = str_view{};
+#endif
+    std::size_t p = 0;
+    for (std::size_t i = name.size_; i > 0; --i) {
+      if (name.str_[i] == ':') {
+        p = i + 1;
+        break;
+      }
+    }
+    if (p > 0) {
+      name.size_ -= p;
+      name.str_ += p;
+    }
+    return name;
+  } else {
+    return str_view{}; // Unsupported compiler or Invalid customize.
+  }
+}
+
+#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER < 1920
+#  define MAGIC_ENUM_VS_2017_WORKAROUND 1
+#endif
+
+#if defined(MAGIC_ENUM_VS_2017_WORKAROUND)
+template <typename E, E V>
+constexpr auto n() noexcept {
+  static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
+
+#  if defined(MAGIC_ENUM_GET_ENUM_NAME_BUILTIN)
+  constexpr auto name_ptr = MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V);
+  auto name = name_ptr ? str_view{name_ptr, std::char_traits<char>::length(name_ptr)} : str_view{};
+#  else
+  // CLI/C++ workaround (see https://github.com/Neargye/magic_enum/issues/284).
+  str_view name;
+  name.str_ = __FUNCSIG__;
+  name.size_ = sizeof(__FUNCSIG__) - 17;
+  std::size_t p = 0;
+  for (std::size_t i = name.size_; i > 0; --i) {
+    if (name.str_[i] == ',' || name.str_[i] == ':') {
+      p = i + 1;
+      break;
+    }
+  }
+  if (p > 0) {
+    name.size_ -= p;
+    name.str_ += p;
+  }
+  if (name.str_[0] == '(' || name.str_[0] == '-' || (name.str_[0] >= '0' && name.str_[0] <= '9')) {
+    name = str_view{};
+  }
+  return name;
+#  endif
+}
+#endif
+
+template <typename E, E V>
+constexpr auto enum_name() noexcept {
+  [[maybe_unused]] constexpr auto custom = customize::enum_name<E>(V);
+  static_assert(std::is_same_v<std::decay_t<decltype(custom)>, customize::customize_t>, "magic_enum::customize requires customize_t type.");
+  if constexpr (custom.first == customize::detail::customize_tag::custom_tag) {
+    constexpr auto name = custom.second;
+    static_assert(!name.empty(), "magic_enum::customize requires not empty string.");
+    return static_str<name.size()>{name};
+  } else if constexpr (custom.first == customize::detail::customize_tag::invalid_tag) {
+    return static_str<0>{};
+  } else if constexpr (custom.first == customize::detail::customize_tag::default_tag) {
+#if defined(MAGIC_ENUM_VS_2017_WORKAROUND)
+    constexpr auto name = n<E, V>();
+#else
+    constexpr auto name = n<V>();
+#endif
+    return static_str<name.size_>{name};
+  } else {
+    static_assert(always_false_v<E>, "magic_enum::customize invalid.");
+  }
+}
+
+template <typename E, E V>
+inline constexpr auto enum_name_v = enum_name<E, V>();
+
+template <typename E, auto V>
+constexpr bool is_valid() noexcept {
+#if defined(__clang__) && __clang_major__ >= 16
+  // https://reviews.llvm.org/D130058, https://reviews.llvm.org/D131307
+  constexpr E v = __builtin_bit_cast(E, V);
+#else
+  constexpr E v = static_cast<E>(V);
+#endif
+  [[maybe_unused]] constexpr auto custom = customize::enum_name<E>(v);
+  static_assert(std::is_same_v<std::decay_t<decltype(custom)>, customize::customize_t>, "magic_enum::customize requires customize_t type.");
+  if constexpr (custom.first == customize::detail::customize_tag::custom_tag) {
+    constexpr auto name = custom.second;
+    static_assert(!name.empty(), "magic_enum::customize requires not empty string.");
+    return name.size() != 0;
+  } else if constexpr (custom.first == customize::detail::customize_tag::default_tag) {
+#if defined(MAGIC_ENUM_VS_2017_WORKAROUND)
+    return n<E, v>().size_ != 0;
+#else
+    return n<v>().size_ != 0;
+#endif
+  } else {
+    return false;
+  }
+}
+
+enum class enum_subtype {
+  common,
+  flags
+};
+
+template <typename E, int O, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr U ualue(std::size_t i) noexcept {
+  if constexpr (std::is_same_v<U, bool>) { // bool special case
+    static_assert(O == 0, "magic_enum::detail::ualue requires valid offset.");
+
+    return static_cast<U>(i);
+  } else if constexpr (S == enum_subtype::flags) {
+    return static_cast<U>(U{1} << static_cast<U>(static_cast<int>(i) + O));
+  } else {
+    return static_cast<U>(static_cast<int>(i) + O);
+  }
+}
+
+template <typename E, int O, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr E value(std::size_t i) noexcept {
+  return static_cast<E>(ualue<E, O, S>(i));
+}
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr int reflected_min() noexcept {
+  if constexpr (S == enum_subtype::flags) {
+    return 0;
+  } else {
+    constexpr auto lhs = range_min<E>::value;
+    constexpr auto rhs = (std::numeric_limits<U>::min)();
+
+    if constexpr (cmp_less(rhs, lhs)) {
+      return lhs;
+    } else {
+      return rhs;
+    }
+  }
+}
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr int reflected_max() noexcept {
+  if constexpr (S == enum_subtype::flags) {
+    return std::numeric_limits<U>::digits - 1;
+  } else {
+    constexpr auto lhs = range_max<E>::value;
+    constexpr auto rhs = (std::numeric_limits<U>::max)();
+
+    if constexpr (cmp_less(lhs, rhs)) {
+      return lhs;
+    } else {
+      return rhs;
+    }
+  }
+}
+
+#define MAGIC_ENUM_FOR_EACH_256(T)                                                                                                                                                                 \
+  T(  0)T(  1)T(  2)T(  3)T(  4)T(  5)T(  6)T(  7)T(  8)T(  9)T( 10)T( 11)T( 12)T( 13)T( 14)T( 15)T( 16)T( 17)T( 18)T( 19)T( 20)T( 21)T( 22)T( 23)T( 24)T( 25)T( 26)T( 27)T( 28)T( 29)T( 30)T( 31) \
+  T( 32)T( 33)T( 34)T( 35)T( 36)T( 37)T( 38)T( 39)T( 40)T( 41)T( 42)T( 43)T( 44)T( 45)T( 46)T( 47)T( 48)T( 49)T( 50)T( 51)T( 52)T( 53)T( 54)T( 55)T( 56)T( 57)T( 58)T( 59)T( 60)T( 61)T( 62)T( 63) \
+  T( 64)T( 65)T( 66)T( 67)T( 68)T( 69)T( 70)T( 71)T( 72)T( 73)T( 74)T( 75)T( 76)T( 77)T( 78)T( 79)T( 80)T( 81)T( 82)T( 83)T( 84)T( 85)T( 86)T( 87)T( 88)T( 89)T( 90)T( 91)T( 92)T( 93)T( 94)T( 95) \
+  T( 96)T( 97)T( 98)T( 99)T(100)T(101)T(102)T(103)T(104)T(105)T(106)T(107)T(108)T(109)T(110)T(111)T(112)T(113)T(114)T(115)T(116)T(117)T(118)T(119)T(120)T(121)T(122)T(123)T(124)T(125)T(126)T(127) \
+  T(128)T(129)T(130)T(131)T(132)T(133)T(134)T(135)T(136)T(137)T(138)T(139)T(140)T(141)T(142)T(143)T(144)T(145)T(146)T(147)T(148)T(149)T(150)T(151)T(152)T(153)T(154)T(155)T(156)T(157)T(158)T(159) \
+  T(160)T(161)T(162)T(163)T(164)T(165)T(166)T(167)T(168)T(169)T(170)T(171)T(172)T(173)T(174)T(175)T(176)T(177)T(178)T(179)T(180)T(181)T(182)T(183)T(184)T(185)T(186)T(187)T(188)T(189)T(190)T(191) \
+  T(192)T(193)T(194)T(195)T(196)T(197)T(198)T(199)T(200)T(201)T(202)T(203)T(204)T(205)T(206)T(207)T(208)T(209)T(210)T(211)T(212)T(213)T(214)T(215)T(216)T(217)T(218)T(219)T(220)T(221)T(222)T(223) \
+  T(224)T(225)T(226)T(227)T(228)T(229)T(230)T(231)T(232)T(233)T(234)T(235)T(236)T(237)T(238)T(239)T(240)T(241)T(242)T(243)T(244)T(245)T(246)T(247)T(248)T(249)T(250)T(251)T(252)T(253)T(254)T(255)
+
+template <typename E, enum_subtype S, std::size_t Size, int Min, std::size_t I>
+constexpr void valid_count(bool* valid, std::size_t& count) noexcept {
+#define MAGIC_ENUM_V(O)                                     \
+  if constexpr ((I + O) < Size) {                           \
+    if constexpr (is_valid<E, ualue<E, Min, S>(I + O)>()) { \
+      valid[I + O] = true;                                  \
+      ++count;                                              \
+    }                                                       \
+  }
+
+  MAGIC_ENUM_FOR_EACH_256(MAGIC_ENUM_V)
+
+  if constexpr ((I + 256) < Size) {
+    valid_count<E, S, Size, Min, I + 256>(valid, count);
+  }
+#undef MAGIC_ENUM_V
+}
+
+template <std::size_t N>
+struct valid_count_t {
+  std::size_t count = 0;
+  bool valid[N] = {};
+};
+
+template <typename E, enum_subtype S, std::size_t Size, int Min>
+constexpr auto valid_count() noexcept {
+  valid_count_t<Size> vc;
+  valid_count<E, S, Size, Min, 0>(vc.valid, vc.count);
+  return vc;
+}
+
+template <typename E, enum_subtype S, std::size_t Size, int Min>
+constexpr auto values() noexcept {
+  constexpr auto vc = valid_count<E, S, Size, Min>();
+
+  if constexpr (vc.count > 0) {
+#if defined(MAGIC_ENUM_ARRAY_CONSTEXPR)
+    std::array<E, vc.count> values = {};
+#else
+    E values[vc.count] = {};
+#endif
+    for (std::size_t i = 0, v = 0; v < vc.count; ++i) {
+      if (vc.valid[i]) {
+        values[v++] = value<E, Min, S>(i);
+      }
+    }
+#if defined(MAGIC_ENUM_ARRAY_CONSTEXPR)
+    return values;
+#else
+    return to_array(values, std::make_index_sequence<vc.count>{});
+#endif
+  } else {
+    return std::array<E, 0>{};
+  }
+}
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr auto values() noexcept {
+  constexpr auto min = reflected_min<E, S>();
+  constexpr auto max = reflected_max<E, S>();
+  constexpr auto range_size = max - min + 1;
+  static_assert(range_size > 0, "magic_enum::enum_range requires valid size.");
+
+  return values<E, S, range_size, min>();
+}
+
+template <typename E, typename U = std::underlying_type_t<E>>
+constexpr enum_subtype subtype(std::true_type) noexcept {
+  if constexpr (std::is_same_v<U, bool>) { // bool special case
+    return enum_subtype::common;
+  } else if constexpr (has_is_flags<E>::value) {
+    return customize::enum_range<E>::is_flags ? enum_subtype::flags : enum_subtype::common;
+  } else {
+#if defined(MAGIC_ENUM_AUTO_IS_FLAGS)
+    constexpr auto flags_values = values<E, enum_subtype::flags>();
+    constexpr auto default_values = values<E, enum_subtype::common>();
+    if (flags_values.size() == 0 || default_values.size() > flags_values.size()) {
+      return enum_subtype::common;
+    }
+    for (std::size_t i = 0; i < default_values.size(); ++i) {
+      const auto v = static_cast<U>(default_values[i]);
+      if (v != 0 && (v & (v - 1)) != 0) {
+        return enum_subtype::common;
+      }
+    }
+    return enum_subtype::flags;
+#else
+    return enum_subtype::common;
+#endif
+  }
+}
+
+template <typename T>
+constexpr enum_subtype subtype(std::false_type) noexcept {
+  // For non-enum type return default common subtype.
+  return enum_subtype::common;
+}
+
+template <typename E, typename D = std::decay_t<E>>
+inline constexpr auto subtype_v = subtype<D>(std::is_enum<D>{});
+
+template <typename E, enum_subtype S>
+inline constexpr auto values_v = values<E, S>();
+
+template <typename E, enum_subtype S, typename D = std::decay_t<E>>
+using values_t = decltype((values_v<D, S>));
+
+template <typename E, enum_subtype S>
+inline constexpr auto count_v = values_v<E, S>.size();
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+inline constexpr auto min_v = (count_v<E, S> > 0) ? static_cast<U>(values_v<E, S>.front()) : U{0};
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+inline constexpr auto max_v = (count_v<E, S> > 0) ? static_cast<U>(values_v<E, S>.back()) : U{0};
+
+template <typename E, enum_subtype S, std::size_t... I>
+constexpr auto names(std::index_sequence<I...>) noexcept {
+  constexpr auto names = std::array<string_view, sizeof...(I)>{{enum_name_v<E, values_v<E, S>[I]>...}};
+  return names;
+}
+
+template <typename E, enum_subtype S>
+inline constexpr auto names_v = names<E, S>(std::make_index_sequence<count_v<E, S>>{});
+
+template <typename E, enum_subtype S, typename D = std::decay_t<E>>
+using names_t = decltype((names_v<D, S>));
+
+template <typename E, enum_subtype S, std::size_t... I>
+constexpr auto entries(std::index_sequence<I...>) noexcept {
+  constexpr auto entries = std::array<std::pair<E, string_view>, sizeof...(I)>{{{values_v<E, S>[I], enum_name_v<E, values_v<E, S>[I]>}...}};
+  return entries;
+}
+
+template <typename E, enum_subtype S>
+inline constexpr auto entries_v = entries<E, S>(std::make_index_sequence<count_v<E, S>>{});
+
+template <typename E, enum_subtype S, typename D = std::decay_t<E>>
+using entries_t = decltype((entries_v<D, S>));
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr bool is_sparse() noexcept {
+  if constexpr (count_v<E, S> == 0) {
+    return false;
+  } else if constexpr (std::is_same_v<U, bool>) { // bool special case
+    return false;
+  } else {
+    constexpr auto max = (S == enum_subtype::flags) ? log2(max_v<E, S>) : max_v<E, S>;
+    constexpr auto min = (S == enum_subtype::flags) ? log2(min_v<E, S>) : min_v<E, S>;
+    constexpr auto range_size = max - min + 1;
+
+    return range_size != count_v<E, S>;
+  }
+}
+
+template <typename E, enum_subtype S = subtype_v<E>>
+inline constexpr bool is_sparse_v = is_sparse<E, S>();
+
+template <typename E, enum_subtype S>
+struct is_reflected
+#if defined(MAGIC_ENUM_NO_CHECK_REFLECTED_ENUM)
+  : std::true_type {};
+#else
+  : std::bool_constant<std::is_enum_v<E> && (count_v<E, S> != 0)> {};
+#endif
+
+template <typename E, enum_subtype S>
+inline constexpr bool is_reflected_v = is_reflected<std::decay_t<E>, S>{};
+
+template <bool, typename R>
+struct enable_if_enum {};
+
+template <typename R>
+struct enable_if_enum<true, R> {
+  using type = R;
+  static_assert(supported<R>::value, "magic_enum unsupported compiler (https://github.com/Neargye/magic_enum#compiler-compatibility).");
+};
+
+template <typename T, typename R, typename BinaryPredicate = std::equal_to<>, typename D = std::decay_t<T>>
+using enable_if_t = typename enable_if_enum<std::is_enum_v<D> && std::is_invocable_r_v<bool, BinaryPredicate, char_type, char_type>, R>::type;
+
+template <typename T, std::enable_if_t<std::is_enum_v<std::decay_t<T>>, int> = 0>
+using enum_concept = T;
+
+template <typename T, bool = std::is_enum_v<T>>
+struct is_scoped_enum : std::false_type {};
+
+template <typename T>
+struct is_scoped_enum<T, true> : std::bool_constant<!std::is_convertible_v<T, std::underlying_type_t<T>>> {};
+
+template <typename T, bool = std::is_enum_v<T>>
+struct is_unscoped_enum : std::false_type {};
+
+template <typename T>
+struct is_unscoped_enum<T, true> : std::bool_constant<std::is_convertible_v<T, std::underlying_type_t<T>>> {};
+
+template <typename T, bool = std::is_enum_v<std::decay_t<T>>>
+struct underlying_type {};
+
+template <typename T>
+struct underlying_type<T, true> : std::underlying_type<std::decay_t<T>> {};
+
+#if defined(MAGIC_ENUM_ENABLE_HASH) || defined(MAGIC_ENUM_ENABLE_HASH_SWITCH)
+
+template <typename Value, typename = void>
+struct constexpr_hash_t;
+
+template <typename Value>
+struct constexpr_hash_t<Value, std::enable_if_t<is_enum_v<Value>>> {
+  constexpr auto operator()(Value value) const noexcept {
+    using U = typename underlying_type<Value>::type;
+    if constexpr (std::is_same_v<U, bool>) { // bool special case
+      return static_cast<std::size_t>(value);
+    } else {
+      return static_cast<U>(value);
+    }
+  }
+  using secondary_hash = constexpr_hash_t;
+};
+
+template <typename Value>
+struct constexpr_hash_t<Value, std::enable_if_t<std::is_same_v<Value, string_view>>> {
+  static constexpr std::uint32_t crc_table[256] {
+    0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L, 0x706af48fL, 0xe963a535L, 0x9e6495a3L,
+    0x0edb8832L, 0x79dcb8a4L, 0xe0d5e91eL, 0x97d2d988L, 0x09b64c2bL, 0x7eb17cbdL, 0xe7b82d07L, 0x90bf1d91L,
+    0x1db71064L, 0x6ab020f2L, 0xf3b97148L, 0x84be41deL, 0x1adad47dL, 0x6ddde4ebL, 0xf4d4b551L, 0x83d385c7L,
+    0x136c9856L, 0x646ba8c0L, 0xfd62f97aL, 0x8a65c9ecL, 0x14015c4fL, 0x63066cd9L, 0xfa0f3d63L, 0x8d080df5L,
+    0x3b6e20c8L, 0x4c69105eL, 0xd56041e4L, 0xa2677172L, 0x3c03e4d1L, 0x4b04d447L, 0xd20d85fdL, 0xa50ab56bL,
+    0x35b5a8faL, 0x42b2986cL, 0xdbbbc9d6L, 0xacbcf940L, 0x32d86ce3L, 0x45df5c75L, 0xdcd60dcfL, 0xabd13d59L,
+    0x26d930acL, 0x51de003aL, 0xc8d75180L, 0xbfd06116L, 0x21b4f4b5L, 0x56b3c423L, 0xcfba9599L, 0xb8bda50fL,
+    0x2802b89eL, 0x5f058808L, 0xc60cd9b2L, 0xb10be924L, 0x2f6f7c87L, 0x58684c11L, 0xc1611dabL, 0xb6662d3dL,
+    0x76dc4190L, 0x01db7106L, 0x98d220bcL, 0xefd5102aL, 0x71b18589L, 0x06b6b51fL, 0x9fbfe4a5L, 0xe8b8d433L,
+    0x7807c9a2L, 0x0f00f934L, 0x9609a88eL, 0xe10e9818L, 0x7f6a0dbbL, 0x086d3d2dL, 0x91646c97L, 0xe6635c01L,
+    0x6b6b51f4L, 0x1c6c6162L, 0x856530d8L, 0xf262004eL, 0x6c0695edL, 0x1b01a57bL, 0x8208f4c1L, 0xf50fc457L,
+    0x65b0d9c6L, 0x12b7e950L, 0x8bbeb8eaL, 0xfcb9887cL, 0x62dd1ddfL, 0x15da2d49L, 0x8cd37cf3L, 0xfbd44c65L,
+    0x4db26158L, 0x3ab551ceL, 0xa3bc0074L, 0xd4bb30e2L, 0x4adfa541L, 0x3dd895d7L, 0xa4d1c46dL, 0xd3d6f4fbL,
+    0x4369e96aL, 0x346ed9fcL, 0xad678846L, 0xda60b8d0L, 0x44042d73L, 0x33031de5L, 0xaa0a4c5fL, 0xdd0d7cc9L,
+    0x5005713cL, 0x270241aaL, 0xbe0b1010L, 0xc90c2086L, 0x5768b525L, 0x206f85b3L, 0xb966d409L, 0xce61e49fL,
+    0x5edef90eL, 0x29d9c998L, 0xb0d09822L, 0xc7d7a8b4L, 0x59b33d17L, 0x2eb40d81L, 0xb7bd5c3bL, 0xc0ba6cadL,
+    0xedb88320L, 0x9abfb3b6L, 0x03b6e20cL, 0x74b1d29aL, 0xead54739L, 0x9dd277afL, 0x04db2615L, 0x73dc1683L,
+    0xe3630b12L, 0x94643b84L, 0x0d6d6a3eL, 0x7a6a5aa8L, 0xe40ecf0bL, 0x9309ff9dL, 0x0a00ae27L, 0x7d079eb1L,
+    0xf00f9344L, 0x8708a3d2L, 0x1e01f268L, 0x6906c2feL, 0xf762575dL, 0x806567cbL, 0x196c3671L, 0x6e6b06e7L,
+    0xfed41b76L, 0x89d32be0L, 0x10da7a5aL, 0x67dd4accL, 0xf9b9df6fL, 0x8ebeeff9L, 0x17b7be43L, 0x60b08ed5L,
+    0xd6d6a3e8L, 0xa1d1937eL, 0x38d8c2c4L, 0x4fdff252L, 0xd1bb67f1L, 0xa6bc5767L, 0x3fb506ddL, 0x48b2364bL,
+    0xd80d2bdaL, 0xaf0a1b4cL, 0x36034af6L, 0x41047a60L, 0xdf60efc3L, 0xa867df55L, 0x316e8eefL, 0x4669be79L,
+    0xcb61b38cL, 0xbc66831aL, 0x256fd2a0L, 0x5268e236L, 0xcc0c7795L, 0xbb0b4703L, 0x220216b9L, 0x5505262fL,
+    0xc5ba3bbeL, 0xb2bd0b28L, 0x2bb45a92L, 0x5cb36a04L, 0xc2d7ffa7L, 0xb5d0cf31L, 0x2cd99e8bL, 0x5bdeae1dL,
+    0x9b64c2b0L, 0xec63f226L, 0x756aa39cL, 0x026d930aL, 0x9c0906a9L, 0xeb0e363fL, 0x72076785L, 0x05005713L,
+    0x95bf4a82L, 0xe2b87a14L, 0x7bb12baeL, 0x0cb61b38L, 0x92d28e9bL, 0xe5d5be0dL, 0x7cdcefb7L, 0x0bdbdf21L,
+    0x86d3d2d4L, 0xf1d4e242L, 0x68ddb3f8L, 0x1fda836eL, 0x81be16cdL, 0xf6b9265bL, 0x6fb077e1L, 0x18b74777L,
+    0x88085ae6L, 0xff0f6a70L, 0x66063bcaL, 0x11010b5cL, 0x8f659effL, 0xf862ae69L, 0x616bffd3L, 0x166ccf45L,
+    0xa00ae278L, 0xd70dd2eeL, 0x4e048354L, 0x3903b3c2L, 0xa7672661L, 0xd06016f7L, 0x4969474dL, 0x3e6e77dbL,
+    0xaed16a4aL, 0xd9d65adcL, 0x40df0b66L, 0x37d83bf0L, 0xa9bcae53L, 0xdebb9ec5L, 0x47b2cf7fL, 0x30b5ffe9L,
+    0xbdbdf21cL, 0xcabac28aL, 0x53b39330L, 0x24b4a3a6L, 0xbad03605L, 0xcdd70693L, 0x54de5729L, 0x23d967bfL,
+    0xb3667a2eL, 0xc4614ab8L, 0x5d681b02L, 0x2a6f2b94L, 0xb40bbe37L, 0xc30c8ea1L, 0x5a05df1bL, 0x2d02ef8dL
+  };
+  constexpr std::uint32_t operator()(string_view value) const noexcept {
+    auto crc = static_cast<std::uint32_t>(0xffffffffL);
+    for (const auto c : value) {
+      crc = (crc >> 8) ^ crc_table[(crc ^ static_cast<std::uint32_t>(c)) & 0xff];
+    }
+    return crc ^ 0xffffffffL;
+  }
+
+  struct secondary_hash {
+    constexpr std::uint32_t operator()(string_view value) const noexcept {
+      auto acc = static_cast<std::uint64_t>(2166136261ULL);
+      for (const auto c : value) {
+        acc = ((acc ^ static_cast<std::uint64_t>(c)) * static_cast<std::uint64_t>(16777619ULL)) & (std::numeric_limits<std::uint32_t>::max)();
+      }
+      return static_cast<std::uint32_t>(acc);
+    }
+  };
+};
+
+template <typename Hash>
+inline constexpr Hash hash_v{};
+
+template <auto* GlobValues, typename Hash>
+constexpr auto calculate_cases(std::size_t Page) noexcept {
+  constexpr std::array values = *GlobValues;
+  constexpr std::size_t size = values.size();
+
+  using switch_t = std::invoke_result_t<Hash, typename decltype(values)::value_type>;
+  static_assert(std::is_integral_v<switch_t> && !std::is_same_v<switch_t, bool>);
+  const std::size_t values_to = (std::min)(static_cast<std::size_t>(256), size - Page);
+
+  std::array<switch_t, 256> result{};
+  auto fill = result.begin();
+  {
+    auto first = values.begin() + static_cast<std::ptrdiff_t>(Page);
+    auto last = values.begin() + static_cast<std::ptrdiff_t>(Page + values_to);
+    while (first != last) {
+      *fill++ = hash_v<Hash>(*first++);
+    }
+  }
+
+  // dead cases, try to avoid case collisions
+  for (switch_t last_value = result[values_to - 1]; fill != result.end() && last_value != (std::numeric_limits<switch_t>::max)(); *fill++ = ++last_value) {
+  }
+
+  {
+    auto it = result.begin();
+    auto last_value = (std::numeric_limits<switch_t>::min)();
+    for (; fill != result.end(); *fill++ = last_value++) {
+      while (last_value == *it) {
+        ++last_value, ++it;
+      }
+    }
+  }
+
+  return result;
+}
+
+template <typename R, typename F, typename... Args>
+constexpr R invoke_r(F&& f, Args&&... args) noexcept(std::is_nothrow_invocable_r_v<R, F, Args...>) {
+  if constexpr (std::is_void_v<R>) {
+    std::forward<F>(f)(std::forward<Args>(args)...);
+  } else {
+    return static_cast<R>(std::forward<F>(f)(std::forward<Args>(args)...));
+  }
+}
+
+enum class case_call_t {
+  index,
+  value
+};
+
+template <typename T = void>
+inline constexpr auto default_result_type_lambda = []() noexcept(std::is_nothrow_default_constructible_v<T>) { return T{}; };
+
+template <>
+inline constexpr auto default_result_type_lambda<void> = []() noexcept {};
+
+template <auto* Arr, typename Hash>
+constexpr bool has_duplicate() noexcept {
+  using value_t = std::decay_t<decltype((*Arr)[0])>;
+  using hash_value_t = std::invoke_result_t<Hash, value_t>;
+  std::array<hash_value_t, Arr->size()> hashes{};
+  std::size_t size = 0;
+  for (auto elem : *Arr) {
+    hashes[size] = hash_v<Hash>(elem);
+    for (auto i = size++; i > 0; --i) {
+      if (hashes[i] < hashes[i - 1]) {
+        auto tmp = hashes[i];
+        hashes[i] = hashes[i - 1];
+        hashes[i - 1] = tmp;
+      } else if (hashes[i] == hashes[i - 1]) {
+        return false;
+      } else {
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+#define MAGIC_ENUM_CASE(val)                                                                                                  \
+  case cases[val]:                                                                                                            \
+    if constexpr ((val) + Page < size) {                                                                                      \
+      if (!pred(values[val + Page], searched)) {                                                                              \
+        break;                                                                                                                \
+      }                                                                                                                       \
+      if constexpr (CallValue == case_call_t::index) {                                                                        \
+        if constexpr (std::is_invocable_r_v<result_t, Lambda, std::integral_constant<std::size_t, val + Page>>) {             \
+          return detail::invoke_r<result_t>(std::forward<Lambda>(lambda), std::integral_constant<std::size_t, val + Page>{}); \
+        } else if constexpr (std::is_invocable_v<Lambda, std::integral_constant<std::size_t, val + Page>>) {                  \
+          MAGIC_ENUM_ASSERT(false && "magic_enum::detail::constexpr_switch wrong result type.");                                         \
+        }                                                                                                                     \
+      } else if constexpr (CallValue == case_call_t::value) {                                                                 \
+        if constexpr (std::is_invocable_r_v<result_t, Lambda, enum_constant<values[val + Page]>>) {                           \
+          return detail::invoke_r<result_t>(std::forward<Lambda>(lambda), enum_constant<values[val + Page]>{});               \
+        } else if constexpr (std::is_invocable_r_v<result_t, Lambda, enum_constant<values[val + Page]>>) {                    \
+          MAGIC_ENUM_ASSERT(false && "magic_enum::detail::constexpr_switch wrong result type.");                                         \
+        }                                                                                                                     \
+      }                                                                                                                       \
+      break;                                                                                                                  \
+    } else [[fallthrough]];
+
+template <auto* GlobValues,
+          case_call_t CallValue,
+          std::size_t Page = 0,
+          typename Hash = constexpr_hash_t<typename std::decay_t<decltype(*GlobValues)>::value_type>,
+          typename BinaryPredicate = std::equal_to<>,
+          typename Lambda,
+          typename ResultGetterType>
+constexpr decltype(auto) constexpr_switch(
+    Lambda&& lambda,
+    typename std::decay_t<decltype(*GlobValues)>::value_type searched,
+    ResultGetterType&& def,
+    BinaryPredicate&& pred = {}) {
+  using result_t = std::invoke_result_t<ResultGetterType>;
+  using hash_t = std::conditional_t<has_duplicate<GlobValues, Hash>(), Hash, typename Hash::secondary_hash>;
+  static_assert(has_duplicate<GlobValues, hash_t>(), "magic_enum::detail::constexpr_switch duplicated hash found, please report it: https://github.com/Neargye/magic_enum/issues.");
+  constexpr std::array values = *GlobValues;
+  constexpr std::size_t size = values.size();
+  constexpr std::array cases = calculate_cases<GlobValues, hash_t>(Page);
+
+  switch (hash_v<hash_t>(searched)) {
+    MAGIC_ENUM_FOR_EACH_256(MAGIC_ENUM_CASE)
+    default:
+      if constexpr (size > 256 + Page) {
+        return constexpr_switch<GlobValues, CallValue, Page + 256, Hash>(std::forward<Lambda>(lambda), searched, std::forward<ResultGetterType>(def));
+      }
+      break;
+  }
+  return def();
+}
+
+#undef MAGIC_ENUM_CASE
+
+#endif
+
+} // namespace magic_enum::detail
+
+// Checks is magic_enum supported compiler.
+inline constexpr bool is_magic_enum_supported = detail::supported<void>::value;
+
+template <typename T>
+using Enum = detail::enum_concept<T>;
+
+// Checks whether T is an Unscoped enumeration type.
+// Provides the member constant value which is equal to true, if T is an [Unscoped enumeration](https://en.cppreference.com/w/cpp/language/enum#Unscoped_enumeration) type. Otherwise, value is equal to false.
+template <typename T>
+struct is_unscoped_enum : detail::is_unscoped_enum<T> {};
+
+template <typename T>
+inline constexpr bool is_unscoped_enum_v = is_unscoped_enum<T>::value;
+
+// Checks whether T is an Scoped enumeration type.
+// Provides the member constant value which is equal to true, if T is an [Scoped enumeration](https://en.cppreference.com/w/cpp/language/enum#Scoped_enumerations) type. Otherwise, value is equal to false.
+template <typename T>
+struct is_scoped_enum : detail::is_scoped_enum<T> {};
+
+template <typename T>
+inline constexpr bool is_scoped_enum_v = is_scoped_enum<T>::value;
+
+// If T is a complete enumeration type, provides a member typedef type that names the underlying type of T.
+// Otherwise, if T is not an enumeration type, there is no member type. Otherwise (T is an incomplete enumeration type), the program is ill-formed.
+template <typename T>
+struct underlying_type : detail::underlying_type<T> {};
+
+template <typename T>
+using underlying_type_t = typename underlying_type<T>::type;
+
+template <auto V>
+using enum_constant = detail::enum_constant<V>;
+
+// Returns type name of enum.
+template <typename E>
+[[nodiscard]] constexpr auto enum_type_name() noexcept -> detail::enable_if_t<E, string_view> {
+  constexpr string_view name = detail::type_name_v<std::decay_t<E>>;
+  static_assert(!name.empty(), "magic_enum::enum_type_name enum type does not have a name.");
+
+  return name;
+}
+
+// Returns number of enum values.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_count() noexcept -> detail::enable_if_t<E, std::size_t> {
+  return detail::count_v<std::decay_t<E>, S>;
+}
+
+// Returns enum value at specified index.
+// No bounds checking is performed: the behavior is undefined if index >= number of enum values.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_value(std::size_t index) noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  if constexpr (detail::is_sparse_v<D, S>) {
+    return MAGIC_ENUM_ASSERT(index < detail::count_v<D, S>), detail::values_v<D, S>[index];
+  } else {
+    constexpr auto min = (S == detail::enum_subtype::flags) ? detail::log2(detail::min_v<D, S>) : detail::min_v<D, S>;
+
+    return MAGIC_ENUM_ASSERT(index < detail::count_v<D, S>), detail::value<D, min, S>(index);
+  }
+}
+
+// Returns enum value at specified index.
+template <typename E, std::size_t I, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_value() noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+  static_assert(I < detail::count_v<D, S>, "magic_enum::enum_value out of range.");
+
+  return enum_value<D, S>(I);
+}
+
+// Returns std::array with enum values, sorted by enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_values() noexcept -> detail::enable_if_t<E, detail::values_t<E, S>> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  return detail::values_v<D, S>;
+}
+
+// Returns integer value from enum value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_integer(E value) noexcept -> detail::enable_if_t<E, underlying_type_t<E>> {
+  return static_cast<underlying_type_t<E>>(value);
+}
+
+// Returns underlying value from enum value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_underlying(E value) noexcept -> detail::enable_if_t<E, underlying_type_t<E>> {
+  return static_cast<underlying_type_t<E>>(value);
+}
+
+// Obtains index in enum values from enum value.
+// Returns optional with index.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_index(E value) noexcept -> detail::enable_if_t<E, optional<std::size_t>> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  if constexpr (detail::is_sparse_v<D, S> || (S == detail::enum_subtype::flags)) {
+#if defined(MAGIC_ENUM_ENABLE_HASH)
+    return detail::constexpr_switch<&detail::values_v<D, S>, detail::case_call_t::index>(
+        [](std::size_t i) { return optional<std::size_t>{i}; },
+        value,
+        detail::default_result_type_lambda<optional<std::size_t>>);
+#else
+    for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+      if (enum_value<D, S>(i) == value) {
+        return i;
+      }
+    }
+    return {}; // Invalid value or out of range.
+#endif
+  } else {
+    const auto v = static_cast<U>(value);
+    if (v >= detail::min_v<D, S> && v <= detail::max_v<D, S>) {
+      return static_cast<std::size_t>(v - detail::min_v<D, S>);
+    }
+    return {}; // Invalid value or out of range.
+  }
+}
+
+// Obtains index in enum values from enum value.
+// Returns optional with index.
+template <detail::enum_subtype S, typename E>
+[[nodiscard]] constexpr auto enum_index(E value) noexcept -> detail::enable_if_t<E, optional<std::size_t>> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  return enum_index<D, S>(value);
+}
+
+// Obtains index in enum values from static storage enum variable.
+template <auto V, detail::enum_subtype S = detail::subtype_v<std::decay_t<decltype(V)>>>
+[[nodiscard]] constexpr auto enum_index() noexcept -> detail::enable_if_t<decltype(V), std::size_t> {\
+  using D = std::decay_t<decltype(V)>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+  constexpr auto index = enum_index<D, S>(V);
+  static_assert(index, "magic_enum::enum_index enum value does not have a index.");
+
+  return *index;
+}
+
+// Returns name from static storage enum variable.
+// This version is much lighter on the compile times and is not restricted to the enum_range limitation.
+template <auto V>
+[[nodiscard]] constexpr auto enum_name() noexcept -> detail::enable_if_t<decltype(V), string_view> {
+  constexpr string_view name = detail::enum_name_v<std::decay_t<decltype(V)>, V>;
+  static_assert(!name.empty(), "magic_enum::enum_name enum value does not have a name.");
+
+  return name;
+}
+
+// Returns name from enum value.
+// If enum value does not have name or value out of range, returns empty string.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_name(E value) noexcept -> detail::enable_if_t<E, string_view> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  if (const auto i = enum_index<D, S>(value)) {
+    return detail::names_v<D, S>[*i];
+  }
+  return {};
+}
+
+// Returns name from enum value.
+// If enum value does not have name or value out of range, returns empty string.
+template <detail::enum_subtype S, typename E>
+[[nodiscard]] constexpr auto enum_name(E value) -> detail::enable_if_t<E, string_view> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  return enum_name<D, S>(value);
+}
+
+// Returns std::array with names, sorted by enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_names() noexcept -> detail::enable_if_t<E, detail::names_t<E, S>> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  return detail::names_v<D, S>;
+}
+
+// Returns std::array with pairs (value, name), sorted by enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_entries() noexcept -> detail::enable_if_t<E, detail::entries_t<E, S>> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  return detail::entries_v<D, S>;
+}
+
+// Allows you to write magic_enum::enum_cast<foo>("bar", magic_enum::case_insensitive);
+inline constexpr auto case_insensitive = detail::case_insensitive<>{};
+
+// Obtains enum value from integer value.
+// Returns optional with enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_cast(underlying_type_t<E> value) noexcept -> detail::enable_if_t<E, optional<std::decay_t<E>>> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  if constexpr (detail::is_sparse_v<D, S> || (S == detail::enum_subtype::flags)) {
+#if defined(MAGIC_ENUM_ENABLE_HASH)
+    return detail::constexpr_switch<&detail::values_v<D, S>, detail::case_call_t::value>(
+        [](D v) { return optional<D>{v}; },
+        static_cast<D>(value),
+        detail::default_result_type_lambda<optional<D>>);
+#else
+    for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+      if (value == static_cast<underlying_type_t<D>>(enum_value<D, S>(i))) {
+        return static_cast<D>(value);
+      }
+    }
+    return {}; // Invalid value or out of range.
+#endif
+  } else {
+    if (value >= detail::min_v<D, S> && value <= detail::max_v<D, S>) {
+      return static_cast<D>(value);
+    }
+    return {}; // Invalid value or out of range.
+  }
+}
+
+// Obtains enum value from name.
+// Returns optional with enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>, typename BinaryPredicate = std::equal_to<>>
+[[nodiscard]] constexpr auto enum_cast(string_view value, [[maybe_unused]] BinaryPredicate p = {}) noexcept(detail::is_nothrow_invocable<BinaryPredicate>()) -> detail::enable_if_t<E, optional<std::decay_t<E>>, BinaryPredicate> {
+  using D = std::decay_t<E>;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+#if defined(MAGIC_ENUM_ENABLE_HASH)
+  if constexpr (detail::is_default_predicate<BinaryPredicate>()) {
+    return detail::constexpr_switch<&detail::names_v<D, S>, detail::case_call_t::index>(
+        [](std::size_t i) { return optional<D>{detail::values_v<D, S>[i]}; },
+        value,
+        detail::default_result_type_lambda<optional<D>>,
+        [&p](string_view lhs, string_view rhs) { return detail::cmp_equal(lhs, rhs, p); });
+  }
+#endif
+  for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+    if (detail::cmp_equal(value, detail::names_v<D, S>[i], p)) {
+      return enum_value<D, S>(i);
+    }
+  }
+  return {}; // Invalid value or out of range.
+}
+
+// Checks whether enum contains value with such value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_contains(E value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+
+  return static_cast<bool>(enum_cast<D, S>(static_cast<U>(value)));
+}
+
+// Checks whether enum contains value with such value.
+template <detail::enum_subtype S, typename E>
+[[nodiscard]] constexpr auto enum_contains(E value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+
+  return static_cast<bool>(enum_cast<D, S>(static_cast<U>(value)));
+}
+
+// Checks whether enum contains value with such integer value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_contains(underlying_type_t<E> value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+
+  return static_cast<bool>(enum_cast<D, S>(value));
+}
+
+// Checks whether enum contains enumerator with such name.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>, typename BinaryPredicate = std::equal_to<>>
+[[nodiscard]] constexpr auto enum_contains(string_view value, BinaryPredicate p = {}) noexcept(detail::is_nothrow_invocable<BinaryPredicate>()) -> detail::enable_if_t<E, bool, BinaryPredicate> {
+  using D = std::decay_t<E>;
+
+  return static_cast<bool>(enum_cast<D, S>(value, std::move(p)));
+}
+
+// Returns true if the enum integer value is in the range of values that can be reflected.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_reflected(underlying_type_t<E> value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+
+  if constexpr (detail::is_reflected_v<D, S>) {
+    constexpr auto min = detail::reflected_min<E, S>();
+    constexpr auto max = detail::reflected_max<E, S>();
+    return value >= min && value <= max;
+  } else {
+    return false;
+  }
+}
+
+// Returns true if the enum value is in the range of values that can be reflected.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_reflected(E value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+
+  return enum_reflected<D, S>(static_cast<underlying_type_t<D>>(value));
+}
+
+// Returns true if the enum value is in the range of values that can be reflected.
+template <detail::enum_subtype S, typename E>
+[[nodiscard]] constexpr auto enum_reflected(E value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+
+  return enum_reflected<D, S>(value);
+}
+
+template <bool AsFlags = true>
+inline constexpr auto as_flags = AsFlags ? detail::enum_subtype::flags : detail::enum_subtype::common;
+
+template <bool AsFlags = true>
+inline constexpr auto as_common = AsFlags ? detail::enum_subtype::common : detail::enum_subtype::flags;
+
+namespace bitwise_operators {
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E operator~(E rhs) noexcept {
+  return static_cast<E>(~static_cast<underlying_type_t<E>>(rhs));
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E operator|(E lhs, E rhs) noexcept {
+  return static_cast<E>(static_cast<underlying_type_t<E>>(lhs) | static_cast<underlying_type_t<E>>(rhs));
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E operator&(E lhs, E rhs) noexcept {
+  return static_cast<E>(static_cast<underlying_type_t<E>>(lhs) & static_cast<underlying_type_t<E>>(rhs));
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E operator^(E lhs, E rhs) noexcept {
+  return static_cast<E>(static_cast<underlying_type_t<E>>(lhs) ^ static_cast<underlying_type_t<E>>(rhs));
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E& operator|=(E& lhs, E rhs) noexcept {
+  return lhs = (lhs | rhs);
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E& operator&=(E& lhs, E rhs) noexcept {
+  return lhs = (lhs & rhs);
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E& operator^=(E& lhs, E rhs) noexcept {
+  return lhs = (lhs ^ rhs);
+}
+
+} // namespace magic_enum::bitwise_operators
+
+} // namespace magic_enum
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
+
+#undef MAGIC_ENUM_GET_ENUM_NAME_BUILTIN
+#undef MAGIC_ENUM_GET_TYPE_NAME_BUILTIN
+#undef MAGIC_ENUM_VS_2017_WORKAROUND
+#undef MAGIC_ENUM_ARRAY_CONSTEXPR
+#undef MAGIC_ENUM_FOR_EACH_256
+
+#endif // NEARGYE_MAGIC_ENUM_HPP

--- a/src/libraries/magic_enum/magic_enum_all.hpp
+++ b/src/libraries/magic_enum/magic_enum_all.hpp
@@ -1,0 +1,44 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.7
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_ALL_HPP
+#define NEARGYE_MAGIC_ENUM_ALL_HPP
+
+#include "magic_enum.hpp"
+#include "magic_enum_containers.hpp"
+#include "magic_enum_flags.hpp"
+#include "magic_enum_format.hpp"
+#include "magic_enum_fuse.hpp"
+#include "magic_enum_iostream.hpp"
+#include "magic_enum_switch.hpp"
+#include "magic_enum_utility.hpp"
+
+#endif // NEARGYE_MAGIC_ENUM_ALL_HPP

--- a/src/libraries/magic_enum/magic_enum_containers.hpp
+++ b/src/libraries/magic_enum/magic_enum_containers.hpp
@@ -1,0 +1,1174 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.7
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+// Copyright (c) 2022 - 2023 Bela Schaum <schaumb@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_CONTAINERS_HPP
+#define NEARGYE_MAGIC_ENUM_CONTAINERS_HPP
+
+#include "magic_enum.hpp"
+
+#if !defined(MAGIC_ENUM_NO_EXCEPTION) && (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+#ifndef MAGIC_ENUM_USE_STD_MODULE
+#  include <stdexcept>
+#endif
+#  define MAGIC_ENUM_THROW(...) throw (__VA_ARGS__)
+#else
+#ifndef MAGIC_ENUM_USE_STD_MODULE
+#  include <cstdlib>
+#endif
+#  define MAGIC_ENUM_THROW(...) std::abort()
+#endif
+
+namespace magic_enum::containers {
+
+namespace detail {
+
+template <typename T, typename = void>
+static constexpr bool is_transparent_v{};
+
+template <typename T>
+static constexpr bool is_transparent_v<T, std::void_t<typename T::is_transparent>>{true};
+
+template <typename Eq = std::equal_to<>, typename T1, typename T2>
+constexpr bool equal(T1&& t1, T2&& t2, Eq&& eq = {}) {
+  auto first1 = t1.begin();
+  auto last1 = t1.end();
+  auto first2 = t2.begin();
+  auto last2 = t2.end();
+
+  for (; first1 != last1; ++first1, ++first2) {
+    if (first2 == last2 || !eq(*first1, *first2)) {
+      return false;
+    }
+  }
+  return first2 == last2;
+}
+
+template <typename Cmp = std::less<>, typename T1, typename T2>
+constexpr bool lexicographical_compare(T1&& t1, T2&& t2, Cmp&& cmp = {}) noexcept {
+  auto first1 = t1.begin();
+  auto last1 = t1.end();
+  auto first2 = t2.begin();
+  auto last2 = t2.end();
+
+  // copied from std::lexicographical_compare
+  for (; (first1 != last1) && (first2 != last2); ++first1, (void)++first2) {
+    if (cmp(*first1, *first2)) {
+      return true;
+    }
+    if (cmp(*first2, *first1)) {
+      return false;
+    }
+  }
+  return (first1 == last1) && (first2 != last2);
+}
+
+template <typename T>
+constexpr std::size_t popcount(T x) noexcept {
+  std::size_t c = 0;
+  while (x > 0) {
+    c += x & 1;
+    x >>= 1;
+  }
+  return c;
+}
+
+template <typename Cmp = std::less<>, typename ForwardIt, typename E>
+constexpr ForwardIt lower_bound(ForwardIt first, ForwardIt last, E&& e, Cmp&& comp = {}) {
+  auto count = std::distance(first, last);
+  for (auto it = first; count > 0;) {
+    auto step = count / 2;
+    std::advance(it, step);
+    if (comp(*it, e)) {
+      first = ++it;
+      count -= step + 1;
+    } else {
+      count = step;
+    }
+  }
+  return first;
+}
+
+template <typename Cmp = std::less<>, typename BidirIt, typename E>
+constexpr auto equal_range(BidirIt begin, BidirIt end, E&& e, Cmp&& comp = {}) {
+  const auto first = lower_bound(begin, end, e, comp);
+  return std::pair{first, lower_bound(std::make_reverse_iterator(end), std::make_reverse_iterator(first), e, [&comp](auto&& lhs, auto&& rhs) { return comp(rhs, lhs); }).base()};
+}
+
+template <typename E = void, typename Cmp = std::less<E>, typename = void>
+class indexing {
+  [[nodiscard]] static constexpr auto get_indices() noexcept {
+    // reverse result index mapping
+    std::array<std::size_t, enum_count<E>()> rev_res{};
+
+    // std::iota
+    for (std::size_t i = 0; i < enum_count<E>(); ++i) {
+      rev_res[i] = i;
+    }
+
+    constexpr auto orig_values = enum_values<E>();
+    constexpr Cmp cmp{};
+
+    // ~std::sort
+    for (std::size_t i = 0; i < enum_count<E>(); ++i) {
+      for (std::size_t j = i + 1; j < enum_count<E>(); ++j) {
+        if (cmp(orig_values[rev_res[j]], orig_values[rev_res[i]])) {
+          auto tmp = rev_res[i];
+          rev_res[i] = rev_res[j];
+          rev_res[j] = tmp;
+        }
+      }
+    }
+
+    std::array<E, enum_count<E>()> sorted_values{};
+    // reverse the sorted indices
+    std::array<std::size_t, enum_count<E>()> res{};
+    for (std::size_t i = 0; i < enum_count<E>(); ++i) {
+      res[rev_res[i]] = i;
+      sorted_values[i] = orig_values[rev_res[i]];
+    }
+
+    return std::pair{sorted_values, res};
+  }
+
+  static constexpr auto indices = get_indices();
+
+ public:
+  [[nodiscard]] static constexpr const E* begin() noexcept { return indices.first.data(); }
+
+  [[nodiscard]] static constexpr const E* end() noexcept { return indices.first.data() + indices.first.size(); }
+
+  [[nodiscard]] static constexpr const E* it(std::size_t i) noexcept { return indices.first.data() + i; }
+
+  [[nodiscard]] static constexpr optional<std::size_t> at(E val) noexcept {
+    if (auto i = enum_index(val)) {
+      return indices.second[*i];
+    }
+    return {};
+  }
+};
+
+template <typename E, typename Cmp>
+class indexing<E, Cmp, std::enable_if_t<std::is_enum_v<std::decay_t<E>> && (std::is_same_v<Cmp, std::less<E>> || std::is_same_v<Cmp, std::less<>>)>> {
+   static constexpr auto& values = enum_values<E>();
+
+ public:
+   [[nodiscard]] static constexpr const E* begin() noexcept { return values.data(); }
+
+   [[nodiscard]] static constexpr const E* end() noexcept { return values.data() + values.size(); }
+
+  [[nodiscard]] static constexpr const E* it(std::size_t i) noexcept { return values.data() + i; }
+
+  [[nodiscard]] static constexpr optional<std::size_t> at(E val) noexcept { return enum_index(val); }
+};
+
+template <typename Cmp>
+struct indexing<void, Cmp, void> {
+  using is_transparent = std::true_type;
+
+  template <typename E>
+  [[nodiscard]] static constexpr optional<std::size_t> at(E val) noexcept {
+    return indexing<E, Cmp>::at(val);
+  }
+};
+
+template <typename E = void, typename Cmp = std::less<>, typename = void>
+struct name_sort_impl {
+  [[nodiscard]] constexpr bool operator()(E e1, E e2) const noexcept { return Cmp{}(enum_name(e1), enum_name(e2)); }
+};
+
+template <typename Cmp>
+struct name_sort_impl<void, Cmp> {
+  using is_transparent = std::true_type;
+
+  template <typename C = Cmp, typename = void>
+  struct FullCmp : C {};
+
+  template <typename C>
+  struct FullCmp<C, std::enable_if_t<!std::is_invocable_v<C, string_view, string_view> && std::is_invocable_v<C, char_type, char_type>>> {
+    [[nodiscard]] constexpr bool operator()(string_view s1, string_view s2) const noexcept { return lexicographical_compare<C>(s1, s2); }
+  };
+
+  template <typename E1, typename E2>
+  [[nodiscard]] constexpr std::enable_if_t<
+      // at least one of need to be an enum type
+      (std::is_enum_v<std::decay_t<E1>> || std::is_enum_v<std::decay_t<E2>>) &&
+      // if both is enum, only accept if the same enum
+      (!std::is_enum_v<std::decay_t<E1>> || !std::is_enum_v<std::decay_t<E2>> || std::is_same_v<E1, E2>) &&
+      // is invocable with comparator
+      (std::is_invocable_r_v<bool, FullCmp<>, std::conditional_t<std::is_enum_v<std::decay_t<E1>>, string_view, E1>, std::conditional_t<std::is_enum_v<std::decay_t<E2>>, string_view, E2>>),
+      bool>
+  operator()(E1 e1, E2 e2) const noexcept {
+    using D1 = std::decay_t<E1>;
+    using D2 = std::decay_t<E2>;
+    constexpr FullCmp<> cmp{};
+
+    if constexpr (std::is_enum_v<D1> && std::is_enum_v<D2>) {
+      return cmp(enum_name(e1), enum_name(e2));
+    } else if constexpr (std::is_enum_v<D1>) {
+      return cmp(enum_name(e1), e2);
+    } else /* if constexpr (std::is_enum_v<D2>) */ {
+      return cmp(e1, enum_name(e2));
+    }
+  }
+};
+
+struct raw_access_t {};
+
+template <typename Parent, typename Iterator, typename Getter, typename Predicate>
+struct FilteredIterator {
+  Parent parent;
+  Iterator first;
+  Iterator last;
+  Iterator current;
+  Getter getter;
+  Predicate predicate;
+
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = std::remove_reference_t<std::invoke_result_t<Getter, Parent, Iterator>>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;
+
+  constexpr FilteredIterator() noexcept = default;
+  constexpr FilteredIterator(const FilteredIterator&) = default;
+  constexpr FilteredIterator& operator=(const FilteredIterator&) = default;
+  constexpr FilteredIterator(FilteredIterator&&) noexcept = default;
+  constexpr FilteredIterator& operator=(FilteredIterator&&) noexcept = default;
+
+  template <typename OtherParent, typename OtherIterator, typename = std::enable_if_t<std::is_convertible_v<OtherParent, Parent> && std::is_convertible_v<OtherIterator, Iterator>>*>
+  constexpr explicit FilteredIterator(const FilteredIterator<OtherParent, OtherIterator, Getter, Predicate>& other)
+      : parent(other.parent), first(other.first), last(other.last), current(other.current), getter(other.getter), predicate(other.predicate) {}
+
+  constexpr FilteredIterator(Parent p, Iterator begin, Iterator end, Iterator curr, Getter get = {}, Predicate pred = {})
+      : parent(p), first(std::move(begin)), last(std::move(end)), current(std::move(curr)), getter{std::move(get)}, predicate{std::move(pred)} {
+    if (current == first && !predicate(parent, current)) {
+      ++*this;
+    }
+  }
+
+  [[nodiscard]] constexpr reference operator*() const { return getter(parent, current); }
+
+  [[nodiscard]] constexpr pointer operator->() const { return std::addressof(**this); }
+
+  constexpr FilteredIterator& operator++() {
+    do {
+      ++current;
+    } while (current != last && !predicate(parent, current));
+    return *this;
+  }
+
+  [[nodiscard]] constexpr FilteredIterator operator++(int) {
+    FilteredIterator cp = *this;
+    ++*this;
+    return cp;
+  }
+
+  constexpr FilteredIterator& operator--() {
+    do {
+      --current;
+    } while (current != first && !predicate(parent, current));
+    return *this;
+  }
+
+  [[nodiscard]] constexpr FilteredIterator operator--(int) {
+    FilteredIterator cp = *this;
+    --*this;
+    return cp;
+  }
+
+  [[nodiscard]] friend constexpr bool operator==(const FilteredIterator& lhs, const FilteredIterator& rhs) { return lhs.current == rhs.current; }
+
+  [[nodiscard]] friend constexpr bool operator!=(const FilteredIterator& lhs, const FilteredIterator& rhs) { return lhs.current != rhs.current; }
+};
+
+} // namespace detail
+
+template <typename E = void>
+using name_less = detail::name_sort_impl<E>;
+
+template <typename E = void>
+using name_greater = detail::name_sort_impl<E, std::greater<>>;
+
+using name_less_case_insensitive = detail::name_sort_impl<void, magic_enum::detail::case_insensitive<std::less<>>>;
+
+using name_greater_case_insensitive = detail::name_sort_impl<void, magic_enum::detail::case_insensitive<std::greater<>>>;
+
+template <typename E = void>
+using default_indexing = detail::indexing<E>;
+
+template <typename Cmp = std::less<>>
+using comparator_indexing = detail::indexing<void, Cmp>;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                          ARRAY                                                            //
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename E, typename V, typename Index = default_indexing<E>>
+struct array {
+  static_assert(std::is_enum_v<E>);
+  static_assert(std::is_trivially_constructible_v<Index>);
+  static_assert(enum_count<E>() > 0 && Index::at(enum_values<E>().front()));
+
+  using index_type = Index;
+  using container_type = std::array<V, enum_count<E>()>;
+
+  using value_type = typename container_type::value_type;
+  using size_type = typename container_type::size_type;
+  using difference_type = typename container_type::difference_type;
+  using reference = typename container_type::reference;
+  using const_reference = typename container_type::const_reference;
+  using pointer = typename container_type::pointer;
+  using const_pointer = typename container_type::const_pointer;
+  using iterator = typename container_type::iterator;
+  using const_iterator = typename container_type::const_iterator;
+  using reverse_iterator = typename container_type::reverse_iterator;
+  using const_reverse_iterator = typename container_type::const_reverse_iterator;
+
+  constexpr reference at(E pos) {
+    if (auto index = index_type::at(pos)) {
+      return a[*index];
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::array::at Unrecognized position"));
+  }
+
+  constexpr const_reference at(E pos) const {
+    if (auto index = index_type::at(pos)) {
+      return a[*index];
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::array::at: Unrecognized position"));
+  }
+
+  [[nodiscard]] constexpr reference operator[](E pos) {
+    auto i = index_type::at(pos);
+    return MAGIC_ENUM_ASSERT(i), a[*i];
+  }
+
+  [[nodiscard]] constexpr const_reference operator[](E pos) const {
+    auto i = index_type::at(pos);
+    return MAGIC_ENUM_ASSERT(i), a[*i];
+  }
+
+  [[nodiscard]] constexpr reference front() noexcept { return a.front(); }
+
+  [[nodiscard]] constexpr const_reference front() const noexcept { return a.front(); }
+
+  [[nodiscard]] constexpr reference back() noexcept { return a.back(); }
+
+  [[nodiscard]] constexpr const_reference back() const noexcept { return a.back(); }
+
+  [[nodiscard]] constexpr pointer data() noexcept { return a.data(); }
+
+  [[nodiscard]] constexpr const_pointer data() const noexcept { return a.data(); }
+
+  [[nodiscard]] constexpr iterator begin() noexcept { return a.begin(); }
+
+  [[nodiscard]] constexpr const_iterator begin() const noexcept { return a.begin(); }
+
+  [[nodiscard]] constexpr const_iterator cbegin() const noexcept { return a.cbegin(); }
+
+  [[nodiscard]] constexpr iterator end() noexcept { return a.end(); }
+
+  [[nodiscard]] constexpr const_iterator end() const noexcept { return a.end(); }
+
+  [[nodiscard]] constexpr const_iterator cend() const noexcept { return a.cend(); }
+
+  [[nodiscard]] constexpr iterator rbegin() noexcept { return a.rbegin(); }
+
+  [[nodiscard]] constexpr const_iterator rbegin() const noexcept { return a.rbegin(); }
+
+  [[nodiscard]] constexpr const_iterator crbegin() const noexcept { return a.crbegin(); }
+
+  [[nodiscard]] constexpr iterator rend() noexcept { return a.rend(); }
+
+  [[nodiscard]] constexpr const_iterator rend() const noexcept { return a.rend(); }
+
+  [[nodiscard]] constexpr const_iterator crend() const noexcept { return a.crend(); }
+
+  [[nodiscard]] constexpr bool empty() const noexcept { return a.empty(); }
+
+  [[nodiscard]] constexpr size_type size() const noexcept { return a.size(); }
+
+  [[nodiscard]] constexpr size_type max_size() const noexcept { return a.max_size(); }
+
+  constexpr void fill(const V& value) {
+    for (auto& v : a) {
+      v = value;
+    }
+  }
+
+  constexpr void swap(array& other) noexcept(std::is_nothrow_swappable_v<V>) {
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      auto v = std::move(other.a[i]);
+      other.a[i] = std::move(a[i]);
+      a[i] = std::move(v);
+    }
+  }
+
+  [[nodiscard]] friend constexpr bool operator==(const array& a1, const array& a2) { return detail::equal(a1, a2); }
+
+  [[nodiscard]] friend constexpr bool operator!=(const array& a1, const array& a2) { return !detail::equal(a1, a2); }
+
+  [[nodiscard]] friend constexpr bool operator<(const array& a1, const array& a2) { return detail::lexicographical_compare(a1, a2); }
+
+  [[nodiscard]] friend constexpr bool operator<=(const array& a1, const array& a2) { return !detail::lexicographical_compare(a2, a1); }
+
+  [[nodiscard]] friend constexpr bool operator>(const array& a1, const array& a2) { return detail::lexicographical_compare(a2, a1); }
+
+  [[nodiscard]] friend constexpr bool operator>=(const array& a1, const array& a2) { return !detail::lexicographical_compare(a1, a2); }
+
+  container_type a;
+};
+
+namespace detail {
+
+template <typename E, typename T, std::size_t N, std::size_t... I>
+constexpr array<E, std::remove_cv_t<T>> to_array_impl(T (&a)[N], std::index_sequence<I...>) {
+  return {{a[I]...}};
+}
+
+template <typename E, typename T, std::size_t N, std::size_t... I>
+constexpr array<E, std::remove_cv_t<T>> to_array_impl(T(&&a)[N], std::index_sequence<I...>) {
+  return {{std::move(a[I])...}};
+}
+
+} // namespace detail
+
+template <typename E, typename T, std::size_t N>
+constexpr std::enable_if_t<(enum_count<E>() == N), array<E, std::remove_cv_t<T>>> to_array(T (&a)[N]) {
+  return detail::to_array_impl<E>(a, std::make_index_sequence<N>{});
+}
+
+template <typename E, typename T, std::size_t N>
+constexpr std::enable_if_t<(enum_count<E>() == N), array<E, std::remove_cv_t<T>>> to_array(T(&&a)[N]) {
+  return detail::to_array_impl<E>(std::move(a), std::make_index_sequence<N>{});
+}
+
+template <typename E, typename... Ts>
+constexpr std::enable_if_t<(enum_count<E>() == sizeof...(Ts)), array<E, std::remove_cv_t<std::common_type_t<Ts...>>>> make_array(Ts&&... ts) {
+  return {{std::forward<Ts>(ts)...}};
+}
+
+inline constexpr detail::raw_access_t raw_access{};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                         BITSET                                                            //
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename E, typename Index = default_indexing<E>>
+class bitset {
+  static_assert(std::is_enum_v<E>);
+  static_assert(std::is_trivially_constructible_v<Index>);
+  static_assert(enum_count<E>() > 0 && Index::at(enum_values<E>().front()));
+
+  using base_type = std::conditional_t<enum_count<E>() <= 8,  std::uint_least8_t,
+                    std::conditional_t<enum_count<E>() <= 16, std::uint_least16_t,
+                    std::conditional_t<enum_count<E>() <= 32, std::uint_least32_t,
+                                                              std::uint_least64_t>>>;
+
+  static constexpr std::size_t bits_per_base = sizeof(base_type) * 8;
+  static constexpr std::size_t base_type_count = (enum_count<E>() > 0 ? (enum_count<E>() - 1) / bits_per_base + 1 : 0);
+  static constexpr std::size_t not_interested = base_type_count * bits_per_base - enum_count<E>();
+  static constexpr base_type last_value_max = (base_type{1} << (bits_per_base - not_interested)) - 1;
+
+  template <typename parent_t = bitset*>
+  class reference_impl {
+    friend class bitset;
+
+    parent_t parent;
+    std::size_t num_index;
+    base_type bit_index;
+
+    constexpr reference_impl(parent_t p, std::size_t i) noexcept : reference_impl(p, std::pair{i / bits_per_base, base_type{1} << (i % bits_per_base)}) {}
+
+    constexpr reference_impl(parent_t p, std::pair<std::size_t, base_type> i) noexcept : parent(p), num_index(std::get<0>(i)), bit_index(std::get<1>(i)) {}
+
+   public:
+    constexpr reference_impl& operator=(bool v) noexcept {
+      if (v) {
+        parent->a[num_index] |= bit_index;
+      } else {
+        parent->a[num_index] &= ~bit_index;
+      }
+      return *this;
+    }
+
+    constexpr reference_impl& operator=(const reference_impl& v) noexcept {
+      if (this == &v) {
+        return *this;
+      }
+      *this = static_cast<bool>(v);
+      return *this;
+    }
+
+    [[nodiscard]] constexpr operator bool() const noexcept { return (parent->a[num_index] & bit_index) > 0; }
+
+    [[nodiscard]] constexpr bool operator~() const noexcept { return !static_cast<bool>(*this); }
+
+    constexpr reference_impl& flip() noexcept {
+      *this = ~*this;
+      return *this;
+    }
+  };
+
+  template <typename T>
+  [[nodiscard]] constexpr T to_(detail::raw_access_t) const {
+    T res{};
+    T flag{1};
+    for (std::size_t i = 0; i < size(); ++i, flag <<= 1) {
+      if (const_reference{this, i}) {
+        if (i >= sizeof(T) * 8) {
+          MAGIC_ENUM_THROW(std::overflow_error("magic_enum::containers::bitset::to: Cannot represent enum in this type"));
+        }
+        res |= flag;
+      }
+    }
+    return res;
+  }
+
+ public:
+  using index_type = Index;
+  using container_type = std::array<base_type, base_type_count>;
+  using reference = reference_impl<>;
+  using const_reference = reference_impl<const bitset*>;
+
+  constexpr explicit bitset(detail::raw_access_t = raw_access) noexcept : a{{}} {}
+
+  constexpr explicit bitset(detail::raw_access_t, unsigned long long val) : a{{}} {
+    unsigned long long bit{1};
+    for (std::size_t i = 0; i < (sizeof(val) * 8); ++i, bit <<= 1) {
+      if ((val & bit) > 0) {
+        if (i >= enum_count<E>()) {
+          MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::constructor: Upper bit set in raw number"));
+        }
+
+        reference{this, i} = true;
+      }
+    }
+  }
+
+  constexpr explicit bitset(detail::raw_access_t, string_view sv, string_view::size_type pos = 0, string_view::size_type n = string_view::npos, char_type zero = static_cast<char_type>('0'), char_type one = static_cast<char_type>('1'))
+      : a{{}} {
+    std::size_t i = 0;
+    for (auto c : sv.substr(pos, n)) {
+      if (c == one) {
+        if (i >= enum_count<E>()) {
+          MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::constructor: Upper bit set in raw string"));
+        }
+        reference{this, i} = true;
+      } else if (c != zero) {
+        MAGIC_ENUM_THROW(std::invalid_argument("magic_enum::containers::bitset::constructor: Unrecognized character in raw string"));
+      }
+      ++i;
+    }
+  }
+
+  constexpr explicit bitset(detail::raw_access_t, const char_type* str, std::size_t n = ~std::size_t{0}, char_type zero = static_cast<char_type>('0'), char_type one = static_cast<char_type>('1'))
+      : bitset(string_view{str, (std::min)(std::char_traits<char_type>::length(str), n)}, 0, n, zero, one) {}
+
+  constexpr bitset(std::initializer_list<E> starters) : a{{}} {
+    if constexpr (magic_enum::detail::subtype_v<E> == magic_enum::detail::enum_subtype::flags) {
+      for (auto& f : starters) {
+        *this |= bitset(f);
+      }
+    } else {
+      for (auto& f : starters) {
+        set(f);
+      }
+    }
+  }
+  template <typename V, std::enable_if_t<std::is_same_v<V, E> && magic_enum::detail::subtype_v<V> == magic_enum::detail::enum_subtype::flags, int> = 0>
+  constexpr explicit bitset(V starter) : a{{}} {
+    auto u = enum_underlying(starter);
+    for (E v : enum_values<E>()) {
+      if (auto ul = enum_underlying(v); (ul & u) != 0) {
+        u &= ~ul;
+        (*this)[v] = true;
+      }
+    }
+    if (u != 0) {
+      MAGIC_ENUM_THROW(std::invalid_argument("magic_enum::containers::bitset::constructor: Unrecognized enum value in flag"));
+    }
+  }
+
+  template <typename Cmp = std::equal_to<>>
+  constexpr explicit bitset(string_view sv, Cmp&& cmp = {}, char_type sep = static_cast<char_type>('|')) {
+    for (std::size_t to = 0; (to = magic_enum::detail::find(sv, sep)) != string_view::npos; sv.remove_prefix(to + 1)) {
+      if (auto v = enum_cast<E>(sv.substr(0, to), cmp)) {
+        set(*v);
+      } else {
+        MAGIC_ENUM_THROW(std::invalid_argument("magic_enum::containers::bitset::constructor: Unrecognized enum value in string"));
+      }
+    }
+    if (!sv.empty()) {
+      if (auto v = enum_cast<E>(sv, cmp)) {
+        set(*v);
+      } else {
+        MAGIC_ENUM_THROW(std::invalid_argument("magic_enum::containers::bitset::constructor: Unrecognized enum value in string"));
+      }
+    }
+  }
+
+  [[nodiscard]] friend constexpr bool operator==(const bitset& lhs, const bitset& rhs) noexcept { return detail::equal(lhs.a, rhs.a); }
+
+  [[nodiscard]] friend constexpr bool operator!=(const bitset& lhs, const bitset& rhs) noexcept { return !detail::equal(lhs.a, rhs.a); }
+
+  [[nodiscard]] constexpr bool operator[](E pos) const {
+    auto i = index_type::at(pos);
+    return MAGIC_ENUM_ASSERT(i), static_cast<bool>(const_reference(this, *i));
+  }
+
+  [[nodiscard]] constexpr reference operator[](E pos) {
+    auto i = index_type::at(pos);
+    return MAGIC_ENUM_ASSERT(i), reference{this, *i};
+  }
+
+  constexpr bool test(E pos) const {
+    if (auto i = index_type::at(pos)) {
+      return static_cast<bool>(const_reference(this, *i));
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::test: Unrecognized position"));
+  }
+
+  [[nodiscard]] constexpr bool all() const noexcept {
+    if constexpr (base_type_count == 0) {
+      return true;
+    }
+
+    for (std::size_t i = 0; i < base_type_count - (not_interested > 0); ++i) {
+      auto check = ~a[i];
+      if (check) {
+        return false;
+      }
+    }
+
+    if constexpr (not_interested > 0) {
+      return a[base_type_count - 1] == last_value_max;
+    }
+  }
+
+  [[nodiscard]] constexpr bool any() const noexcept {
+    for (auto& v : a) {
+      if (v > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] constexpr bool none() const noexcept { return !any(); }
+
+  [[nodiscard]] constexpr std::size_t count() const noexcept {
+    std::size_t c = 0;
+    for (auto& v : a) {
+      c += detail::popcount(v);
+    }
+    return c;
+  }
+
+  [[nodiscard]] constexpr std::size_t size() const noexcept { return enum_count<E>(); }
+
+  [[nodiscard]] constexpr std::size_t max_size() const noexcept { return enum_count<E>(); }
+
+  constexpr bitset& operator&=(const bitset& other) noexcept {
+    for (std::size_t i = 0; i < base_type_count; ++i) {
+      a[i] &= other.a[i];
+    }
+    return *this;
+  }
+
+  constexpr bitset& operator|=(const bitset& other) noexcept {
+    for (std::size_t i = 0; i < base_type_count; ++i) {
+      a[i] |= other.a[i];
+    }
+    return *this;
+  }
+
+  constexpr bitset& operator^=(const bitset& other) noexcept {
+    for (std::size_t i = 0; i < base_type_count; ++i) {
+      a[i] ^= other.a[i];
+    }
+    return *this;
+  }
+
+  [[nodiscard]] constexpr bitset operator~() const noexcept {
+    bitset res;
+    for (std::size_t i = 0; i < base_type_count - (not_interested > 0); ++i) {
+      res.a[i] = ~a[i];
+    }
+
+    if constexpr (not_interested > 0) {
+      res.a[base_type_count - 1] = ~a[base_type_count - 1] & last_value_max;
+    }
+    return res;
+  }
+
+  constexpr bitset& set() noexcept {
+    for (std::size_t i = 0; i < base_type_count - (not_interested > 0); ++i) {
+      a[i] = ~base_type{0};
+    }
+
+    if constexpr (not_interested > 0) {
+      a[base_type_count - 1] = last_value_max;
+    }
+    return *this;
+  }
+
+  constexpr bitset& set(E pos, bool value = true) {
+    if (auto i = index_type::at(pos)) {
+      reference{this, *i} = value;
+      return *this;
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::set: Unrecognized position"));
+  }
+
+  constexpr bitset& reset() noexcept { return *this = bitset{}; }
+
+  constexpr bitset& reset(E pos) {
+    if (auto i = index_type::at(pos)) {
+      reference{this, *i} = false;
+      return *this;
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::reset: Unrecognized position"));
+  }
+
+  constexpr bitset& flip() noexcept { return *this = ~*this; }
+
+  [[nodiscard]] friend constexpr bitset operator&(const bitset& lhs, const bitset& rhs) noexcept {
+    bitset cp = lhs;
+    cp &= rhs;
+    return cp;
+  }
+
+  [[nodiscard]] friend constexpr bitset operator|(const bitset& lhs, const bitset& rhs) noexcept {
+    bitset cp = lhs;
+    cp |= rhs;
+    return cp;
+  }
+
+  [[nodiscard]] friend constexpr bitset operator^(const bitset& lhs, const bitset& rhs) noexcept {
+    bitset cp = lhs;
+    cp ^= rhs;
+    return cp;
+  }
+
+  template <typename V = E>
+  [[nodiscard]] constexpr explicit operator std::enable_if_t<magic_enum::detail::subtype_v<V> == magic_enum::detail::enum_subtype::flags, E>() const {
+    E res{};
+    for (const auto& e : enum_values<E>()) {
+      if (test(e)) {
+        res |= e;
+      }
+    }
+    return res;
+  }
+
+  [[nodiscard]] string to_string(char_type sep = static_cast<char_type>('|')) const {
+    string name;
+
+    for (const auto& e : enum_values<E>()) {
+      if (test(e)) {
+        if (!name.empty()) {
+          name.append(1, sep);
+        }
+        auto n = enum_name(e);
+        name.append(n.data(), n.size());
+      }
+    }
+    return name;
+  }
+
+  [[nodiscard]] string to_string(detail::raw_access_t, char_type zero = static_cast<char_type>('0'), char_type one = static_cast<char_type>('1')) const {
+    string name;
+    name.reserve(size());
+    for (std::size_t i = 0; i < size(); ++i) {
+      name.append(1, const_reference{this, i} ? one : zero);
+    }
+    return name;
+  }
+
+  [[nodiscard]] constexpr unsigned long long to_ullong(detail::raw_access_t raw) const { return to_<unsigned long long>(raw); }
+
+  [[nodiscard]] constexpr unsigned long long to_ulong(detail::raw_access_t raw) const { return to_<unsigned long>(raw); }
+
+  friend std::ostream& operator<<(std::ostream& o, const bitset& bs) { return o << bs.to_string(); }
+
+  friend std::istream& operator>>(std::istream& i, bitset& bs) {
+    string s;
+    if (i >> s; !s.empty()) {
+      bs = bitset(string_view{s});
+    }
+    return i;
+  }
+
+ private:
+  container_type a;
+};
+
+template <typename V, int = 0>
+explicit bitset(V starter) -> bitset<V>;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                           SET                                                             //
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename E, typename Cmp = std::less<E>>
+class set {
+  using index_type = detail::indexing<E, Cmp>;
+  struct Getter {
+    constexpr const E& operator()(const set*, const E* p) const noexcept { return *p; }
+  };
+  struct Predicate {
+    constexpr bool operator()(const set* h, const E* e) const noexcept { return h->a[*e]; }
+  };
+
+ public:
+  using container_type = bitset<E, index_type>;
+  using key_type = E;
+  using value_type = E;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using key_compare = Cmp;
+  using value_compare = Cmp;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using iterator = detail::FilteredIterator<const set*, const E*, Getter, Predicate>;
+  using const_iterator = detail::FilteredIterator<const set*, const E*, Getter, Predicate>;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  constexpr set() noexcept = default;
+
+  template <typename InputIt>
+  constexpr set(InputIt first, InputIt last) {
+    while (first != last) {
+      insert(*first++);
+    }
+  }
+
+  constexpr set(std::initializer_list<E> ilist) {
+    for (auto e : ilist) {
+      insert(e);
+    }
+  }
+  template <typename V, std::enable_if_t<std::is_same_v<V, E> && magic_enum::detail::subtype_v<V> == magic_enum::detail::enum_subtype::flags, int> = 0>
+  constexpr explicit set(V starter) {
+    auto u = enum_underlying(starter);
+    for (E v : enum_values<E>()) {
+      if ((enum_underlying(v) & u) != 0) {
+        insert(v);
+      }
+    }
+  }
+
+  constexpr set(const set&) noexcept = default;
+  constexpr set(set&&) noexcept = default;
+
+  constexpr set& operator=(const set&) noexcept = default;
+  constexpr set& operator=(set&&) noexcept = default;
+  constexpr set& operator=(std::initializer_list<E> ilist) {
+    for (auto e : ilist) {
+      insert(e);
+    }
+  }
+
+  constexpr const_iterator begin() const noexcept {
+    return const_iterator{this, index_type::begin(), index_type::end(), index_type::begin()};
+  }
+
+  constexpr const_iterator end() const noexcept {
+    return const_iterator{this, index_type::begin(), index_type::end(), index_type::end()};
+  }
+
+  constexpr const_iterator cbegin() const noexcept { return begin(); }
+
+  constexpr const_iterator cend() const noexcept { return end(); }
+
+  constexpr const_reverse_iterator rbegin() const noexcept { return {end()}; }
+
+  constexpr const_reverse_iterator rend() const noexcept { return {begin()}; }
+
+  constexpr const_reverse_iterator crbegin() const noexcept { return rbegin(); }
+
+  constexpr const_reverse_iterator crend() const noexcept { return rend(); }
+
+  [[nodiscard]] constexpr bool empty() const noexcept { return s == 0; }
+
+  [[nodiscard]] constexpr size_type size() const noexcept { return s; }
+
+  [[nodiscard]] constexpr size_type max_size() const noexcept { return a.max_size(); }
+
+  constexpr void clear() noexcept {
+    a.reset();
+    s = 0;
+  }
+
+  constexpr std::pair<iterator, bool> insert(const value_type& value) noexcept {
+    if (auto i = index_type::at(value)) {
+      typename container_type::reference ref = a[value];
+      bool r = !ref;
+      if (r) {
+        ref = true;
+        ++s;
+      }
+
+      return {iterator{this, index_type::begin(), index_type::end(), index_type::it(*i)}, r};
+    }
+    return {end(), false};
+  }
+
+  constexpr std::pair<iterator, bool> insert(value_type&& value) noexcept { return insert(value); }
+
+  constexpr iterator insert(const_iterator, const value_type& value) noexcept { return insert(value).first; }
+
+  constexpr iterator insert(const_iterator hint, value_type&& value) noexcept { return insert(hint, value); }
+
+  template <typename InputIt>
+  constexpr void insert(InputIt first, InputIt last) noexcept {
+    while (first != last) {
+      insert(*first++);
+    }
+  }
+
+  constexpr void insert(std::initializer_list<value_type> ilist) noexcept {
+    for (auto v : ilist) {
+      insert(v);
+    }
+  }
+
+  template <typename... Args>
+  constexpr std::pair<iterator, bool> emplace(Args&&... args) noexcept {
+    return insert({std::forward<Args>(args)...});
+  }
+
+  template <typename... Args>
+  constexpr iterator emplace_hint(const_iterator, Args&&... args) noexcept {
+    return emplace(std::forward<Args>(args)...).first;
+  }
+
+  constexpr iterator erase(const_iterator pos) noexcept {
+    erase(*pos++);
+    return pos;
+  }
+
+  constexpr iterator erase(const_iterator first, const_iterator last) noexcept {
+    while ((first = erase(first)) != last) {
+    }
+    return first;
+  }
+
+  constexpr size_type erase(const key_type& key) noexcept {
+    typename container_type::reference ref = a[key];
+    bool res = ref;
+    if (res) {
+      --s;
+    }
+    ref = false;
+    return res;
+  }
+
+  template <typename K, typename KC = key_compare>
+  constexpr std::enable_if_t<detail::is_transparent_v<KC>, size_type> erase(K&& x) noexcept {
+    size_type c = 0;
+    for (auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{}); first != last;) {
+      c += erase(*first++);
+    }
+    return c;
+  }
+
+  void swap(set& other) noexcept {
+    set cp = *this;
+    *this = other;
+    other = cp;
+  }
+
+  [[nodiscard]] constexpr size_type count(const key_type& key) const noexcept { return index_type::at(key) && a[key]; }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, size_type> count(const K& x) const {
+    size_type c = 0;
+    for (auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{}); first != last; ++first) {
+      c += count(*first);
+    }
+    return c;
+  }
+
+  [[nodiscard]] constexpr const_iterator find(const key_type& key) const noexcept {
+    if (auto i = index_type::at(key); i && a.test(key)) {
+      return const_iterator{this, index_type::begin(), index_type::end(), index_type::it(*i)};
+    }
+    return end();
+  }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, const_iterator> find(const K& x) const {
+    for (auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{}); first != last; ++first) {
+      if (a.test(*first)) {
+        return find(*first);
+      }
+    }
+    return end();
+  }
+
+  [[nodiscard]] constexpr bool contains(const key_type& key) const noexcept { return count(key); }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, bool> contains(const K& x) const noexcept {
+    return count(x) > 0;
+  }
+
+  [[nodiscard]] constexpr std::pair<const_iterator, const_iterator> equal_range(const key_type& key) const noexcept { return {lower_bound(key), upper_bound(key)}; }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, std::pair<const_iterator, const_iterator>> equal_range(const K& x) const noexcept {
+    return {lower_bound(x), upper_bound(x)};
+  }
+
+  [[nodiscard]] constexpr const_iterator lower_bound(const key_type& key) const noexcept {
+    if (auto i = index_type::at(key)) {
+      auto it = const_iterator{this, index_type::begin(), index_type::end(), index_type::it(*i)};
+      return a.test(key) ? it : std::next(it);
+    }
+    return end();
+  }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, const_iterator> lower_bound(const K& x) const noexcept {
+    auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{});
+    return first != last ? lower_bound(*first) : end();
+  }
+
+  [[nodiscard]] constexpr const_iterator upper_bound(const key_type& key) const noexcept {
+    if (auto i = index_type::at(key)) {
+      return std::next(const_iterator{this, index_type::begin(), index_type::end(), index_type::it(*i)});
+    }
+    return end();
+  }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, const_iterator> upper_bound(const K& x) const noexcept {
+    auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{});
+    return first != last ? upper_bound(*std::prev(last)) : end();
+  }
+
+  [[nodiscard]] constexpr key_compare key_comp() const { return {}; }
+
+  [[nodiscard]] constexpr value_compare value_comp() const { return {}; }
+
+  [[nodiscard]] constexpr friend bool operator==(const set& lhs, const set& rhs) noexcept { return lhs.a == rhs.a; }
+
+  [[nodiscard]] constexpr friend bool operator!=(const set& lhs, const set& rhs) noexcept { return lhs.a != rhs.a; }
+
+  [[nodiscard]] constexpr friend bool operator<(const set& lhs, const set& rhs) noexcept {
+    if (lhs.s < rhs.s) {
+      return true;
+    }
+    if (rhs.s < lhs.s) {
+      return false;
+    }
+
+    for (auto it = index_type::begin(); it != index_type::end(); ++it) {
+      if (auto c = rhs.contains(*it); c != lhs.contains(*it)) {
+        return c;
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] constexpr friend bool operator<=(const set& lhs, const set& rhs) noexcept { return !(rhs < lhs); }
+
+  [[nodiscard]] constexpr friend bool operator>(const set& lhs, const set& rhs) noexcept { return rhs < lhs; }
+
+  [[nodiscard]] constexpr friend bool operator>=(const set& lhs, const set& rhs) noexcept { return !(lhs < rhs); }
+
+  template <typename Pred>
+  size_type erase_if(Pred pred) {
+    auto old_size = size();
+    for (auto i = begin(), last = end(); i != last;) {
+      if (pred(*i)) {
+        i = erase(i);
+      } else {
+        ++i;
+      }
+    }
+    return old_size - size();
+  }
+
+ private:
+  container_type a;
+  std::size_t s = 0;
+};
+
+template <typename V, int = 0>
+explicit set(V starter) -> set<V>;
+
+template <auto I, typename E, typename V, typename Index>
+constexpr std::enable_if_t<(std::is_integral_v<decltype(I)> && I < enum_count<E>()), V&> get(array<E, V, Index>& a) noexcept {
+  return a.a[I];
+}
+
+template <auto I, typename E, typename V, typename Index>
+constexpr std::enable_if_t<(std::is_integral_v<decltype(I)> && I < enum_count<E>()), V&&> get(array<E, V, Index>&& a) noexcept {
+  return std::move(a.a[I]);
+}
+
+template <auto I, typename E, typename V, typename Index>
+constexpr std::enable_if_t<(std::is_integral_v<decltype(I)> && I < enum_count<E>()), const V&> get(const array<E, V, Index>& a) noexcept {
+  return a.a[I];
+}
+
+template <auto I, typename E, typename V, typename Index>
+constexpr std::enable_if_t<(std::is_integral_v<decltype(I)> && I < enum_count<E>()), const V&&> get(const array<E, V, Index>&& a) noexcept {
+  return std::move(a.a[I]);
+}
+
+template <auto Enum, typename E, typename V, typename Index>
+constexpr std::enable_if_t<std::is_same_v<decltype(Enum), E> && enum_contains(Enum), V&> get(array<E, V, Index>& a) {
+  return a[Enum];
+}
+
+template <auto Enum, typename E, typename V, typename Index>
+constexpr std::enable_if_t<std::is_same_v<decltype(Enum), E> && enum_contains(Enum), V&&> get(array<E, V, Index>&& a) {
+  return std::move(a[Enum]);
+}
+
+template <auto Enum, typename E, typename V, typename Index>
+constexpr std::enable_if_t<std::is_same_v<decltype(Enum), E> && enum_contains(Enum), const V&> get(const array<E, V, Index>& a) {
+  return a[Enum];
+}
+
+template <auto Enum, typename E, typename V, typename Index>
+constexpr std::enable_if_t<std::is_same_v<decltype(Enum), E> && enum_contains(Enum), const V&&> get(const array<E, V, Index>&& a) {
+  return std::move(a[Enum]);
+}
+
+} // namespace magic_enum::containers
+
+#endif // NEARGYE_MAGIC_ENUM_CONTAINERS_HPP

--- a/src/libraries/magic_enum/magic_enum_flags.hpp
+++ b/src/libraries/magic_enum/magic_enum_flags.hpp
@@ -1,0 +1,222 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.7
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_FLAGS_HPP
+#define NEARGYE_MAGIC_ENUM_FLAGS_HPP
+
+#include "magic_enum.hpp"
+
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized" // May be used uninitialized 'return {};'.
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#endif
+
+namespace magic_enum {
+
+namespace detail {
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr U values_ors() noexcept {
+  static_assert(S == enum_subtype::flags, "magic_enum::detail::values_ors requires valid subtype.");
+
+  auto ors = U{0};
+  for (std::size_t i = 0; i < count_v<E, S>; ++i) {
+    ors |= static_cast<U>(values_v<E, S>[i]);
+  }
+
+  return ors;
+}
+
+} // namespace magic_enum::detail
+
+// Returns name from enum-flags value.
+// If enum-flags value does not have name or value out of range, returns empty string.
+template <typename E>
+[[nodiscard]] auto enum_flags_name(E value, char_type sep = static_cast<char_type>('|')) -> detail::enable_if_t<E, string> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+  constexpr auto S = detail::enum_subtype::flags;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  string name;
+  auto check_value = U{0};
+  for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+    if (const auto v = static_cast<U>(enum_value<D, S>(i)); (static_cast<U>(value) & v) != 0) {
+      if (const auto n = detail::names_v<D, S>[i]; !n.empty()) {
+        check_value |= v;
+        if (!name.empty()) {
+          name.append(1, sep);
+        }
+        name.append(n.data(), n.size());
+      } else {
+        return {}; // Value out of range.
+      }
+    }
+  }
+
+  if (check_value != 0 && check_value == static_cast<U>(value)) {
+    return name;
+  }
+  return {}; // Invalid value or out of range.
+}
+
+// Obtains enum-flags value from integer value.
+// Returns optional with enum-flags value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_flags_cast(underlying_type_t<E> value) noexcept -> detail::enable_if_t<E, optional<std::decay_t<E>>> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+  constexpr auto S = detail::enum_subtype::flags;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  if constexpr (detail::count_v<D, S> == 0) {
+    static_cast<void>(value);
+    return {}; // Empty enum.
+  } else {
+    if constexpr (detail::is_sparse_v<D, S>) {
+      auto check_value = U{0};
+      for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+        if (const auto v = static_cast<U>(enum_value<D, S>(i)); (value & v) != 0) {
+          check_value |= v;
+        }
+      }
+
+      if (check_value != 0 && check_value == value) {
+        return static_cast<D>(value);
+      }
+    } else {
+      constexpr auto min = detail::min_v<D, S>;
+      constexpr auto max = detail::values_ors<D, S>();
+
+      if (value >= min && value <= max) {
+        return static_cast<D>(value);
+      }
+    }
+    return {}; // Invalid value or out of range.
+  }
+}
+
+// Obtains enum-flags value from name.
+// Returns optional with enum-flags value.
+template <typename E, typename BinaryPredicate = std::equal_to<>>
+[[nodiscard]] constexpr auto enum_flags_cast(string_view value, [[maybe_unused]] BinaryPredicate p = {}) noexcept(detail::is_nothrow_invocable<BinaryPredicate>()) -> detail::enable_if_t<E, optional<std::decay_t<E>>, BinaryPredicate> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+  constexpr auto S = detail::enum_subtype::flags;
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+  if constexpr (detail::count_v<D, S> == 0) {
+    static_cast<void>(value);
+    return {}; // Empty enum.
+  } else {
+    auto result = U{0};
+    while (!value.empty()) {
+      const auto d = detail::find(value, '|');
+      const auto s = (d == string_view::npos) ? value : value.substr(0, d);
+      auto f = U{0};
+      for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+        if (detail::cmp_equal(s, detail::names_v<D, S>[i], p)) {
+          f = static_cast<U>(enum_value<D, S>(i));
+          result |= f;
+          break;
+        }
+      }
+      if (f == U{0}) {
+        return {}; // Invalid value or out of range.
+      }
+      value.remove_prefix((d == string_view::npos) ? value.size() : d + 1);
+    }
+
+    if (result != U{0}) {
+      return static_cast<D>(result);
+    }
+    return {}; // Invalid value or out of range.
+  }
+}
+
+// Checks whether enum-flags contains value with such value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_flags_contains(E value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+
+  return static_cast<bool>(enum_flags_cast<D>(static_cast<U>(value)));
+}
+
+// Checks whether enum-flags contains value with such integer value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_flags_contains(underlying_type_t<E> value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+
+  return static_cast<bool>(enum_flags_cast<D>(value));
+}
+
+// Checks whether enum-flags contains enumerator with such name.
+template <typename E, typename BinaryPredicate = std::equal_to<>>
+[[nodiscard]] constexpr auto enum_flags_contains(string_view value, BinaryPredicate p = {}) noexcept(detail::is_nothrow_invocable<BinaryPredicate>()) -> detail::enable_if_t<E, bool, BinaryPredicate> {
+  using D = std::decay_t<E>;
+
+  return static_cast<bool>(enum_flags_cast<D>(value, std::move(p)));
+}
+
+// Checks whether `flags set` contains `flag`.
+// Note: If `flag` equals 0, it returns false, as 0 is not a flag.
+template <typename E>
+constexpr auto enum_flags_test(E flags, E flag) noexcept -> detail::enable_if_t<E, bool> {
+  using U = underlying_type_t<E>;
+
+  return static_cast<U>(flag) && ((static_cast<U>(flags) & static_cast<U>(flag)) == static_cast<U>(flag));
+}
+
+// Checks whether `lhs flags set` and `rhs flags set` have common flags.
+// Note: If `lhs flags set` or `rhs flags set` equals 0, it returns false, as 0 is not a flag, and therfore cannot have any matching flag.
+template <typename E>
+constexpr auto enum_flags_test_any(E lhs, E rhs) noexcept -> detail::enable_if_t<E, bool> {
+  using U = underlying_type_t<E>;
+
+  return (static_cast<U>(lhs) & static_cast<U>(rhs)) != 0;
+}
+
+} // namespace magic_enum
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
+
+#endif // NEARGYE_MAGIC_ENUM_FLAGS_HPP

--- a/src/libraries/magic_enum/magic_enum_format.hpp
+++ b/src/libraries/magic_enum/magic_enum_format.hpp
@@ -1,0 +1,114 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.7
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_FORMAT_HPP
+#define NEARGYE_MAGIC_ENUM_FORMAT_HPP
+
+#include "magic_enum.hpp"
+#include "magic_enum_flags.hpp"
+
+#if !defined(MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT)
+#  define MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT 1
+#  define MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT_AUTO_DEFINE
+#endif
+
+namespace magic_enum::customize {
+  // customize enum to enable/disable automatic std::format
+  template <typename E>
+  constexpr bool enum_format_enabled() noexcept {
+    return MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT;
+  }
+} // magic_enum::customize
+
+#if defined(__cpp_lib_format)
+
+#ifndef MAGIC_ENUM_USE_STD_MODULE
+#include <format>
+#endif
+
+template <typename E>
+struct std::formatter<E, std::enable_if_t<std::is_enum_v<std::decay_t<E>> && magic_enum::customize::enum_format_enabled<E>(), char>> : std::formatter<std::string_view, char> {
+  template <class FormatContext>
+  auto format(E e, FormatContext& ctx) const {
+    static_assert(std::is_same_v<char, string_view::value_type>, "formatter requires string_view::value_type type same as char.");
+    using D = std::decay_t<E>;
+
+    if constexpr (magic_enum::detail::supported<D>::value) {
+      if constexpr (magic_enum::detail::subtype_v<D> == magic_enum::detail::enum_subtype::flags) {
+        if (const auto name = magic_enum::enum_flags_name<D>(e); !name.empty()) {
+          return formatter<std::string_view, char>::format(std::string_view{name.data(), name.size()}, ctx);
+        }
+      } else {
+        if (const auto name = magic_enum::enum_name<D>(e); !name.empty()) {
+          return formatter<std::string_view, char>::format(std::string_view{name.data(), name.size()}, ctx);
+        }
+      }
+    }
+    return formatter<std::string_view, char>::format(std::to_string(magic_enum::enum_integer<D>(e)), ctx);
+  }
+};
+
+#endif
+
+#if defined(FMT_VERSION)
+
+#include <fmt/format.h>
+
+template <typename E>
+struct fmt::formatter<E, std::enable_if_t<std::is_enum_v<std::decay_t<E>> && magic_enum::customize::enum_format_enabled<E>(), char>> : fmt::formatter<std::string_view> {
+  template <class FormatContext>
+  auto format(E e, FormatContext& ctx) const {
+    static_assert(std::is_same_v<char, string_view::value_type>, "formatter requires string_view::value_type type same as char.");
+    using D = std::decay_t<E>;
+
+    if constexpr (magic_enum::detail::supported<D>::value) {
+      if constexpr (magic_enum::detail::subtype_v<D> == magic_enum::detail::enum_subtype::flags) {
+        if (const auto name = magic_enum::enum_flags_name<D>(e); !name.empty()) {
+          return formatter<std::string_view, char>::format(std::string_view{name.data(), name.size()}, ctx);
+        }
+      } else {
+        if (const auto name = magic_enum::enum_name<D>(e); !name.empty()) {
+          return formatter<std::string_view, char>::format(std::string_view{name.data(), name.size()}, ctx);
+        }
+      }
+    }
+    return formatter<std::string_view, char>::format(std::to_string(magic_enum::enum_integer<D>(e)), ctx);
+  }
+};
+
+#endif
+
+#if defined(MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT_AUTO_DEFINE)
+#  undef MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT
+#  undef MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT_AUTO_DEFINE
+#endif
+
+#endif // NEARGYE_MAGIC_ENUM_FORMAT_HPP

--- a/src/libraries/magic_enum/magic_enum_fuse.hpp
+++ b/src/libraries/magic_enum/magic_enum_fuse.hpp
@@ -1,0 +1,89 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.7
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_FUSE_HPP
+#define NEARGYE_MAGIC_ENUM_FUSE_HPP
+
+#include "magic_enum.hpp"
+
+namespace magic_enum {
+
+namespace detail {
+
+template <typename E>
+constexpr optional<std::uintmax_t> fuse_one_enum(optional<std::uintmax_t> hash, E value) noexcept {
+  if (hash) {
+    if (const auto index = enum_index(value)) {
+      return (*hash << log2((enum_count<E>() << 1) - 1)) | *index;
+    }
+  }
+  return {};
+}
+
+template <typename E>
+constexpr optional<std::uintmax_t> fuse_enum(E value) noexcept {
+  return fuse_one_enum(0, value);
+}
+
+template <typename E, typename... Es>
+constexpr optional<std::uintmax_t> fuse_enum(E head, Es... tail) noexcept {
+  return fuse_one_enum(fuse_enum(tail...), head);
+}
+
+template <typename... Es>
+constexpr auto typesafe_fuse_enum(Es... values) noexcept {
+  enum class enum_fuse_t : std::uintmax_t;
+  const auto fuse = fuse_enum(values...);
+  if (fuse) {
+    return optional<enum_fuse_t>{static_cast<enum_fuse_t>(*fuse)};
+  }
+  return optional<enum_fuse_t>{};
+}
+
+} // namespace magic_enum::detail
+
+// Returns a bijective mix of several enum values. This can be used to emulate 2D switch/case statements.
+template <typename... Es>
+[[nodiscard]] constexpr auto enum_fuse(Es... values) noexcept {
+  static_assert((std::is_enum_v<std::decay_t<Es>> && ...), "magic_enum::enum_fuse requires enum type.");
+  static_assert(sizeof...(Es) >= 2, "magic_enum::enum_fuse requires at least 2 values.");
+  static_assert((detail::log2(enum_count<std::decay_t<Es>>() + 1) + ...) <= (sizeof(std::uintmax_t) * 8), "magic_enum::enum_fuse does not work for large enums");
+#if defined(MAGIC_ENUM_NO_TYPESAFE_ENUM_FUSE)
+  const auto fuse = detail::fuse_enum<std::decay_t<Es>...>(values...);
+#else
+  const auto fuse = detail::typesafe_fuse_enum<std::decay_t<Es>...>(values...);
+#endif
+  return MAGIC_ENUM_ASSERT(fuse), fuse;
+}
+
+} // namespace magic_enum
+
+#endif // NEARGYE_MAGIC_ENUM_FUSE_HPP

--- a/src/libraries/magic_enum/magic_enum_iostream.hpp
+++ b/src/libraries/magic_enum/magic_enum_iostream.hpp
@@ -1,0 +1,117 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.7
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_IOSTREAM_HPP
+#define NEARGYE_MAGIC_ENUM_IOSTREAM_HPP
+
+#include "magic_enum.hpp"
+#include "magic_enum_flags.hpp"
+
+#ifndef MAGIC_ENUM_USE_STD_MODULE
+#include <iosfwd>
+#endif
+
+namespace magic_enum {
+
+namespace ostream_operators {
+
+template <typename Char, typename Traits, typename E, detail::enable_if_t<E, int> = 0>
+std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& os, E value) {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+
+  if constexpr (detail::supported<D>::value) {
+    if constexpr (detail::subtype_v<D> == detail::enum_subtype::flags) {
+      if (const auto name = enum_flags_name<D>(value); !name.empty()) {
+        for (const auto c : name) {
+          os.put(c);
+        }
+        return os;
+      }
+    } else {
+      if (const auto name = enum_name<D>(value); !name.empty()) {
+        for (const auto c : name) {
+          os.put(c);
+        }
+        return os;
+      }
+    }
+  }
+  return (os << static_cast<U>(value));
+}
+
+template <typename Char, typename Traits, typename E, detail::enable_if_t<E, int> = 0>
+std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& os, optional<E> value) {
+  return value ? (os << *value) : os;
+}
+
+} // namespace magic_enum::ostream_operators
+
+namespace istream_operators {
+
+template <typename Char, typename Traits, typename E, detail::enable_if_t<E, int> = 0>
+std::basic_istream<Char, Traits>& operator>>(std::basic_istream<Char, Traits>& is, E& value) {
+  using D = std::decay_t<E>;
+
+  std::basic_string<Char, Traits> s;
+  is >> s;
+  if constexpr (detail::supported<D>::value) {
+    if constexpr (detail::subtype_v<D> == detail::enum_subtype::flags) {
+      if (const auto v = enum_flags_cast<D>(s)) {
+        value = *v;
+      } else {
+        is.setstate(std::basic_ios<Char>::failbit);
+      }
+    } else {
+      if (const auto v = enum_cast<D>(s)) {
+        value = *v;
+      } else {
+        is.setstate(std::basic_ios<Char>::failbit);
+      }
+    }
+  } else {
+    is.setstate(std::basic_ios<Char>::failbit);
+  }
+  return is;
+}
+
+} // namespace magic_enum::istream_operators
+
+namespace iostream_operators {
+
+using magic_enum::ostream_operators::operator<<;
+using magic_enum::istream_operators::operator>>;
+
+} // namespace magic_enum::iostream_operators
+
+} // namespace magic_enum
+
+#endif // NEARGYE_MAGIC_ENUM_IOSTREAM_HPP

--- a/src/libraries/magic_enum/magic_enum_switch.hpp
+++ b/src/libraries/magic_enum/magic_enum_switch.hpp
@@ -1,0 +1,195 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.7
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_SWITCH_HPP
+#define NEARGYE_MAGIC_ENUM_SWITCH_HPP
+
+#include "magic_enum.hpp"
+
+namespace magic_enum {
+
+namespace detail {
+
+struct default_result_type {};
+
+template <typename T>
+struct identity {
+  using type = T;
+};
+
+struct nonesuch {};
+
+template <typename F, typename V, bool = std::is_invocable_v<F, V>>
+struct invoke_result : identity<nonesuch> {};
+
+template <typename F, typename V>
+struct invoke_result<F, V, true> : std::invoke_result<F, V> {};
+
+template <typename F, typename V>
+using invoke_result_t = typename invoke_result<F, V>::type;
+
+template <typename E, enum_subtype S, typename F, std::size_t... I>
+constexpr auto common_invocable(std::index_sequence<I...>) noexcept {
+  static_assert(std::is_enum_v<E>, "magic_enum::detail::invocable_index requires enum type.");
+
+  if constexpr (count_v<E, S> == 0) {
+    return identity<nonesuch>{};
+  } else {
+    return std::common_type<invoke_result_t<F, enum_constant<values_v<E, S>[I]>>...>{};
+  }
+}
+
+template <typename E, enum_subtype S, typename Result, typename F>
+constexpr auto result_type() noexcept {
+  static_assert(std::is_enum_v<E>, "magic_enum::detail::result_type requires enum type.");
+
+  constexpr auto seq = std::make_index_sequence<count_v<E, S>>{};
+  using R = typename decltype(common_invocable<E, S, F>(seq))::type;
+  if constexpr (std::is_same_v<Result, default_result_type>) {
+    if constexpr (std::is_same_v<R, nonesuch>) {
+      return identity<void>{};
+    } else {
+      return identity<R>{};
+    }
+  } else {
+    if constexpr (std::is_convertible_v<R, Result>) {
+      return identity<Result>{};
+    } else if constexpr (std::is_convertible_v<Result, R>) {
+      return identity<R>{};
+    } else {
+      return identity<nonesuch>{};
+    }
+  }
+}
+
+template <typename E, enum_subtype S, typename Result, typename F, typename D = std::decay_t<E>, typename R = typename decltype(result_type<D, S, Result, F>())::type>
+using result_t = std::enable_if_t<std::is_enum_v<D> && !std::is_same_v<R, nonesuch>, R>;
+
+#if !defined(MAGIC_ENUM_ENABLE_HASH) && !defined(MAGIC_ENUM_ENABLE_HASH_SWITCH)
+
+template <typename T = void>
+inline constexpr auto default_result_type_lambda = []() noexcept(std::is_nothrow_default_constructible_v<T>) { return T{}; };
+
+template <>
+inline constexpr auto default_result_type_lambda<void> = []() noexcept {};
+
+template <std::size_t I, std::size_t End, typename R, typename E, enum_subtype S, typename F, typename Def>
+constexpr decltype(auto) constexpr_switch_impl(F&& f, E value, Def&& def) {
+  if constexpr(I < End) {
+    constexpr auto v = enum_constant<enum_value<E, I, S>()>{};
+    if (value == v) {
+      if constexpr (std::is_invocable_r_v<R, F, decltype(v)>) {
+        return static_cast<R>(std::forward<F>(f)(v));
+      } else {
+        return def();
+      }
+    } else {
+      return constexpr_switch_impl<I + 1, End, R, E, S>(std::forward<F>(f), value, std::forward<Def>(def));
+    }
+  } else {
+    return def();
+  }
+}
+
+template <typename R, typename E, enum_subtype S, typename F, typename Def>
+constexpr decltype(auto) constexpr_switch(F&& f, E value, Def&& def) {
+  static_assert(is_enum_v<E>, "magic_enum::detail::constexpr_switch requires enum type.");
+
+  if constexpr (count_v<E, S> == 0) {
+    return def();
+  } else {
+    return constexpr_switch_impl<0, count_v<E, S>, R, E, S>(std::forward<F>(f), value, std::forward<Def>(def));
+  }
+}
+#endif
+
+} // namespace magic_enum::detail
+
+template <typename Result = detail::default_result_type, typename E, detail::enum_subtype S = detail::subtype_v<E>, typename F, typename R = detail::result_t<E, S, Result, F>>
+constexpr decltype(auto) enum_switch(F&& f, E value) {
+  using D = std::decay_t<E>;
+  static_assert(std::is_enum_v<D>, "magic_enum::enum_switch requires enum type.");
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+#if defined(MAGIC_ENUM_ENABLE_HASH) || defined(MAGIC_ENUM_ENABLE_HASH_SWITCH)
+  return detail::constexpr_switch<&detail::values_v<D, S>, detail::case_call_t::value>(
+      std::forward<F>(f),
+      value,
+      detail::default_result_type_lambda<R>);
+#else
+  return detail::constexpr_switch<R, D, S>(
+      std::forward<F>(f),
+      value,
+      detail::default_result_type_lambda<R>);
+#endif
+}
+
+template <typename Result = detail::default_result_type, detail::enum_subtype S, typename E, typename F, typename R = detail::result_t<E, S, Result, F>>
+constexpr decltype(auto) enum_switch(F&& f, E value) {
+  return enum_switch<Result, E, S>(std::forward<F>(f), value);
+}
+
+template <typename Result, typename E, detail::enum_subtype S = detail::subtype_v<E>, typename F, typename R = detail::result_t<E, S, Result, F>>
+constexpr decltype(auto) enum_switch(F&& f, E value, Result&& result) {
+  using D = std::decay_t<E>;
+  static_assert(std::is_enum_v<D>, "magic_enum::enum_switch requires enum type.");
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+
+#if defined(MAGIC_ENUM_ENABLE_HASH) || defined(MAGIC_ENUM_ENABLE_HASH_SWITCH)
+  return detail::constexpr_switch<&detail::values_v<D, S>, detail::case_call_t::value>(
+      std::forward<F>(f),
+      value,
+      [&result]() -> R { return std::forward<Result>(result); });
+#else
+  return detail::constexpr_switch<R, D, S>(
+      std::forward<F>(f),
+      value,
+      [&result]() -> R { return std::forward<Result>(result); });
+#endif
+}
+
+template <typename Result, detail::enum_subtype S, typename E, typename F, typename R = detail::result_t<E, S, Result, F>>
+constexpr decltype(auto) enum_switch(F&& f, E value, Result&& result) {
+  return enum_switch<Result, E, S>(std::forward<F>(f), value, std::forward<Result>(result));
+}
+
+} // namespace magic_enum
+
+template <>
+struct std::common_type<magic_enum::detail::nonesuch, magic_enum::detail::nonesuch> : magic_enum::detail::identity<magic_enum::detail::nonesuch> {};
+
+template <typename T>
+struct std::common_type<T, magic_enum::detail::nonesuch> : magic_enum::detail::identity<T> {};
+
+template <typename T>
+struct std::common_type<magic_enum::detail::nonesuch, T> : magic_enum::detail::identity<T> {};
+
+#endif // NEARGYE_MAGIC_ENUM_SWITCH_HPP

--- a/src/libraries/magic_enum/magic_enum_utility.hpp
+++ b/src/libraries/magic_enum/magic_enum_utility.hpp
@@ -1,0 +1,138 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.7
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_UTILITY_HPP
+#define NEARGYE_MAGIC_ENUM_UTILITY_HPP
+
+#include "magic_enum.hpp"
+
+namespace magic_enum {
+
+namespace detail {
+
+template <typename E, enum_subtype S, typename F, std::size_t... I>
+constexpr auto for_each(F&& f, std::index_sequence<I...>) {
+  constexpr bool has_void_return = (std::is_void_v<std::invoke_result_t<F, enum_constant<values_v<E, S>[I]>>> || ...);
+  constexpr bool all_same_return = (std::is_same_v<std::invoke_result_t<F, enum_constant<values_v<E, S>[0]>>, std::invoke_result_t<F, enum_constant<values_v<E, S>[I]>>> && ...);
+
+  if constexpr (has_void_return) {
+    (f(enum_constant<values_v<E, S>[I]>{}), ...);
+  } else if constexpr (all_same_return) {
+    return std::array{f(enum_constant<values_v<E, S>[I]>{})...};
+  } else {
+    return std::tuple{f(enum_constant<values_v<E, S>[I]>{})...};
+  }
+}
+
+template <typename E, enum_subtype S, typename F,std::size_t... I>
+constexpr bool all_invocable(std::index_sequence<I...>) {
+  if constexpr (count_v<E, S> == 0) {
+    return false;
+  } else {
+    return (std::is_invocable_v<F, enum_constant<values_v<E, S>[I]>> && ...);
+  }
+}
+
+} // namespace magic_enum::detail
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>, typename F, detail::enable_if_t<E, int> = 0>
+constexpr auto enum_for_each(F&& f) {
+  using D = std::decay_t<E>;
+  static_assert(std::is_enum_v<D>, "magic_enum::enum_for_each requires enum type.");
+  static_assert(detail::is_reflected_v<D, S>, "magic_enum requires enum implementation and valid max and min.");
+  constexpr auto sep = std::make_index_sequence<detail::count_v<D, S>>{};
+
+  if constexpr (detail::all_invocable<D, S, F>(sep)) {
+    return detail::for_each<D, S>(std::forward<F>(f), sep);
+  } else {
+    static_assert(detail::always_false_v<D>, "magic_enum::enum_for_each requires invocable of all enum value.");
+  }
+}
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_next_value(E value, std::ptrdiff_t n = 1) noexcept -> detail::enable_if_t<E, optional<std::decay_t<E>>> {
+  using D = std::decay_t<E>;
+  constexpr std::ptrdiff_t count = detail::count_v<D, S>;
+
+  if (const auto i = enum_index<D, S>(value)) {
+    const std::ptrdiff_t index = (static_cast<std::ptrdiff_t>(*i) + n);
+    if (index >= 0 && index < count) {
+      return enum_value<D, S>(static_cast<std::size_t>(index));
+    }
+  }
+  return {};
+}
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_next_value_circular(E value, std::ptrdiff_t n = 1) noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+  constexpr std::ptrdiff_t count = detail::count_v<D, S>;
+
+  if (const auto i = enum_index<D, S>(value)) {
+    const std::ptrdiff_t index = ((((static_cast<std::ptrdiff_t>(*i) + n) % count) + count) % count);
+    if (index >= 0 && index < count) {
+      return enum_value<D, S>(static_cast<std::size_t>(index));
+    }
+  }
+  return MAGIC_ENUM_ASSERT(false), value;
+}
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_prev_value(E value, std::ptrdiff_t n = 1) noexcept -> detail::enable_if_t<E, optional<std::decay_t<E>>> {
+  using D = std::decay_t<E>;
+  constexpr std::ptrdiff_t count = detail::count_v<D, S>;
+
+  if (const auto i = enum_index<D, S>(value)) {
+    const std::ptrdiff_t index = (static_cast<std::ptrdiff_t>(*i) - n);
+    if (index >= 0 && index < count) {
+      return enum_value<D, S>(static_cast<std::size_t>(index));
+    }
+  }
+  return {};
+}
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_prev_value_circular(E value, std::ptrdiff_t n = 1) noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+  constexpr std::ptrdiff_t count = detail::count_v<D, S>;
+
+  if (const auto i = enum_index<D, S>(value)) {
+    const std::ptrdiff_t index = ((((static_cast<std::ptrdiff_t>(*i) - n) % count) + count) % count);
+    if (index >= 0 && index < count) {
+      return enum_value<D, S>(static_cast<std::size_t>(index));
+    }
+  }
+  return MAGIC_ENUM_ASSERT(false), value;
+}
+
+} // namespace magic_enum
+
+#endif // NEARGYE_MAGIC_ENUM_UTILITY_HPP

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -21,6 +21,7 @@
 #include "ui/display/display_fields.h"
 #include "ui/input/buttons.h"
 #include "ui/settings/settings.h"
+#include "utils/magic_enum.h"
 
 Power power;  // struct for battery-state and on-state variables
 
@@ -41,18 +42,6 @@ Power power;  // struct for battery-state and on-state variables
 #define AUTO_OFF_MAX_ACCEL 10  // Max accelerometer signal
 #define AUTO_OFF_MAX_ALT 400   // cm altitude change for timer auto-stop
 #define AUTO_OFF_MIN_SEC 20    // seconds of low speed / low accel for timer to auto-stop
-
-const char* nameOf(PowerState state) {
-  switch (state) {
-    case PowerState::Off:
-      return "Off";
-    case PowerState::On:
-      return "On";
-    case PowerState::OffUSB:
-      return "OffUSB";
-  }
-  return "Unknown";
-}
 
 const char* nameOf(PowerInputLevel level) {
   switch (level) {

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -27,15 +27,11 @@ enum class PowerState : uint8_t {
   OffUSB
 };
 
-const char* nameOf(PowerState state);
-
 // iMax set by ILIM pin resistor on battery charger chip. Results in 1.348Amps max input (for
 // battery charging AND system load) Note: with this higher input limit, the battery charging will
 // then be limited by the ISET pin resistor value, to approximately 810mA charging current)
 enum class PowerInputLevel : uint8_t { Standby = 0, i100mA = 1, i500mA = 2, Max = 3 };
 DEFINE_CLAMPING_BOUNDS(PowerInputLevel, PowerInputLevel::Standby, PowerInputLevel::Max);
-
-const char* nameOf(PowerInputLevel level);
 
 class Power {
  public:

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -21,6 +21,7 @@
 #include "ui/display/display.h"
 #include "ui/input/buttons.h"
 #include "ui/settings/settings.h"
+#include "utils/magic_enum.h"
 #include "wind_estimate/wind_estimate.h"
 
 #ifdef MEMORY_PROFILING

--- a/src/vario/utils/magic_enum.h
+++ b/src/vario/utils/magic_enum.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <Arduino.h>  // for String
+#include <magic_enum.hpp>
+#include <type_traits>
+
+// Constrain to enum class (scoped enum): it's an enum and not implicitly convertible to int
+template <typename TEnum,
+          typename = std::enable_if_t<std::is_enum_v<TEnum> && !std::is_convertible_v<TEnum, int>>>
+inline String nameOf(TEnum value) {
+  auto sv = magic_enum::enum_name(value);  // std::string_view
+  return String(sv.data(), sv.size());     // construct Arduino String from ptr+len
+}


### PR DESCRIPTION
C++ is apparently very limited in terms of things that can be done with enums because it does not have any native reflection capability.  To avoid a bunch of boilerplate where we have to repeatedly specify enum members in various ways (listing all valid members, translating them to strings, etc), this PR adds the [magic_enum header library](https://github.com/Neargye/magic_enum) (MIT license).  This should add little to no overhead where it's not used and a relatively small amount of overhead where it is used -- specifically, ChatGPT says it should use no additional RAM, and additional flash memory dominated by the length of all the members' names.

This PR demonstrates usage by replacing existing `nameOf` functions with a generic function backed by magic_enum.  Unfortunately, we will usually want to use thin wrappers because magic_enum returns string_views which are not easily consumed by most string-related tools on Arduino.  But, constructing an Arduino String from a string_view is easy.

In the future, I expect to take advantage of magic_enum's ability to enumerate the members on an enum (something that C++ is ironically unable to do).

I tested c3a2bfb54fef9f4ee5978a318030c73dd0d89af3 on 3.2.7+radio with leaf_3_2_7_dev solely from the charging screen by observing the three places were the results of `nameOf` are easily visible.

Reviewers of this PR should likely ignore all the content in src/libraries/magic_enum apart from perhaps verifying that it seems like I copied the right stuff from magic_enum.