### PR TITLE
Add Astro docs metadata to flights_and_logging.md

### DIFF
--- a/docs/dev-references/flights_and_logging.md
+++ b/docs/dev-references/flights_and_logging.md
@@ -1,3 +1,8 @@
+---
+title: Flights and Logging
+description: Definitions and intent around flights and logging
+---
+
 # Leaf Logging Functions
 
 <!-- Adopted from https://docs.google.com/document/d/1Rp0IslOAHZlb1cdwXtGMdCtgvGe01PvQ_RnXXEvWxjQ/edit?usp=sharing -->


### PR DESCRIPTION
This PR will hopefully fix the build break (due to Astro docs deployment failure) from #195 (see #199 also)