### PR TITLE
Improve fatal error and add backtrace

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,6 +30,31 @@
         "reveal": "always",
         "panel": "new"
       }
+    },
+    {
+      "label": "Decode ESP32 Backtrace",
+      "type": "shell",
+      "windows": {
+        "command": "powershell.exe",
+        "args": [
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "${workspaceFolder}/src/scripts/decode_backtrace.ps1"
+        ]
+      },
+      "osx": {
+        "command": "${workspaceFolder}/src/scripts/decode_backtrace.sh"
+      },
+      "linux": {
+        "command": "${workspaceFolder}/src/scripts/decode_backtrace.sh"
+      },
+      "options": {
+        "env": {
+          "PIOENV": "${command:platformio-ide.activeEnvironment}"
+        }
+      },
+      "problemMatcher": []
     }
   ]
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -87,7 +87,6 @@ extends = env:_base
 build_flags = 
 	${env:_base.build_flags}
 	-D DEBUG_WIFI  # Enables WiFi on boot, enables webserver, does not disable Wifi after setup
-	-D DEBUG_FATALERROR_COREDUMP  # Enables core dump via assert(0) on fatal errors (instead of restarting after holding key)
 	-D DISABLE_MASS_STORAGE  # Disables mass storage on SD card mount
 	; -D MEMORY_PROFILING  # Enables memory profiling troubleshooting features
 	-D ARDUINO_USB_MODE=1

--- a/src/scripts/decode_backtrace.ps1
+++ b/src/scripts/decode_backtrace.ps1
@@ -1,0 +1,111 @@
+<#  Decode ESP32/ESP32‑S2/S3 (Xtensa) and ESP32‑C3/C6 (RISC‑V) backtraces.
+
+Usage:
+  powershell -ExecutionPolicy Bypass -File scripts/decode-backtrace.ps1 [-Backtrace "..."] [-ElfPath path]
+
+If -Backtrace is omitted, the script will try clipboard text and then prompt.
+It auto-selects the correct addr2line from %USERPROFILE%\.platformio\packages.
+#>
+
+param(
+  [string]$Backtrace,
+  [string]$ElfPath
+)
+
+function Write-Err($msg) { Write-Host "ERROR: $msg" -ForegroundColor Red }
+
+# --- 1) Acquire backtrace text ---
+if (-not $Backtrace -or $Backtrace.Trim() -eq "") {
+  try {
+    $clip = Get-Clipboard -Raw -ErrorAction Stop
+  } catch { $clip = "" }
+  if ($clip -and ($clip -match "0x[0-9A-Fa-f]+")) {
+    $Backtrace = $clip
+    Write-Host "Using backtrace from clipboard." -ForegroundColor DarkCyan
+  } else {
+    Write-Host "*** Note that a backtrace on the clipboard will be processed automatically."
+    $Backtrace = Read-Host "Paste your Backtrace line or just addresses (e.g. 0x4200F891:0x3FCC0450 ...)"
+  }
+}
+
+# --- 2) Extract program counters (PCs) from the backtrace text ---
+# Accepts:
+#   "Backtrace: 0xAAA:0xBBB 0xCCC:0xDDD ..."  (pc:sp pairs)
+#   "0xAAA 0xCCC ..."                         (pc-only)
+#   commas/semicolons mixed in
+function Get-PCsFromBacktrace([string]$text) {
+  $norm = $text -replace '[,;]', ' '
+  $matches = [regex]::Matches($norm, '0x[0-9A-Fa-f]+(?::0x[0-9A-Fa-f]+)?')
+  $pcs = @()
+  foreach ($m in $matches) {
+    $token = $m.Value
+    if ($token -match '^0x[0-9A-Fa-f]+:0x[0-9A-Fa-f]+$') {
+      # "pc:sp" -> take the pc (left side)
+      $pcs += $token.Split(':')[0]
+    } else {
+      $pcs += $token
+    }
+  }
+  return $pcs
+}
+
+$pcs = Get-PCsFromBacktrace $Backtrace
+if (-not $pcs -or $pcs.Count -eq 0) {
+  Write-Err "No addresses found in input."
+  exit 1
+}
+
+# --- 3) Locate the ELF for the current PlatformIO environment ---
+function Resolve-ElfStrict {
+  $pioEnv = $env:PIOENV
+  if (-not $pioEnv -or -not $pioEnv.Trim()) {
+    Write-Err "PIOENV is not set. Run from a PlatformIO terminal/task that sets $env:PIOENV, or export it manually."
+    exit 1
+  }
+  $projectRoot = (Resolve-Path ".").Path
+  $envDir = Join-Path $projectRoot ".pio/build/$pioEnv"
+  $candidate = Join-Path $envDir "firmware.elf"
+  if (-not (Test-Path $candidate)) {
+    Write-Err "ELF not found for env '$pioEnv': $candidate`nBuild the project for this environment first, then retry."
+    exit 1
+  }
+  return (Resolve-Path $candidate).Path
+}
+
+$ElfPath = Resolve-ElfStrict
+Write-Host "Using PIOENV: $($env:PIOENV)" -ForegroundColor DarkCyan
+Write-Host "Using ELF: $ElfPath" -ForegroundColor DarkCyan
+
+# --- 4) Select the proper addr2line ---
+function Find-Addr2line() {
+  $pkgs = Join-Path $env:USERPROFILE ".platformio\packages"
+  $candidates = @(
+    "toolchain-xtensa-esp32s3\bin\xtensa-esp32s3-elf-addr2line.exe",
+    "toolchain-xtensa-esp32\bin\xtensa-esp32-elf-addr2line.exe",
+    "toolchain-riscv32-esp\bin\riscv32-unknown-elf-addr2line.exe"
+  ) | ForEach-Object { Join-Path $pkgs $_ }
+
+  foreach ($p in $candidates) {
+    if (Test-Path $p) { return $p }
+  }
+  # last resort: hope addr2line is on PATH
+  return "addr2line"
+}
+
+$Addr2linePath = Find-Addr2line
+Write-Host "Using addr2line: $Addr2linePath" -ForegroundColor DarkCyan
+
+# --- 5) Run addr2line on each PC ---
+Write-Host "`nDecoding:" -ForegroundColor Cyan
+$argList = @("-pfiaC", "-e", $ElfPath) + $pcs
+$proc = Start-Process -FilePath $Addr2linePath -ArgumentList $argList -NoNewWindow -PassThru -RedirectStandardOutput "STDOUT.tmp" -RedirectStandardError "STDERR.tmp"
+$proc.WaitForExit()
+
+if ((Get-Item "STDERR.tmp").Length -gt 0) {
+  Write-Host (Get-Content "STDERR.tmp" -Raw) -ForegroundColor Yellow
+}
+if ((Get-Item "STDOUT.tmp").Length -gt 0) {
+  Get-Content "STDOUT.tmp"
+}
+
+Remove-Item -ErrorAction SilentlyContinue "STDOUT.tmp","STDERR.tmp"

--- a/src/scripts/decode_backtrace.sh
+++ b/src/scripts/decode_backtrace.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Decode ESP32 backtrace addresses using the ELF from the active PlatformIO env.
+# Usage:
+#   1) Pipe/paste a whole backtrace:   cat backtrace.txt | ./decode_backtrace.sh
+#   2) Or pass addresses directly:     ./decode_backtrace.sh 0x42010abc 0x4037fe12 ...
+
+set -euo pipefail
+
+# ---------- Helpers ----------
+err() { printf "Error: %s\n" "$*" >&2; exit 1; }
+info() { printf "[info] %s\n" "$*" >&2; }
+
+# ---------- Require PIOENV (provided by tasks.json) ----------
+PIOENV="${PIOENV:-}"
+[[ -n "$PIOENV" ]] || err "PIOENV is not set. Ensure the VS Code task provides it via \${command:platformio-ide.activeEnvironment}."
+
+# ---------- Resolve ELF ----------
+BUILD_DIR=".pio/build/${PIOENV}"
+[[ -d "$BUILD_DIR" ]] || err "Build directory not found: ${BUILD_DIR}"
+
+ELF_CANDIDATES=()
+if [[ -f "${BUILD_DIR}/firmware.elf" ]]; then
+  ELF_CANDIDATES+=("${BUILD_DIR}/firmware.elf")
+fi
+# Fallback: any .elf in the env's build directory
+while IFS= read -r -d '' f; do ELF_CANDIDATES+=("$f"); done < <(find "$BUILD_DIR" -maxdepth 1 -type f -name '*.elf' -print0)
+
+[[ ${#ELF_CANDIDATES[@]} -gt 0 ]] || err "No .elf found in ${BUILD_DIR}."
+ELF="${ELF_CANDIDATES[0]}"
+
+info "Using ELF: ${ELF}"
+
+[[ -r "$ELF" ]] || err "ELF not readable: ${ELF}"
+
+# ---------- Locate addr2line ----------
+# Preferred (ESP32-S3):
+CAND_BIN_NAMES=(
+  "xtensa-esp32s3-elf-addr2line"
+  "xtensa-esp32-elf-addr2line"
+  "riscv32-esp-elf-addr2line"
+)
+
+ADDR2LINE_BIN=""
+# 1) PATH lookup
+for b in "${CAND_BIN_NAMES[@]}"; do
+  if command -v "$b" >/dev/null 2>&1; then
+    ADDR2LINE_BIN="$(command -v "$b")"
+    break
+  fi
+done
+
+# 2) Search common PlatformIO tool locations if not found
+if [[ -z "$ADDR2LINE_BIN" ]]; then
+  PIO_HOME="${PLATFORMIO_HOME_DIR:-$HOME/.platformio}"
+  if [[ -d "$PIO_HOME/packages" ]]; then
+    while IFS= read -r -d '' candidate; do
+      ADDR2LINE_BIN="$candidate"
+      break
+    done < <(find "$PIO_HOME/packages" -type f \( \
+        -name 'xtensa-esp32s3-elf-addr2line' -o \
+        -name 'xtensa-esp32-elf-addr2line'   -o \
+        -name 'riscv32-esp-elf-addr2line'    \
+      \) -print0 2>/dev/null | head -zn 1)
+  fi
+fi
+
+[[ -n "$ADDR2LINE_BIN" ]] || err "Could not locate addr2line (xtensa-esp32s3-elf-addr2line / xtensa-esp32-elf-addr2line / riscv32-esp-elf-addr2line). Ensure PlatformIO toolchains are installed and on PATH."
+
+info "Using addr2line: ${ADDR2LINE_BIN}"
+
+# ---------- Gather addresses ----------
+INPUT_ADDRESSES=""
+if [[ $# -gt 0 ]]; then
+  # Take addresses from CLI args
+  INPUT_ADDRESSES="$(printf "%s\n" "$@")"
+else
+  # Read from stdin (paste backtrace or pipe a file)
+  if [ -t 0 ]; then
+    info "Paste the backtrace (Ctrl-D when done):"
+  fi
+  INPUT_ADDRESSES="$(cat)"
+fi
+
+# Extract hex addresses of form 0x...
+# Keep original order while removing duplicates.
+mapfile -t ADDRS < <(printf "%s" "$INPUT_ADDRESSES" \
+  | grep -Eo '0x[0-9a-fA-F]+' \
+  | awk '!seen[$0]++')
+
+[[ ${#ADDRS[@]} -gt 0 ]] || err "No addresses found (expected tokens like 0x400d1234)."
+
+info "Decoding ${#ADDRS[@]} unique addresses..."
+
+# ---------- Decode ----------
+# -p: show function names with offsets, -f: function name on its own line,
+# -i: include inlined frames, -a: print address, -C: demangle
+"${ADDR2LINE_BIN}" -e "${ELF}" -pfiaC "${ADDRS[@]}"

--- a/src/vario/README.md
+++ b/src/vario/README.md
@@ -30,7 +30,7 @@ To program the current hardware:
 
 ## Fatal errors
 
-When something happens that shouldn't ever happen, the function `fatalError` in [diagnostics/fatal_error.h](./diagnostics/fatal_error.h) should be called. When it is called, it will attempt to capture as much information as practical about the failure and both print that information to the screen and Serial log.
+When something happens that shouldn't ever happen, the function `fatalError` in [diagnostics/fatal_error.h](./diagnostics/fatal_error.h) should be called. When it is called, it will attempt to capture as much information as practical about the failure and print that information to the Serial log, SD card, and screen, when possible.
 
 ### Decoding backtraces
 
@@ -42,7 +42,7 @@ Backtrace: 0x420189EF:0x3FCC0770 0x4201904A:0x3FCC0790 0x42016152:0x3FCC07E0 0x4
 
 There are a number of ways to decode this into a human-readable stack trace, but the recommended method is:
 
-- Ensure the current PlatformIO environment and git version exactly match the firmware from which the backtrace was obtained
+- Ensure the current PlatformIO environment, git version, and codebase state exactly match the firmware from which the backtrace was obtained
 - Open command palette (ctrl-shift-P in Windows)
 - Select "Tasks: Run Task" (may have to type some of that in to find the appropriate entry)
 - Select "Decode ESP32 Backtrace" (may have to scroll to find it)

--- a/src/vario/README.md
+++ b/src/vario/README.md
@@ -28,6 +28,29 @@ To program the current hardware:
 - Select the [appropriate board](#esp32-configuration) and port in the Arduino IDE
 - Configure the [appropriate board settings](#esp32-configuration)
 
+## Fatal errors
+
+When something happens that shouldn't ever happen, the function `fatalError` in [diagnostics/fatal_error.h](./diagnostics/fatal_error.h) should be called. When it is called, it will attempt to capture as much information as practical about the failure and both print that information to the screen and Serial log.
+
+### Decoding backtraces
+
+One thing `fatalError` does is print a backtrace (stack trace) of the current execution point. A backtrace looks like:
+
+```
+Backtrace: 0x420189EF:0x3FCC0770 0x4201904A:0x3FCC0790 0x42016152:0x3FCC07E0 0x4206D96F:0x3FCC0800 0x40384AAE:0x3FCC0820
+```
+
+There are a number of ways to decode this into a human-readable stack trace, but the recommended method is:
+
+- Ensure the current PlatformIO environment and git version exactly match the firmware from which the backtrace was obtained
+- Open command palette (ctrl-shift-P in Windows)
+- Select "Tasks: Run Task" (may have to type some of that in to find the appropriate entry)
+- Select "Decode ESP32 Backtrace" (may have to scroll to find it)
+
+If the backtrace is already copied to the clipboard, the decoded content will be displayed immediately. Otherwise, the terminal will prompt you to paste in the backtrace of interest.
+
+Note: the Linux/Mac script for decoding backtraces is untested -- feedback welcome!
+
 ## Notes
 
 tried but not going to use:

--- a/src/vario/diagnostics/fatal_error.cpp
+++ b/src/vario/diagnostics/fatal_error.cpp
@@ -23,6 +23,19 @@ portMUX_TYPE btMux = portMUX_INITIALIZER_UNLOCKED;
 
 constexpr size_t BUFFER_SIZE = 512;
 
+namespace putc_interception {
+  // state used by the putc hook
+  static char* putc_buffer = nullptr;
+  static size_t putc_buffer_capacity = 0;
+  static size_t putc_buffer_index = 0;
+
+  extern "C" void IRAM_ATTR putc_intercept(char c) {
+    if (putc_buffer && putc_buffer_index < putc_buffer_capacity) {
+      putc_buffer[putc_buffer_index++] = c;
+    }
+  }
+}  // namespace putc_interception
+
 bool useFile() {
   if (fatal_error_file) {
     return true;
@@ -51,9 +64,34 @@ bool useFile() {
   fatal_error_file = SD_MMC.open(fileName, "w", true);  // open for writing, create if doesn't exist
 
   // Write the version information to know what generated this fatal error
+  fatal_error_file.print("Firmware version: ");
   fatal_error_file.println(FIRMWARE_VERSION);
 
   return fatal_error_file;
+}
+
+static void getBacktrace(char* buffer, size_t n) {
+  portENTER_CRITICAL(&btMux);
+
+  // Redirect ROM printf to our buffer for the duration of the backtrace print
+  putc_interception::putc_buffer = buffer;
+  putc_interception::putc_buffer_capacity = n;
+  putc_interception::putc_buffer_index = 0;
+  esp_rom_install_channel_putc(1, putc_interception::putc_intercept);
+
+  // Trigger backtrace print
+  esp_backtrace_print(16);
+
+  // Restore default UART output for ROM printf
+  esp_rom_install_uart_printf();
+
+  portEXIT_CRITICAL(&btMux);
+
+  // Null-terminate backtrace string in buffer
+  if (putc_interception::putc_buffer_index >= n) {
+    putc_interception::putc_buffer_index = n - 1;
+  }
+  buffer[putc_interception::putc_buffer_index] = 0;
 }
 
 void fatalErrorInfo(const char* msg, ...) {
@@ -66,6 +104,7 @@ void fatalErrorInfo(const char* msg, ...) {
 
   Serial.println(buffer);
   if (useFile()) {
+    fatal_error_file.print("Info: ");
     fatal_error_file.println(buffer);
   }
 }
@@ -134,8 +173,23 @@ void fatalError(const char* msg, ...) {
   va_end(args);
 
   Serial.println(buffer);
+  Serial.flush();
 
   // Try to write final error message to file
+  if (useFile()) {
+    fatal_error_file.print("Error: ");
+    fatal_error_file.println(buffer);
+  }
+
+  // Show fatal error info on screen
+  u8g2.clear();
+  displayFatalError(buffer);
+
+  // Load backtrace into buffer
+  getBacktrace(buffer, BUFFER_SIZE);
+
+  // Report backtrace
+  Serial.println(buffer);
   if (useFile()) {
     fatal_error_file.println(buffer);
   }
@@ -145,15 +199,6 @@ void fatalError(const char* msg, ...) {
     fatal_error_file.close();
   }
 
-  // Show fatal error info on screen
-  u8g2.clear();
-  displayFatalError(buffer);
-
-  // Print stack trace to default log output (Serial)
-  portENTER_CRITICAL(&btMux);
-  esp_backtrace_print(16);
-  portEXIT_CRITICAL(&btMux);
-
   // Play fatal error sound
   speaker.unMute();
   settings.system_volume = 3;
@@ -162,9 +207,5 @@ void fatalError(const char* msg, ...) {
     delay(10);
   }
 
-#ifdef DEBUG_FATALERROR_COREDUMP
-  assert(0);  // Force core dump
-#else
   rebootOnKeyPress();
-#endif
 }


### PR DESCRIPTION
This PR substantially improves the ability to report information about fatal errors when they occur, including logging and printing a backtrace (stack trace).  This means we should be able to see stack traces for fatal errors that occur in the field (as long as the leaf is being operated with an SD card).  Because the backtrace is now included in the standard fatal error, there is no need to force a core dump, so the differing behavior for debug environments is removed.

In addition, this PR adds a VS Code "task" that makes using the existing installed tools to decode a backtracer easier (instructions in src/README.md).

Tested by adding a line to force a fatal error at power-on and verifying correct behavior and logging with and without an SD card.  Then, tested c314e5978833ca0d839f502730dbc2cab774f412 via the standard test procedure (3.2.7+radio, leaf_3_2_7_dev).