### PR TITLE
Add Fanet-ReBroadcast Developer Setting

### DIFF
--- a/src/vario/main.cpp
+++ b/src/vario/main.cpp
@@ -33,7 +33,7 @@
 // a message bus and hook the module's event routers into the bus
 
 // Main message bus
-MessageBus<10> bus;
+MessageBus<11> bus;
 
 TaskManager taskman;
 

--- a/src/vario/ui/display/pages/menu/page_menu_developer.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_developer.cpp
@@ -14,6 +14,7 @@
 
 enum developer_menu_items {
   cursor_developer_back,
+  cursor_developer_fanetReTx,
   cursor_developer_startupStart,
   cursor_developer_startupDisconnect,
   cursor_developer_busLogControl
@@ -30,7 +31,7 @@ void DeveloperMenuPage::draw() {
     uint8_t y_spacing = 16;
     uint8_t setting_name_x = 2;
     uint8_t setting_choice_x = 76;
-    uint8_t menu_items_y[] = {190, 60, 75, 135};
+    uint8_t menu_items_y[] = {190, 35, 135, 150, 170};
 
     // first draw cursor selection box
     uint8_t largerChoiceSize = 0;
@@ -40,8 +41,9 @@ void DeveloperMenuPage::draw() {
     u8g2.drawRBox(setting_choice_x - 4 - largerChoiceSize, menu_items_y[cursor_position] - 14,
                   30 + largerChoiceSize, 16, 2);
 
-    // draw On Startup Category
-    u8g2.setCursor(0, 45);
+    // draw Bus Logger Section
+    u8g2.drawHLine(0, 105, 96);
+    u8g2.setCursor(0, 120);
     u8g2.print("On Startup:");
 
     // then draw all the menu items
@@ -54,6 +56,12 @@ void DeveloperMenuPage::draw() {
       else
         u8g2.setDrawColor(1);
       switch (i) {
+        case cursor_developer_fanetReTx:
+          if (settings.dev_fanetReTx)
+            u8g2.print(char(125));
+          else
+            u8g2.print(char(123));
+          break;
         case cursor_developer_startupStart:
           if (settings.dev_startLogAtBoot)
             u8g2.print(char(125));
@@ -85,6 +93,10 @@ void DeveloperMenuPage::draw() {
 
 void DeveloperMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
   switch (cursor_position) {
+    case cursor_developer_fanetReTx: {
+      if (state == RELEASED) settings.toggleBoolOnOff(&settings.dev_fanetReTx);
+      break;
+    }
     case cursor_developer_startupStart: {
       if (state == RELEASED) settings.toggleBoolOnOff(&settings.dev_startLogAtBoot);
       break;

--- a/src/vario/ui/display/pages/menu/page_menu_developer.h
+++ b/src/vario/ui/display/pages/menu/page_menu_developer.h
@@ -10,7 +10,7 @@ class DeveloperMenuPage : public SettingsMenuPage {
  public:
   DeveloperMenuPage() {
     cursor_position = 0;
-    cursor_max = 3;
+    cursor_max = 4;
   }
   void draw();
 
@@ -18,7 +18,7 @@ class DeveloperMenuPage : public SettingsMenuPage {
   void setting_change(Button dir, ButtonState state, uint8_t count);
 
  private:
-  static constexpr char* labels[8] = {"Back", "StartBusLog", "Detach HW", "Log Now:"};
+  static constexpr char* labels[8] = {"Back", "Fanet ReTX", "StartBusLog", "Detach HW", "Log Now:"};
 };
 
 #endif

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -94,6 +94,7 @@ void Settings::loadDefaults() {
   dev_menu = DEF_DEV_MENU;
   dev_startLogAtBoot = DEF_DEV_START_LOG_AT_BOOT;
   dev_startDisconnected = DEF_DEV_START_DISCONNECTED;
+  dev_fanetReTx = DEF_DEV_FANET_RETX;
 
   // Boot Flags
   boot_enterBootloader = DEF_ENTER_BOOTLOAD;
@@ -152,9 +153,12 @@ void Settings::retrieve() {
   system_wifiOn = leafPrefs.getBool("WIFI_ON");
   system_bluetoothOn = leafPrefs.getBool("BLUETOOTH_ON");
   system_showWarning = leafPrefs.getBool("SHOW_WARNING");
+
+  // Developer Options
   dev_menu = leafPrefs.getBool("DEVELOPER_MENU");
   dev_startLogAtBoot = leafPrefs.getBool("DEV_STARTLOG");
   dev_startDisconnected = leafPrefs.getBool("DEV_STARTDISCON");
+  dev_fanetReTx = leafPrefs.getBool("DEV_FANET_RETX");
 
   // Boot Flags
   boot_enterBootloader = leafPrefs.getBool("ENTER_BOOTLOAD");
@@ -228,6 +232,7 @@ void Settings::save() {
   leafPrefs.putBool("DEVELOPER_MENU", dev_menu);
   leafPrefs.putBool("DEV_STARTLOG", dev_startLogAtBoot);
   leafPrefs.putBool("DEV_STARTDISCON", dev_startDisconnected);
+  leafPrefs.putBool("DEV_FANET_RETX", dev_fanetReTx);
   // Boot Flags
   leafPrefs.putBool("ENTER_BOOTLOAD", boot_enterBootloader);
   leafPrefs.putBool("BOOT_TO_ON", boot_toOnState);

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -77,6 +77,8 @@ typedef uint8_t SettingLogFormat;
 #define DEF_DEV_MENU 0                // default hide the dev menu
 #define DEF_DEV_START_LOG_AT_BOOT 0   // default do not start log at boot
 #define DEF_DEV_START_DISCONNECTED 0  // default do not disconnect hardware at boot
+#define DEF_DEV_FANET_RETX \
+  1  // default DO rebroadcast Fanet packets (generally only turned off for range testing)
 
 // Boot Flags
 // Boot-to-ON Flag (when resetting from system updates,
@@ -149,6 +151,7 @@ class Settings {
   bool dev_menu;
   bool dev_startLogAtBoot;
   bool dev_startDisconnected;
+  bool dev_fanetReTx;
 
   // Boot Flags
   bool boot_enterBootloader;


### PR DESCRIPTION
* In Developer Menu, Add Setting to turn Off/On Fanet Packet Rebroadcast flag 
 (This is largely valuable just for range testing, to ensure packets are direct unit<->unit and not through the Mesh)