### PR TITLE
Capture build info to troubleshoot long builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,7 @@ extra_configs =
 
 # See documentation in scripts for expected configuration variables
 extra_scripts =
+	pre:src/scripts/capture_build_info.py
 	pre:src/scripts/versioning.py
 	post:src/scripts/rename_firmware.py
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,7 @@ extra_scripts =
 	pre:src/scripts/capture_build_info.py
 	pre:src/scripts/versioning.py
 	post:src/scripts/rename_firmware.py
+	post:src/scripts/write_build_result.py
 
 # platform = espressif32  # Old, default platform
 # https://github.com/pioarduino/platform-espressif32

--- a/src/scripts/capture_build_info.py
+++ b/src/scripts/capture_build_info.py
@@ -1,0 +1,172 @@
+# tools/capture_build_info.py
+# Capture a comprehensive, pretty-printed snapshot for diff-friendly troubleshooting.
+Import("env")
+import os, sys, json, hashlib, pathlib, platform, subprocess, datetime
+
+BUILD_DIR = pathlib.Path(env.subst("$BUILD_DIR"))
+DIAG_DIR  = BUILD_DIR / "diagnostics"
+DIAG_DIR.mkdir(parents=True, exist_ok=True)
+
+CUR_FP  = DIAG_DIR / "build_info.json"
+PREV_FP = DIAG_DIR / "build_info.prev.json"
+
+def _jsonable(x):
+    try:
+        json.dumps(x)
+        return x
+    except TypeError:
+        return str(x)
+
+def _norm_path(p: str) -> str:
+    if p is None:
+        return ""
+    q = p.replace("\\", "/")
+    if sys.platform.startswith("win"):
+        q = q.lower()
+    return q
+
+def _realpath(p: str) -> str:
+    try:
+        return str(pathlib.Path(p).resolve())
+    except Exception:
+        return str(p)
+
+def _count_objs(root: pathlib.Path) -> int:
+    return sum(1 for _ in root.rglob("*.o")) if root.exists() else 0
+
+def _sha256_text(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+def _maybe(cmd: list[str]) -> str | None:
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        return out.decode(errors="replace").strip()
+    except Exception:
+        return None
+
+def _git_info(project_dir: str) -> dict:
+    info = {}
+    try:
+        cwd = os.getcwd()
+        os.chdir(project_dir)
+        info["root"]     = _maybe(["git", "rev-parse", "--show-toplevel"])
+        info["head"]     = _maybe(["git", "rev-parse", "HEAD"])
+        info["describe"] = _maybe(["git", "describe", "--tags", "--always", "--dirty"])
+        info["status"]   = _maybe(["git", "status", "--porcelain"])
+        if info["status"] is not None:
+            info["dirty"] = (info["status"] != "")
+            # For large repos, status could be long; provide a hash too.
+            info["status_sha256"] = _sha256_text(info["status"])
+        os.chdir(cwd)
+    except Exception:
+        pass
+    return info
+
+def _tool_versions() -> dict:
+    # Try to grab compiler versions quickly (optional if missing)
+    return {
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "platformio_core": _maybe(["pio", "--version"]),
+        "gcc_version": _maybe([str(env.get("CC") or "gcc"), "--version"]),
+        "gpp_version": _maybe([str(env.get("CXX") or "g++"), "--version"]),
+        "ar_version":  _maybe([str(env.get("AR") or "ar"), "--version"]),
+    }
+
+def _package_versions(plat) -> dict:
+    out = {}
+    try:
+        pkgs = [
+            "framework-arduinoespressif32","framework-arduinoespressif8266","framework-arduino",
+            "toolchain-xtensa-esp32","toolchain-xtensa-esp32s3",
+            "toolchain-riscv32-esp","toolchain-gccarmnoneeabi",
+            "tool-cmake","tool-ninja","tool-esptoolpy"
+        ]
+        for pkg in pkgs:
+            v = plat.get_package_version(pkg)
+            if v:
+                out[pkg] = v
+    except Exception:
+        pass
+    return out
+
+def _collect():
+    plat = env.PioPlatform()
+
+    # Core identifiers
+    env_name     = env["PIOENV"]
+    project_dir  = str(env["PROJECT_DIR"])
+    build_dir    = str(BUILD_DIR)
+
+    # Paths (raw, normalized, realpath)
+    paths = {
+        "project_dir_raw": project_dir,
+        "project_dir_norm": _norm_path(project_dir),
+        "project_dir_real": _realpath(project_dir),
+        "build_dir_raw": build_dir,
+        "build_dir_norm": _norm_path(build_dir),
+        "build_dir_real": _realpath(build_dir),
+        "cwd_raw": os.getcwd(),
+        "cwd_norm": _norm_path(os.getcwd()),
+        "cwd_real": _realpath(os.getcwd()),
+    }
+
+    # Flags/defines/paths as seen by SCons
+    snapshot = {
+        "timestamp_utc": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "env_name": env_name,
+        "board": _jsonable(env.get("BOARD")),
+        "pio_platform": _jsonable(env.get("PIOPLATFORM")),
+        "pio_framework": _jsonable(env.get("PIOFRAMEWORK")),
+        "sconsflags": os.environ.get("SCONSFLAGS", ""),
+        "build_flags_raw": _jsonable(env.get("BUILD_FLAGS")),
+        "ccflags": _jsonable(env.get("CCFLAGS")),
+        "cflags": _jsonable(env.get("CFLAGS")),
+        "cxxflags": _jsonable(env.get("CXXFLAGS")),
+        "linkflags": _jsonable(env.get("LINKFLAGS")),
+        "cppdefines": _jsonable(env.get("CPPDEFINES")),
+        "cpppath_norm": [_norm_path(str(p)) for p in (env.get("CPPPATH") or [])],
+        "cpppath_raw":  [str(p) for p in (env.get("CPPPATH") or [])],
+        "libpath_norm": [_norm_path(str(p)) for p in (env.get("LIBPATH") or [])],
+        "libpath_raw":  [str(p) for p in (env.get("LIBPATH") or [])],
+        "libs": _jsonable(env.get("LIBS")),
+        "tools": _tool_versions(),
+        "platform": {
+            "name": str(plat),
+            "version": getattr(plat, "version", None),
+            "packages": _package_versions(plat),
+        },
+        "paths": paths,
+        "preexisting_objects": {
+            "framework_count": _count_objs(BUILD_DIR / "FrameworkArduino"),
+            "lib_counts": { p.name: _count_objs(p) for p in BUILD_DIR.glob("lib*/") },
+        },
+        "git": _git_info(project_dir),
+    }
+
+    # Add quick signatures for fast comparisons
+    # (stable uses normalized paths; raw uses raw strings)
+    exclude = {"tools"}  # omit verbose tool --version strings from signature
+    stable_basis = {k: snapshot[k] for k in snapshot if k not in exclude}
+    raw_basis    = dict(stable_basis)
+    # swap normalized with raw for raw signature
+    raw_basis["paths"]["project_dir_norm"] = snapshot["paths"]["project_dir_raw"]
+    raw_basis["paths"]["build_dir_norm"]   = snapshot["paths"]["build_dir_raw"]
+    raw_basis["paths"]["cwd_norm"]         = snapshot["paths"]["cwd_raw"]
+    raw_basis["cpppath_norm"] = snapshot["cpppath_raw"]
+    raw_basis["libpath_norm"] = snapshot["libpath_raw"]
+
+    snapshot["signature_stable_sha1"] = hashlib.sha1(json.dumps(stable_basis, sort_keys=True, default=str).encode()).hexdigest()
+    snapshot["signature_raw_sha1"]    = hashlib.sha1(json.dumps(raw_basis,    sort_keys=True, default=str).encode()).hexdigest()
+
+    return snapshot
+
+def _write_snapshot(cur: dict):
+    # rotate previous → prev.json
+    if CUR_FP.exists():
+        PREV_FP.write_bytes(CUR_FP.read_bytes())
+    # write current (pretty, sorted keys)
+    CUR_FP.write_text(json.dumps(cur, indent=2, sort_keys=True))
+
+snap = _collect()
+_write_snapshot(snap)

--- a/src/scripts/write_build_result.py
+++ b/src/scripts/write_build_result.py
@@ -1,7 +1,7 @@
 # tools/write_build_result.py
-# Post-build summary: what changed/was produced in this build, timing, and roll-forward.
+# Post-build summary (capture-only). Safe with both .elf and .bin post-actions.
 Import("env")
-import os, json, pathlib, time, datetime, sys
+import os, json, pathlib, time, datetime
 
 BUILD_DIR = pathlib.Path(env.subst("$BUILD_DIR"))
 DIAG_DIR  = BUILD_DIR / "diagnostics"
@@ -10,21 +10,18 @@ DIAG_DIR.mkdir(parents=True, exist_ok=True)
 CUR_RES  = DIAG_DIR / "build_result.json"
 PREV_RES = DIAG_DIR / "build_result.prev.json"
 
-PRE_INFO = DIAG_DIR / "build_info.json"       # written by the pre script
+PRE_INFO = DIAG_DIR / "build_info.json"       # from the pre script
 PRE_INFO_PREV = DIAG_DIR / "build_info.prev.json"
 
 PROGNAME = env.subst("${PROGNAME}")
 ENV_NAME = env["PIOENV"]
 
-# Common output names (some may not exist depending on platform/toolchain)
 ARTIFACTS = [
     (BUILD_DIR / f"{PROGNAME}.elf"),
     (BUILD_DIR / f"{PROGNAME}.bin"),
     (BUILD_DIR / f"{PROGNAME}.map"),
     (BUILD_DIR / f"{PROGNAME}.hex"),
 ]
-
-# Consider these file types for “touched this run”
 FILE_EXTS = {".o", ".a", ".elf", ".bin", ".map", ".hex"}
 
 def _stat(p: pathlib.Path):
@@ -42,9 +39,10 @@ def _stat(p: pathlib.Path):
 def _now_utc_iso():
     return datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z"
 
-def _epoch(dt_iso: str):
-    # Parse an ISO timestamp like "2025-08-15T17:02:03Z" to epoch; fallback to 0 on error
+def _epoch(dt_iso: str | None):
     try:
+        if not dt_iso:
+            return 0.0
         if dt_iso.endswith("Z"):
             dt_iso = dt_iso[:-1]
         return datetime.datetime.fromisoformat(dt_iso).replace(tzinfo=datetime.timezone.utc).timestamp()
@@ -57,76 +55,66 @@ def _load_json(path: pathlib.Path):
     except Exception:
         return None
 
-def summarize():
-    # Establish build window: start from pre-snapshot (if present), end = now
+def _summarize():
+    # Build window: start from pre-snapshot (if present), end = now
     pre_info = _load_json(PRE_INFO)
-    pre_prev = _load_json(PRE_INFO_PREV)
-
     start_iso = (pre_info or {}).get("timestamp_utc")
-    start_epoch = _epoch(start_iso) if start_iso else 0.0
+    start_epoch = _epoch(start_iso)
     end_epoch = time.time()
     end_iso = _now_utc_iso()
     duration_sec = max(0.0, end_epoch - start_epoch) if start_epoch else None
 
-    # Gather final artifacts
-    artifacts = {}
-    for art in ARTIFACTS:
-        artifacts[art.name] = _stat(art)
+    # Final artifacts
+    artifacts = {art.name: _stat(art) for art in ARTIFACTS}
 
-    # Collect files under this env’s build dir that were *touched this run* (mtime >= start)
+    # Touched files since start
     touched = []
     totals_by_type = {"o": 0, "a": 0, "elf": 0, "bin": 0, "map": 0, "hex": 0, "other": 0}
-    size_by_type = {k: 0 for k in totals_by_type.keys()}
+    size_by_type   = {k: 0 for k in totals_by_type}
+    counts_by_cat  = {"framework": 0, "libdeps": 0, "project_or_misc": 0}
+    size_by_cat    = {k: 0 for k in counts_by_cat}
 
-    # Simple categorization (directories)
-    def categorize(path_rel_str: str):
-        if path_rel_str.startswith("FrameworkArduino/"):
+    def categorize(rel: str):
+        if rel.startswith("FrameworkArduino/"):
             return "framework"
-        if path_rel_str.startswith("lib"):
+        if rel.startswith("lib"):
             return "libdeps"
-        # Any other subdir under the env build dir
         return "project_or_misc"
-
-    counts_by_cat = {"framework": 0, "libdeps": 0, "project_or_misc": 0}
-    size_by_cat   = {k: 0 for k in counts_by_cat.keys()}
 
     for p in BUILD_DIR.rglob("*"):
         if not p.is_file():
             continue
-        if p.suffix.lower() not in FILE_EXTS:
+        ext = p.suffix.lower()
+        if ext not in FILE_EXTS:
             continue
         try:
             st = p.stat()
         except FileNotFoundError:
             continue
-
-        # If we have a start time, only include files modified during/after this run
         if start_epoch and st.st_mtime + 1e-6 < start_epoch:
             continue
 
         rel = p.relative_to(BUILD_DIR).as_posix()
-        ext = p.suffix.lower().lstrip(".")
-        kind = ext if ext in totals_by_type else "other"
+        kind = ext.lstrip(".") if ext.lstrip(".") in totals_by_type else "other"
         cat  = categorize(rel)
 
         rec = {
             "path": rel,
             "type": kind,
-            "category": cat,   # framework / libdeps / project_or_misc
+            "category": cat,
             "size": st.st_size,
             "mtime_epoch": st.st_mtime,
             "mtime_utc": datetime.datetime.utcfromtimestamp(st.st_mtime).isoformat(timespec="seconds") + "Z",
         }
         touched.append(rec)
         totals_by_type[kind] += 1
-        size_by_type[kind] += st.st_size
-        counts_by_cat[cat] += 1
-        size_by_cat[cat] += st.st_size
+        size_by_type[kind]   += st.st_size
+        counts_by_cat[cat]   += 1
+        size_by_cat[cat]     += st.st_size
 
-    # Sort touched files for stable output
     touched.sort(key=lambda r: (r["category"], r["type"], r["path"]))
 
-    # Pull over a few identifiers from pre-info so you can correlate runs
+    # IDs copied from pre-info to correlate runs
     id_block = {}
     for k in ("env_name", "board", "pio_platform", "pio_framework",
               "signature_stable_sha1", "signature_raw_sha1",
@@ -134,7 +122,7 @@ def summarize():
         if pre_info and k in pre_info:
             id_block[k] = pre_info[k]
 
-    result = {
+    return {
         "summary_version": 1,
         "generated_at_utc": end_iso,
         "environment": ENV_NAME,
@@ -150,29 +138,81 @@ def summarize():
             "by_category_sizes": size_by_cat,
             "by_type_counts": totals_by_type,
             "by_type_sizes": size_by_type,
-            "list": touched,  # detailed list (paths relative to the env build dir)
+            "list": touched,
         },
         "identifiers": id_block,
         "notes": [
-            "Files listed in touched_files have mtime >= build start (from capture_build_info.py).",
+            "Files listed have mtime >= build start (from capture_build_info.py).",
             "If build start was unavailable, the list may be empty or incomplete.",
             "Compare build_result.prev.json vs build_result.json to spot unusual bursts of work.",
         ],
     }
 
-    # Rotate previous → prev.json, then write current (pretty, sorted)
+def _write_single_run(result: dict):
+    """Write build_result.json. Rotate to .prev ONLY if this is a new build (different start_utc)."""
+    # Determine this run's start_utc
+    start_utc = (result.get("build_window") or {}).get("start_utc")
+
+    # If we already have a current result for the same build, overwrite without rotating
+    if CUR_RES.exists():
+        try:
+            cur_existing = json.loads(CUR_RES.read_text())
+        except Exception:
+            cur_existing = {}
+        existing_start = (cur_existing.get("build_window") or {}).get("start_utc")
+        if existing_start == start_utc:
+            # Same build → keep prev as the true previous build
+            CUR_RES.write_text(json.dumps(result, indent=2, sort_keys=True))
+            print(f"[build_result] Updated current summary (same build): {CUR_RES}")
+            return
+
+    # New build (or no existing file) → rotate current to prev, then write
     if CUR_RES.exists():
         PREV_RES.write_bytes(CUR_RES.read_bytes())
     CUR_RES.write_text(json.dumps(result, indent=2, sort_keys=True))
+    print(f"[build_result] Wrote {CUR_RES} (rotated previous if it existed)")
 
-# Hook after main program binary; if your toolchain doesn’t emit .bin, hook .elf as fallback
-def _run_summary(source, target, env):
+def _should_write_for_target(target_node) -> bool:
+    """Prefer writing on .bin. If this is .elf and a .bin exists for this build, skip."""
     try:
-        summarize()
-        print(f"[build_result] Wrote {CUR_RES}")
+        tpath = pathlib.Path(str(target_node))
+    except Exception:
+        return True  # fail-open
+    suffix = tpath.suffix.lower()
+
+    if suffix == ".bin":
+        return True
+
+    if suffix == ".elf":
+        # If bin already exists (produced in this run or previously) and is up-to-date vs build start, skip here.
+        pre_info = _load_json(PRE_INFO)
+        start_iso = (pre_info or {}).get("timestamp_utc")
+        start_epoch = _epoch(start_iso)
+        bin_path = BUILD_DIR / f"{PROGNAME}.bin"
+        if bin_path.exists():
+            try:
+                m = bin_path.stat().st_mtime
+                # If the .bin mtime is at/after the build start, prefer letting the .bin hook write.
+                if start_epoch and m + 1e-6 >= start_epoch:
+                    return False
+            except Exception:
+                pass
+        # No .bin detected → allow .elf to write
+        return True
+
+    # Other target types: allow
+    return True
+
+def _run_summary(target, source, env):
+    try:
+        # If this callback is for .elf and a fresh .bin exists, let the .bin callback handle it.
+        if not _should_write_for_target(target[0]):
+            return
+        result = _summarize()
+        _write_single_run(result)
     except Exception as e:
         print(f"[build_result] Failed to write summary: {e}")
 
-# Prefer .bin, but also attach to .elf to be safe
+# Prefer .bin; also hook .elf as fallback
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", _run_summary)
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.elf", _run_summary)

--- a/src/scripts/write_build_result.py
+++ b/src/scripts/write_build_result.py
@@ -1,0 +1,178 @@
+# tools/write_build_result.py
+# Post-build summary: what changed/was produced in this build, timing, and roll-forward.
+Import("env")
+import os, json, pathlib, time, datetime, sys
+
+BUILD_DIR = pathlib.Path(env.subst("$BUILD_DIR"))
+DIAG_DIR  = BUILD_DIR / "diagnostics"
+DIAG_DIR.mkdir(parents=True, exist_ok=True)
+
+CUR_RES  = DIAG_DIR / "build_result.json"
+PREV_RES = DIAG_DIR / "build_result.prev.json"
+
+PRE_INFO = DIAG_DIR / "build_info.json"       # written by the pre script
+PRE_INFO_PREV = DIAG_DIR / "build_info.prev.json"
+
+PROGNAME = env.subst("${PROGNAME}")
+ENV_NAME = env["PIOENV"]
+
+# Common output names (some may not exist depending on platform/toolchain)
+ARTIFACTS = [
+    (BUILD_DIR / f"{PROGNAME}.elf"),
+    (BUILD_DIR / f"{PROGNAME}.bin"),
+    (BUILD_DIR / f"{PROGNAME}.map"),
+    (BUILD_DIR / f"{PROGNAME}.hex"),
+]
+
+# Consider these file types for “touched this run”
+FILE_EXTS = {".o", ".a", ".elf", ".bin", ".map", ".hex"}
+
+def _stat(p: pathlib.Path):
+    try:
+        s = p.stat()
+        return {
+            "exists": True,
+            "size": s.st_size,
+            "mtime_epoch": s.st_mtime,
+            "mtime_utc": datetime.datetime.utcfromtimestamp(s.st_mtime).isoformat(timespec="seconds") + "Z",
+        }
+    except FileNotFoundError:
+        return {"exists": False}
+
+def _now_utc_iso():
+    return datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z"
+
+def _epoch(dt_iso: str):
+    # Parse an ISO timestamp like "2025-08-15T17:02:03Z" to epoch; fallback to 0 on error
+    try:
+        if dt_iso.endswith("Z"):
+            dt_iso = dt_iso[:-1]
+        return datetime.datetime.fromisoformat(dt_iso).replace(tzinfo=datetime.timezone.utc).timestamp()
+    except Exception:
+        return 0.0
+
+def _load_json(path: pathlib.Path):
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+def summarize():
+    # Establish build window: start from pre-snapshot (if present), end = now
+    pre_info = _load_json(PRE_INFO)
+    pre_prev = _load_json(PRE_INFO_PREV)
+
+    start_iso = (pre_info or {}).get("timestamp_utc")
+    start_epoch = _epoch(start_iso) if start_iso else 0.0
+    end_epoch = time.time()
+    end_iso = _now_utc_iso()
+    duration_sec = max(0.0, end_epoch - start_epoch) if start_epoch else None
+
+    # Gather final artifacts
+    artifacts = {}
+    for art in ARTIFACTS:
+        artifacts[art.name] = _stat(art)
+
+    # Collect files under this env’s build dir that were *touched this run* (mtime >= start)
+    touched = []
+    totals_by_type = {"o": 0, "a": 0, "elf": 0, "bin": 0, "map": 0, "hex": 0, "other": 0}
+    size_by_type = {k: 0 for k in totals_by_type.keys()}
+
+    # Simple categorization (directories)
+    def categorize(path_rel_str: str):
+        if path_rel_str.startswith("FrameworkArduino/"):
+            return "framework"
+        if path_rel_str.startswith("lib"):
+            return "libdeps"
+        # Any other subdir under the env build dir
+        return "project_or_misc"
+
+    counts_by_cat = {"framework": 0, "libdeps": 0, "project_or_misc": 0}
+    size_by_cat   = {k: 0 for k in counts_by_cat.keys()}
+
+    for p in BUILD_DIR.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.suffix.lower() not in FILE_EXTS:
+            continue
+        try:
+            st = p.stat()
+        except FileNotFoundError:
+            continue
+
+        # If we have a start time, only include files modified during/after this run
+        if start_epoch and st.st_mtime + 1e-6 < start_epoch:
+            continue
+
+        rel = p.relative_to(BUILD_DIR).as_posix()
+        ext = p.suffix.lower().lstrip(".")
+        kind = ext if ext in totals_by_type else "other"
+        cat  = categorize(rel)
+
+        rec = {
+            "path": rel,
+            "type": kind,
+            "category": cat,   # framework / libdeps / project_or_misc
+            "size": st.st_size,
+            "mtime_epoch": st.st_mtime,
+            "mtime_utc": datetime.datetime.utcfromtimestamp(st.st_mtime).isoformat(timespec="seconds") + "Z",
+        }
+        touched.append(rec)
+        totals_by_type[kind] += 1
+        size_by_type[kind] += st.st_size
+        counts_by_cat[cat] += 1
+        size_by_cat[cat] += st.st_size
+
+    # Sort touched files for stable output
+    touched.sort(key=lambda r: (r["category"], r["type"], r["path"]))
+
+    # Pull over a few identifiers from pre-info so you can correlate runs
+    id_block = {}
+    for k in ("env_name", "board", "pio_platform", "pio_framework",
+              "signature_stable_sha1", "signature_raw_sha1",
+              "paths", "git"):
+        if pre_info and k in pre_info:
+            id_block[k] = pre_info[k]
+
+    result = {
+        "summary_version": 1,
+        "generated_at_utc": end_iso,
+        "environment": ENV_NAME,
+        "build_window": {
+            "start_utc": start_iso or None,
+            "end_utc": end_iso,
+            "duration_seconds": duration_sec,
+        },
+        "final_artifacts": artifacts,
+        "touched_files": {
+            "count": len(touched),
+            "by_category_counts": counts_by_cat,
+            "by_category_sizes": size_by_cat,
+            "by_type_counts": totals_by_type,
+            "by_type_sizes": size_by_type,
+            "list": touched,  # detailed list (paths relative to the env build dir)
+        },
+        "identifiers": id_block,
+        "notes": [
+            "Files listed in touched_files have mtime >= build start (from capture_build_info.py).",
+            "If build start was unavailable, the list may be empty or incomplete.",
+            "Compare build_result.prev.json vs build_result.json to spot unusual bursts of work.",
+        ],
+    }
+
+    # Rotate previous → prev.json, then write current (pretty, sorted)
+    if CUR_RES.exists():
+        PREV_RES.write_bytes(CUR_RES.read_bytes())
+    CUR_RES.write_text(json.dumps(result, indent=2, sort_keys=True))
+
+# Hook after main program binary; if your toolchain doesn’t emit .bin, hook .elf as fallback
+def _run_summary(source, target, env):
+    try:
+        summarize()
+        print(f"[build_result] Wrote {CUR_RES}")
+    except Exception as e:
+        print(f"[build_result] Failed to write summary: {e}")
+
+# Prefer .bin, but also attach to .elf to be safe
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", _run_summary)
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.elf", _run_summary)


### PR DESCRIPTION
I'm still experiencing episodes where PlatformIO decides it needs to rebuild every bit of the entire project down to the non-library framework despite no obvious reason I can see.  After adding `--debug=explain` to SCONSFLAGS, PlatformIO claimed that none of the build artifacts existed any more (as if a "clean" action had occurred).  This PR adds a script that logs some information about the environment as the build started and the results of the build (as well as the previous build) that is placed in the `generated` build folder.  Hopefully, that information will be useful when determining why the issue happened next time it happens.  Unfortunately the occurrences seem fairly random, so having a debugging tool like this in the repository is the only potentially effective approach I know of.

Tested by running the build a few times after changing various things.  But, nothing in this PR should affect the actual leaf firmware -- it only logs debugging information during the build.