### PR TITLE
Simplify Buttons

### DIFF
--- a/src/vario/diagnostics/buttons.cpp
+++ b/src/vario/diagnostics/buttons.cpp
@@ -6,7 +6,7 @@
 
 ButtonMonitor buttonMonitor;
 
-void ButtonMonitor::on_receive(const ButtonEvent& msg) {
+void ButtonMonitor::on_receive(const ButtonEventMessage& msg) {
   switch (msg.button) {
     case Button::CENTER:
       Serial.print("button: CENTER");
@@ -28,18 +28,24 @@ void ButtonMonitor::on_receive(const ButtonEvent& msg) {
       break;
   }
 
-  switch (msg.state) {
-    case PRESSED:
-      Serial.print(" state: PRESSED  ");
+  switch (msg.event) {
+    case ButtonEvent::PRESSED:
+      Serial.print(" state: PRESSED    ");
       break;
-    case RELEASED:
-      Serial.print(" state: RELEASED ");
+    case ButtonEvent::CLICKED:
+      Serial.print(" state: CLICKED    ");
       break;
-    case HELD:
-      Serial.print(" state: HELD     ");
+    case ButtonEvent::RELEASED:
+      Serial.print(" state: RELEASED   ");
       break;
-    case HELD_LONG:
-      Serial.print(" state: HELD_LONG");
+    case ButtonEvent::HELD:
+      Serial.print(" state: HELD       ");
+      break;
+    case ButtonEvent::HELD_LONG:
+      Serial.print(" state: HELD_LONG  ");
+      break;
+    case ButtonEvent::INCREMENTED:
+      Serial.print(" state: INCREMENTED");
   }
 
   Serial.print(" hold count: ");

--- a/src/vario/diagnostics/buttons.h
+++ b/src/vario/diagnostics/buttons.h
@@ -4,12 +4,12 @@
 
 #include "dispatch/message_types.h"
 
-class ButtonMonitor : public etl::message_router<ButtonMonitor, ButtonEvent> {
+class ButtonMonitor : public etl::message_router<ButtonMonitor, ButtonEventMessage> {
  public:
   void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
 
-  // etl::message_router<ButtonMonitor, ButtonEvent>
-  void on_receive(const ButtonEvent& msg);
+  // etl::message_router<ButtonMonitor, ButtonEventMessage>
+  void on_receive(const ButtonEventMessage& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
 };
 

--- a/src/vario/diagnostics/fatal_error.cpp
+++ b/src/vario/diagnostics/fatal_error.cpp
@@ -136,7 +136,7 @@ void displayFatalError(char* msg) {
 
 void rebootOnKeyPress() {
   Button which_button;
-  ButtonState button_state;
+  ButtonEvent button_state;
 
   // Wait until no buttons are pressed
   do {

--- a/src/vario/dispatch/message_types.h
+++ b/src/vario/dispatch/message_types.h
@@ -97,15 +97,15 @@ struct PressureUpdate : public etl::message<PRESSURE_UPDATE> {
 };
 
 /// @brief Update regarding button presses
-struct ButtonEvent : public etl::message<BUTTON_EVENT> {
+struct ButtonEventMessage : public etl::message<BUTTON_EVENT> {
   // Which button triggered event
   Button button;
 
-  // Current state of the button
-  ButtonState state;
+  // Event that occurred
+  ButtonEvent event;
 
   uint16_t holdCount;
 
-  ButtonEvent(Button button, ButtonState state, uint16_t holdCount = 0)
-      : button(button), state(state), holdCount(holdCount) {}
+  ButtonEventMessage(Button button, ButtonEvent event, uint16_t holdCount = 0)
+      : button(button), event(event), holdCount(holdCount) {}
 };

--- a/src/vario/hardware/README.md
+++ b/src/vario/hardware/README.md
@@ -1,3 +1,5 @@
 # hardware
 
 This folder contains abstractions for hardware devices. These tools interact directly with the hardware device at the electrical level and present the information gathered in the most "raw" form that is semantically meaningful.
+
+- [Buttons](./buttons.md)

--- a/src/vario/hardware/buttons.md
+++ b/src/vario/hardware/buttons.md
@@ -1,0 +1,57 @@
+# Buttons hardware
+
+## Overview
+
+Leaf has a 5-way switch where only one switch may be pressed at a time. The state transition diagram for these buttons is shown below. Yellow events are dispatched to the message bus as messages.
+
+Generally, consumers should use either Held + HeldLong events, or they should use Increment events. It should be unusual to use both Increment events and either Held or HeldLong.
+
+## State transition diagram
+
+```mermaid
+flowchart LR
+    UpState["Up"]
+    DebouncingState["Debouncing"]
+    DownState["Down"]
+    HeldState["Held"]
+    HeldLongState["HeldLong"]
+    class UpState,DebouncingState,DownState,HeldState,HeldLongState State
+
+    PressedEvent["Pressed<br>event"]@{ shape: card }
+    HeldEvent["Held<br>event"]@{ shape: card }
+    HeldLongEvent["HeldLong<br>event"]@{ shape: card }
+    ClickedEvent["Clicked<br>event"]@{ shape: card }
+    ClickedEventNewButton["Clicked<br>event"]@{ shape: card }
+    IncrementEventDown["Increment<br>event"]@{ shape: card }
+    IncrementEventHeld["Increment<br>event"]@{ shape: card }
+    IncrementEventHeldLong["Increment<br>event"]@{ shape: card }
+    ReleasedEventUp["Released<br>event"]@{ shape: card }
+    ReleasedEventDown["Released<br>event"]@{ shape: card }
+    class PressedEvent,HeldEvent,HeldLongEvent,ClickedEvent,ClickedEventNewButton,IncrementEventDown,IncrementEventHeld,IncrementEventHeldLong,ReleasedEventUp,ReleasedEventDown Event
+
+    ResetDebounceTimer["Reset debounce timer,<br>set current button"]@{ shape: delay }
+    IncrementHoldCounterHeld["Increment hold counter,<br>reset increment timer"]@{ shape: delay }
+    IncrementHoldCounterHeldLong["Increment hold counter,<br>reset increment timer"]@{ shape: delay }
+    class ResetDebounceTimer,IncrementHoldCounterHeld,IncrementHoldCounterHeldLong Operation
+
+    ReleasedEventUp --> UpState
+    ReleasedEventDown --> ResetDebounceTimer
+    UpState -->|"button pressed"| ResetDebounceTimer --> DebouncingState
+    DebouncingState -->|"1: no button pressed"| UpState
+    DebouncingState -->|"2: different button<br>pressed"| ResetDebounceTimer
+    DebouncingState -->|"3: debounce time<br>elapsed"| PressedEvent --> DownState
+    DownState -->|"1: no button pressed"| ClickedEvent --> ReleasedEventUp
+    DownState -->|"2: different button<br>pressed"| ClickedEventNewButton --> ReleasedEventDown
+    DownState -->|"3: hold time elapsed"| HeldEvent --> IncrementEventDown --> HeldState
+    HeldState -->|"1: no button pressed"| ReleasedEventUp
+    HeldState -->|"2: different button<br>pressed"| ReleasedEventDown
+    HeldState -->|"3: increment<br>time elapsed"| IncrementHoldCounterHeld --> IncrementEventHeld --> HeldState
+    HeldState -->|"4: hold long<br>time elapsed"| HeldLongEvent --> HeldLongState
+    HeldLongState -->|"1: no button pressed"| ReleasedEventUp
+    HeldLongState -->|"2: different button<br>pressed"| ReleasedEventDown
+    HeldLongState -->|"3: increment<br>time elapsed"| IncrementHoldCounterHeldLong --> IncrementEventHeldLong --> HeldLongState
+
+    classDef State fill:#90EE90
+    classDef Event fill:#EEEE90
+    classDef Operation fill:#9090EE
+```

--- a/src/vario/ui/display/menu_page.cpp
+++ b/src/vario/ui/display/menu_page.cpp
@@ -17,13 +17,13 @@ void MenuPage::cursor_next() {
   if (cursor_position > cursor_max) cursor_position = cursor_min;
 }
 
-bool SettingsMenuPage::button_event(Button button, ButtonState state, uint8_t count) {
+bool SettingsMenuPage::button_event(Button button, ButtonEvent state, uint8_t count) {
   switch (button) {
     case Button::UP:
-      if (state == RELEASED) cursor_prev();
+      if (state == ButtonEvent::CLICKED) cursor_prev();
       break;
     case Button::DOWN:
-      if (state == RELEASED) cursor_next();
+      if (state == ButtonEvent::CLICKED) cursor_next();
       break;
     case Button::LEFT:
       setting_change(Button::LEFT, state, count);
@@ -36,7 +36,7 @@ bool SettingsMenuPage::button_event(Button button, ButtonState state, uint8_t co
       break;
   }
   bool redraw = false;
-  if (button != Button::NONE && state != NO_STATE) redraw = true;
+  if (button != Button::NONE) redraw = true;
   return redraw;  // update display after button push so that the UI reflects any changes
                   // immediately
 }
@@ -138,8 +138,8 @@ etl::array_view<const char*> SimpleSettingsMenuPage::get_labels() const {
 }
 
 // Only handle the default back button closing this dialog
-void SimpleSettingsMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
-  if (cursor_position == CURSOR_BACK && state == RELEASED) {
+void SimpleSettingsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (cursor_position == CURSOR_BACK && state == ButtonEvent::CLICKED) {
     pop_page();
     return;
   }

--- a/src/vario/ui/display/menu_page.h
+++ b/src/vario/ui/display/menu_page.h
@@ -32,7 +32,7 @@ class MenuPage {
   //   state: New state of button
   //   count: (TODO: document)
   // Returns true if the page should be redrawn after the event.
-  virtual bool button_event(Button button, ButtonState state, uint8_t count) = 0;
+  virtual bool button_event(Button button, ButtonEvent state, uint8_t count) = 0;
 
   // Called to draw the menu page.
   // Assumes(?) the screen is already clear.
@@ -73,10 +73,10 @@ class MenuPage {
 
 class SettingsMenuPage : public MenuPage {
  public:
-  bool button_event(Button button, ButtonState state, uint8_t count);
+  bool button_event(Button button, ButtonEvent state, uint8_t count);
 
  protected:
-  virtual void setting_change(Button dir, ButtonState state, uint8_t count) = 0;
+  virtual void setting_change(Button dir, ButtonEvent state, uint8_t count) = 0;
 };
 
 // A simple helper class to handle simple menu items that draw things like
@@ -107,6 +107,6 @@ class SimpleSettingsMenuPage : public SettingsMenuPage {
   virtual etl::array_view<const char*> get_labels() const;
 
  protected:
-  virtual void setting_change(Button dir, ButtonState state, uint8_t count) override;
+  virtual void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
   static etl::array<const char*, 0> emptyMenu;
 };

--- a/src/vario/ui/display/pages/dialogs/page_list_select.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_list_select.cpp
@@ -20,11 +20,11 @@ void PageListSelect::draw_menu_input(int8_t cursor_position) {
   u8g2.print(ret);
 }
 
-void PageListSelect::setting_change(Button dir, ButtonState state, uint8_t count) {
+void PageListSelect::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   // Call the parent class to handle the back button
   SimpleSettingsMenuPage::setting_change(dir, state, count);
 
-  if (state != RELEASED) return;
+  if (state != ButtonEvent::CLICKED) return;
 
   // If 255, it's the back button
   if (cursor_position != -1) {

--- a/src/vario/ui/display/pages/dialogs/page_list_select.h
+++ b/src/vario/ui/display/pages/dialogs/page_list_select.h
@@ -24,7 +24,7 @@ class PageListSelect : public SimpleSettingsMenuPage {
   virtual void draw_menu_input(int8_t cursor_position) override;
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count) override;
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
 
  private:
   PageListSelect() {}

--- a/src/vario/ui/display/pages/dialogs/page_warning.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_warning.cpp
@@ -89,9 +89,9 @@ void warningPage_draw() {
   } while (u8g2.nextPage());
 }
 
-void warningPage_button(Button button, ButtonState state, uint8_t count) {
+void warningPage_button(Button button, ButtonEvent state, uint8_t count) {
   // allow turning off in all states
-  if (state == HELD && button == Button::CENTER) {
+  if (state == ButtonEvent::HELD && button == Button::CENTER) {
     power.shutdown();
     return;
   }
@@ -100,13 +100,13 @@ void warningPage_button(Button button, ButtonState state, uint8_t count) {
     case cursor_warningPage_none:
       switch (button) {
         case Button::UP:
-          if (state == RELEASED) {
+          if (state == ButtonEvent::CLICKED) {
             warningPage_cursorPosition = cursor_warningPage_decline;
             speaker.playSound(fx::decrease);
           }
           break;
         case Button::DOWN:
-          if (state == RELEASED) {
+          if (state == ButtonEvent::CLICKED) {
             warningPage_cursorPosition = cursor_warningPage_accept;
             speaker.playSound(fx::increase);
           }
@@ -114,7 +114,7 @@ void warningPage_button(Button button, ButtonState state, uint8_t count) {
       }
       break;
     case cursor_warningPage_decline:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         if (button == Button::UP || button == Button::DOWN) {
           warningPage_cursorPosition = cursor_warningPage_accept;
           speaker.playSound(fx::increase);
@@ -124,7 +124,7 @@ void warningPage_button(Button button, ButtonState state, uint8_t count) {
       }
       break;
     case cursor_warningPage_accept:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         if (button == Button::UP || button == Button::DOWN) {
           warningPage_cursorPosition = cursor_warningPage_decline;
           speaker.playSound(fx::decrease);

--- a/src/vario/ui/display/pages/dialogs/page_warning.h
+++ b/src/vario/ui/display/pages/dialogs/page_warning.h
@@ -6,4 +6,4 @@
 void warningPage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void warningPage_button(Button button, ButtonState state, uint8_t count);
+void warningPage_button(Button button, ButtonEvent state, uint8_t count);

--- a/src/vario/ui/display/pages/fanet/page_fanet.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet.cpp
@@ -8,8 +8,8 @@
 
 // Singleton instance
 
-void PageFanet::setting_change(Button dir, ButtonState state, uint8_t count) {
-  if (state != RELEASED) return;
+void PageFanet::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (state != ButtonEvent::CLICKED) return;
 
   // Handle menu item selection
   switch (cursor_position) {

--- a/src/vario/ui/display/pages/fanet/page_fanet.h
+++ b/src/vario/ui/display/pages/fanet/page_fanet.h
@@ -17,7 +17,7 @@ class PageFanet : public SimpleSettingsMenuPage {
   virtual void draw_menu_input(int8_t cursor_position) override;
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count) override;
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
 
  private:
   static PageFanet& getInstance();

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground_select.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground_select.cpp
@@ -4,12 +4,12 @@
 
 void PageFanetGroundSelect::show() { push_page(&getInstance()); }
 
-void PageFanetGroundSelect::setting_change(Button dir, ButtonState state, uint8_t count) {
+void PageFanetGroundSelect::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   // Call the parent method
   SimpleSettingsMenuPage::setting_change(dir, state, count);
   if (cursor_position == CURSOR_BACK) return;
 
-  if (state != ButtonState::RELEASED) {
+  if (state != ButtonEvent::CLICKED) {
     return;
   }
 

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground_select.h
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground_select.h
@@ -18,7 +18,7 @@ class PageFanetGroundSelect : SimpleSettingsMenuPage {
   }
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count) override;
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
 
  private:
   PageFanetGroundSelect() {}

--- a/src/vario/ui/display/pages/menu/page_menu_altimeter.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_altimeter.cpp
@@ -141,14 +141,14 @@ void AltimeterMenuPage::draw() {
   } while (u8g2.nextPage());
 }
 
-void AltimeterMenuPage::setting_change(Button button, ButtonState state, uint8_t count) {
+void AltimeterMenuPage::setting_change(Button button, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_altimeter_syncGPSLogStart:
-      if ((button == Button::CENTER || button == Button::RIGHT) && state == RELEASED)
+      if ((button == Button::CENTER || button == Button::RIGHT) && state == ButtonEvent::CLICKED)
         settings.toggleBoolNeutral(&settings.vario_altSyncToGPS);
       break;
     case cursor_altimeter_syncGPSNow:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         if (baro.syncToGPSAlt()) {  // successful adjustment of altimeter setting to match GPS
           speaker.playSound(fx::enter);
         } else {  // unsuccessful
@@ -158,7 +158,7 @@ void AltimeterMenuPage::setting_change(Button button, ButtonState state, uint8_t
       break;
     case cursor_altimeter_adjustSetting:
       if (button == Button::CENTER && count == 1 &&
-          state == HELD) {          // if center button held for 1 'action time'
+          state == ButtonEvent::INCREMENTED) {  // if center button held for 1 increment
         if (baro.syncToGPSAlt()) {  // successful adjustment of altimeter setting to match GPS
                                     // altitude
           speaker.playSound(fx::enter);
@@ -166,7 +166,7 @@ void AltimeterMenuPage::setting_change(Button button, ButtonState state, uint8_t
           speaker.playSound(fx::cancel);
         }
       } else if (button == Button::LEFT || button == Button::RIGHT) {
-        if (state == PRESSED || state == HELD || state == HELD_LONG) {
+        if (state == ButtonEvent::CLICKED || state == ButtonEvent::INCREMENTED) {
           if (button == Button::LEFT)
             baro.adjustAltSetting(-1, count);
           else if (button == Button::RIGHT)
@@ -176,11 +176,11 @@ void AltimeterMenuPage::setting_change(Button button, ButtonState state, uint8_t
       }
       break;
     case cursor_altimeter_back:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);
         settings.save();
         mainMenuPage.backToMainMenu();
-      } else if (state == HELD) {
+      } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
         mainMenuPage.quitMenu();

--- a/src/vario/ui/display/pages/menu/page_menu_altimeter.h
+++ b/src/vario/ui/display/pages/menu/page_menu_altimeter.h
@@ -15,7 +15,7 @@ class AltimeterMenuPage : public SettingsMenuPage {
   void draw();
 
  protected:
-  void setting_change(Button button, ButtonState state, uint8_t count);
+  void setting_change(Button button, ButtonEvent state, uint8_t count);
 };
 
 #endif

--- a/src/vario/ui/display/pages/menu/page_menu_developer.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_developer.cpp
@@ -91,22 +91,22 @@ void DeveloperMenuPage::draw() {
   } while (u8g2.nextPage());
 }
 
-void DeveloperMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
+void DeveloperMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_developer_fanetReTx: {
-      if (state == RELEASED) settings.toggleBoolOnOff(&settings.dev_fanetReTx);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.dev_fanetReTx);
       break;
     }
     case cursor_developer_startupStart: {
-      if (state == RELEASED) settings.toggleBoolOnOff(&settings.dev_startLogAtBoot);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.dev_startLogAtBoot);
       break;
     }
     case cursor_developer_startupDisconnect: {
-      if (state == RELEASED) settings.toggleBoolOnOff(&settings.dev_startDisconnected);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.dev_startDisconnected);
       break;
     }
     case cursor_developer_busLogControl: {
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         if (!busLog.isLogging()) {
           if (busLog.startLog()) {
             speaker.playSound(fx::started);
@@ -120,11 +120,11 @@ void DeveloperMenuPage::setting_change(Button dir, ButtonState state, uint8_t co
       break;
     }
     case cursor_developer_back: {
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);
         settings.save();
         mainMenuPage.backToMainMenu();
-      } else if (state == HELD) {
+      } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
         mainMenuPage.quitMenu();

--- a/src/vario/ui/display/pages/menu/page_menu_developer.h
+++ b/src/vario/ui/display/pages/menu/page_menu_developer.h
@@ -15,7 +15,7 @@ class DeveloperMenuPage : public SettingsMenuPage {
   void draw();
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count);
+  void setting_change(Button dir, ButtonEvent state, uint8_t count);
 
  private:
   static constexpr char* labels[8] = {"Back", "Fanet ReTX", "StartBusLog", "Detach HW", "Log Now:"};

--- a/src/vario/ui/display/pages/menu/page_menu_display.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_display.cpp
@@ -85,67 +85,37 @@ void DisplayMenuPage::draw() {
   } while (u8g2.nextPage());
 }
 
-void DisplayMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
+void DisplayMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_display_show_debug:
-      if (state == RELEASED && dir == Button::CENTER)
+      if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
         settings.toggleBoolOnOff(&settings.disp_showDebugPage);
       break;
     case cursor_display_show_thrm:
-      if (state == RELEASED && dir == Button::CENTER)
+      if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
         settings.toggleBoolOnOff(&settings.disp_showThmPage);
       break;
     case cursor_display_show_thrm_adv:
-      if (state == RELEASED && dir == Button::CENTER)
+      if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
         settings.toggleBoolOnOff(&settings.disp_showThmAdvPage);
       break;
     case cursor_display_show_nav:
-      if (state == RELEASED && dir == Button::CENTER)
+      if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
         settings.toggleBoolOnOff(&settings.disp_showNavPage);
       break;
     case cursor_display_contrast:
-      if (state == RELEASED && dir != Button::NONE)
-        settings.adjustContrast(dir);
-      else if (state == HELD && dir == Button::NONE)
+      if (state == ButtonEvent::CLICKED || state == ButtonEvent::INCREMENTED)
         settings.adjustContrast(dir);
       break;
     case cursor_display_back:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);
         settings.save();
         mainMenuPage.backToMainMenu();
-      } else if (state == HELD) {
+      } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
         mainMenuPage.quitMenu();
       }
   }
 }
-
-// helpful switch constructors to copy-paste as needed:
-/*
-switch (button) {
-  case Button::UP:
-    break;
-  case Button::DOWN:
-    break;
-  case Button::LEFT:
-    break;
-  case Button::RIGHT:
-    break;
-  case Button::CENTER:
-    break;
-*/
-
-/*
-switch (state) {
-  case RELEASED:
-    break;
-  case PRESSED:
-    break;
-  case HELD:
-    break;
-  case HELD_LONG:
-    break;
-}
-*/

--- a/src/vario/ui/display/pages/menu/page_menu_display.h
+++ b/src/vario/ui/display/pages/menu/page_menu_display.h
@@ -15,7 +15,7 @@ class DisplayMenuPage : public SettingsMenuPage {
   void draw();
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count);
+  void setting_change(Button dir, ButtonEvent state, uint8_t count);
 
  private:
   static constexpr char* labels[6] = {"Back",        "Debug",    "Thermal",

--- a/src/vario/ui/display/pages/menu/page_menu_gps.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_gps.cpp
@@ -96,17 +96,17 @@ void GPSMenuPage::draw() {
   } while (u8g2.nextPage());
 }
 
-void GPSMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
+void GPSMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_gps_update:
 
       break;
     case cursor_gps_back:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);
         settings.save();
         mainMenuPage.backToMainMenu();
-      } else if (state == HELD) {
+      } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
         mainMenuPage.quitMenu();
@@ -162,31 +162,3 @@ void GPSMenuPage::drawConstellation(uint8_t x, uint8_t y, uint16_t size) {
     }
   }
 }
-
-// helpful switch constructors to copy-paste as needed:
-/*
-switch (button) {
-  case Button::UP:
-    break;
-  case Button::DOWN:
-    break;
-  case Button::LEFT:
-    break;
-  case Button::RIGHT:
-    break;
-  case Button::CENTER:
-    break;
-*/
-
-/*
-switch (state) {
-  case RELEASED:
-    break;
-  case PRESSED:
-    break;
-  case HELD:
-    break;
-  case HELD_LONG:
-    break;
-}
-*/

--- a/src/vario/ui/display/pages/menu/page_menu_gps.h
+++ b/src/vario/ui/display/pages/menu/page_menu_gps.h
@@ -18,7 +18,7 @@ class GPSMenuPage : public SettingsMenuPage {
   void drawConstellation(uint8_t x, uint8_t y, uint16_t size);
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count);
+  void setting_change(Button dir, ButtonEvent state, uint8_t count);
 
  private:
   static constexpr char* labels[2] = {"Back", "Update(sec)"

--- a/src/vario/ui/display/pages/menu/page_menu_log.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_log.cpp
@@ -81,10 +81,10 @@ void LogMenuPage::draw() {
   } while (u8g2.nextPage());
 }
 
-void LogMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
+void LogMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_log_format: {
-      if (state != PRESSED) {
+      if (state != ButtonEvent::CLICKED) {
         return;
       }
       auto new_val = (int8_t)settings.log_format;
@@ -104,23 +104,23 @@ void LogMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
       break;
     }
     case cursor_log_saveLog: {
-      if (state == RELEASED) settings.toggleBoolOnOff(&settings.log_saveTrack);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.log_saveTrack);
       break;
     }
     case cursor_log_autoStart: {
-      if (state == RELEASED) settings.toggleBoolOnOff(&settings.log_autoStart);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.log_autoStart);
       break;
     }
     case cursor_log_autoStop: {
-      if (state == RELEASED) settings.toggleBoolOnOff(&settings.log_autoStop);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.log_autoStop);
       break;
     }
     case cursor_log_back: {
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);
         settings.save();
         mainMenuPage.backToMainMenu();
-      } else if (state == HELD) {
+      } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
         mainMenuPage.quitMenu();

--- a/src/vario/ui/display/pages/menu/page_menu_log.h
+++ b/src/vario/ui/display/pages/menu/page_menu_log.h
@@ -15,7 +15,7 @@ class LogMenuPage : public SettingsMenuPage {
   void draw();
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count);
+  void setting_change(Button dir, ButtonEvent state, uint8_t count);
 
  private:
   static constexpr char* labels[8] = {"Back", "Format", "SaveLog", "AutoStart", "AutoStop"};

--- a/src/vario/ui/display/pages/menu/page_menu_system.h
+++ b/src/vario/ui/display/pages/menu/page_menu_system.h
@@ -16,7 +16,7 @@ class SystemMenuPage : public SettingsMenuPage {
   void draw();
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count);
+  void setting_change(Button dir, ButtonEvent state, uint8_t count);
 
  private:
   static constexpr char* labels[10] = {"Back",  "TimeZone", "Volume", "Auto-Off", "ShowWarning",

--- a/src/vario/ui/display/pages/menu/page_menu_units.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_units.cpp
@@ -100,35 +100,35 @@ void UnitsMenuPage::draw() {
   } while (u8g2.nextPage());
 }
 
-void UnitsMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
+void UnitsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_units_alt:
-      if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_alt);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_alt);
       break;
     case cursor_units_climb:
-      if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_climb);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_climb);
       break;
     case cursor_units_speed:
-      if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_speed);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_speed);
       break;
     case cursor_units_distance:
-      if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_distance);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_distance);
       break;
     case cursor_units_heading:
-      if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_heading);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_heading);
       break;
     case cursor_units_temp:
-      if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_temp);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_temp);
       break;
     case cursor_units_hours:
-      if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_hours);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_hours);
       break;
     case cursor_units_back:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);
         settings.save();
         mainMenuPage.backToMainMenu();
-      } else if (state == HELD) {
+      } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
         mainMenuPage.quitMenu();
@@ -136,31 +136,3 @@ void UnitsMenuPage::setting_change(Button dir, ButtonState state, uint8_t count)
       break;
   }
 }
-
-// helpful switch constructors to copy-paste as needed:
-/*
-switch (button) {
-  case Button::UP:
-    break;
-  case Button::DOWN:
-    break;
-  case Button::LEFT:
-    break;
-  case Button::RIGHT:
-    break;
-  case Button::CENTER:
-    break;
-*/
-
-/*
-switch (state) {
-  case RELEASED:
-    break;
-  case PRESSED:
-    break;
-  case HELD:
-    break;
-  case HELD_LONG:
-    break;
-}
-*/

--- a/src/vario/ui/display/pages/menu/page_menu_units.h
+++ b/src/vario/ui/display/pages/menu/page_menu_units.h
@@ -15,7 +15,7 @@ class UnitsMenuPage : public SettingsMenuPage {
   void draw();
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count);
+  void setting_change(Button dir, ButtonEvent state, uint8_t count);
 
  private:
   static constexpr char* labels[8] = {"Back",     "Altitude", "ClimbRate", "Speed",

--- a/src/vario/ui/display/pages/menu/page_menu_vario.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.cpp
@@ -137,39 +137,39 @@ void VarioMenuPage::draw() {
   } while (u8g2.nextPage());
 }
 
-void VarioMenuPage::setting_change(Button dir, ButtonState state, uint8_t count) {
+void VarioMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_vario_volume:
-      if (state != RELEASED) return;
+      if (state != ButtonEvent::CLICKED) return;
       settings.adjustVolumeVario(dir);
       break;
     case cursor_vario_quietmode:
-      if (state == RELEASED) settings.toggleBoolOnOff(&settings.vario_quietMode);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.vario_quietMode);
       break;
     case cursor_vario_sensitive:
-      if (state == RELEASED) settings.adjustVarioAverage(dir);
+      if (state == ButtonEvent::CLICKED) settings.adjustVarioAverage(dir);
       break;
     case cursor_vario_tones:
-      if (state == RELEASED) settings.toggleBoolNeutral(&settings.vario_tones);
+      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.vario_tones);
       break;
     case cursor_vario_liftyair:
-      if (state == RELEASED) settings.adjustLiftyAir(dir);
+      if (state == ButtonEvent::CLICKED) settings.adjustLiftyAir(dir);
       break;
     case cursor_vario_climbavg:
-      if (state == RELEASED) settings.adjustClimbAverage(dir);
+      if (state == ButtonEvent::CLICKED) settings.adjustClimbAverage(dir);
       break;
     case cursor_vario_climbstart:
-      if (state == RELEASED) settings.adjustClimbStart(dir);
+      if (state == ButtonEvent::CLICKED) settings.adjustClimbStart(dir);
       break;
     case cursor_vario_sinkalarm:
-      if (state == RELEASED) settings.adjustSinkAlarm(dir);
+      if (state == ButtonEvent::CLICKED) settings.adjustSinkAlarm(dir);
       break;
     case cursor_vario_back:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);
         settings.save();
         mainMenuPage.backToMainMenu();
-      } else if (state == HELD) {
+      } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
         mainMenuPage.quitMenu();

--- a/src/vario/ui/display/pages/menu/page_menu_vario.h
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.h
@@ -15,7 +15,7 @@ class VarioMenuPage : public SettingsMenuPage {
   void draw();
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count);
+  void setting_change(Button dir, ButtonEvent state, uint8_t count);
 
  private:
   static constexpr char* labels[9] = {

--- a/src/vario/ui/display/pages/menu/system/page_menu_system_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/system/page_menu_system_wifi.cpp
@@ -12,8 +12,8 @@
 /**************************
  * PageMenuSystemWifi (Top Level)
  */
-void PageMenuSystemWifi::setting_change(Button dir, ButtonState state, uint8_t count) {
-  if (state != RELEASED) return;
+void PageMenuSystemWifi::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (state != ButtonEvent::CLICKED) return;
 
   // Handle updating items
   switch (cursor_position) {
@@ -82,11 +82,11 @@ void PageMenuSystemWifiSetup::shown() {
   WiFi.beginSmartConfig();
 }
 
-void PageMenuSystemWifiSetup::setting_change(Button dir, ButtonState state, uint8_t count) {
+void PageMenuSystemWifiSetup::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   // Call the parent class to handle the back button
   SimpleSettingsMenuPage::setting_change(dir, state, count);
 
-  if (state != RELEASED) return;
+  if (state != ButtonEvent::CLICKED) return;
 
   // Handle updating items
   switch (cursor_position) {

--- a/src/vario/ui/display/pages/menu/system/page_menu_system_wifi.h
+++ b/src/vario/ui/display/pages/menu/system/page_menu_system_wifi.h
@@ -69,7 +69,7 @@ class PageMenuSystemWifiSetup : public SimpleSettingsMenuPage {
 
  protected:
   // Handle the user clicking on the sub menus
-  void setting_change(Button dir, ButtonState state, uint8_t count) override;
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
 
  private:
   WifiState* wifi_state;
@@ -120,7 +120,7 @@ class PageMenuSystemWifi : public SimpleSettingsMenuPage {
   virtual void closed(bool removed_from_stack) override;
 
  protected:
-  void setting_change(Button dir, ButtonState state, uint8_t count) override;
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
 
  private:
   WifiState wifi_state = WifiState::DISCONNECTED;

--- a/src/vario/ui/display/pages/primary/page_menu_main.cpp
+++ b/src/vario/ui/display/pages/primary/page_menu_main.cpp
@@ -175,11 +175,11 @@ void MainMenuPage::menu_item_action(Button button) {
   }
 }
 
-bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonState state, uint8_t count) {
+bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonEvent state, uint8_t count) {
   bool redraw = false;  // only redraw screen if a UI input changes something
   switch (button) {
     case Button::UP:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         cursor_prev();
         if (cursor_position == cursor_developer && !settings.dev_menu) {
           cursor_prev();  // skip developer menu if not in dev mode
@@ -188,7 +188,7 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonState state, uint8_t
       }
       break;
     case Button::DOWN:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         cursor_next();
         if (cursor_position == cursor_developer && !settings.dev_menu) {
           cursor_next();  // skip developer menu if not in dev mode
@@ -199,7 +199,7 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonState state, uint8_t
     case Button::LEFT:
     case Button::RIGHT:
     case Button::CENTER:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         menu_item_action(button);
         redraw = true;
       }
@@ -209,7 +209,7 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonState state, uint8_t
                   // immediately
 }
 
-bool MainMenuPage::button_event(Button button, ButtonState state, uint8_t count) {
+bool MainMenuPage::button_event(Button button, ButtonEvent state, uint8_t count) {
   bool redraw = false;  // only redraw screen if a UI input changes something
   switch (menu_page) {
     case page_menu_main:
@@ -242,31 +242,3 @@ bool MainMenuPage::button_event(Button button, ButtonState state, uint8_t count)
   }
   return redraw;
 }
-
-// helpful switch constructors to copy-paste as needed:
-/*
-switch (button) {
-  case Button::UP:
-    break;
-  case Button::DOWN:
-    break;
-  case Button::LEFT:
-    break;
-  case Button::RIGHT:
-    break;
-  case Button::CENTER:
-    break;
-*/
-
-/*
-switch (state) {
-  case RELEASED:
-    break;
-  case PRESSED:
-    break;
-  case HELD:
-    break;
-  case HELD_LONG:
-    break;
-}
-*/

--- a/src/vario/ui/display/pages/primary/page_menu_main.h
+++ b/src/vario/ui/display/pages/primary/page_menu_main.h
@@ -12,14 +12,14 @@ class MainMenuPage : public MenuPage {
     cursor_position = 0;
     cursor_max = 8;
   }
-  bool button_event(Button button, ButtonState state, uint8_t count);
+  bool button_event(Button button, ButtonEvent state, uint8_t count);
   void draw();
   void backToMainMenu();
   void quitMenu();
 
  private:
   void draw_main_menu();
-  bool mainMenuButtonEvent(Button button, ButtonState state, uint8_t count);
+  bool mainMenuButtonEvent(Button button, ButtonEvent state, uint8_t count);
   void menu_item_action(Button dir);
   static constexpr char* labels[9] = {"Back", "Altimeter", "Vario",  "Display",  "Units",
                                       "GPS",  "Log/Timer", "System", "Developer"};

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -447,7 +447,7 @@ void nav_cursor_move(Button button) {
   }
 }
 
-void navigatePage_button(Button button, ButtonState state, uint8_t count) {
+void navigatePage_button(Button button, ButtonEvent state, uint8_t count) {
   // reset cursor time out count if a button is pushed
   navigatePage_cursorTimeCount = 0;
 
@@ -456,22 +456,22 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) nav_cursor_move(button);
+          if (state == ButtonEvent::CLICKED) nav_cursor_move(button);
           break;
         case Button::RIGHT:
-          if (state == RELEASED) {
+          if (state == ButtonEvent::CLICKED) {
             display.turnPage(PageAction::Next);
             speaker.playSound(fx::increase);
           }
           break;
         case Button::LEFT:
-          if (state == RELEASED) {
+          if (state == ButtonEvent::CLICKED) {
             display.turnPage(PageAction::Prev);
             speaker.playSound(fx::decrease);
           }
           break;
         case Button::CENTER:
-          if (state == HELD && count == 2) {
+          if (state == ButtonEvent::INCREMENTED && count == 2) {
             power.shutdown();
           }
           break;
@@ -481,26 +481,27 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) nav_cursor_move(button);
+          if (state == ButtonEvent::CLICKED) nav_cursor_move(button);
           break;
         case Button::LEFT:
           if (settings.disp_navPageAltType == altType_MSL &&
-              (state == PRESSED || state == HELD || state == HELD_LONG)) {
+              (state == ButtonEvent::CLICKED || state == ButtonEvent::INCREMENTED)) {
             baro.adjustAltSetting(-1, count);
             speaker.playSound(fx::neutral);
           }
           break;
         case Button::RIGHT:
           if (settings.disp_navPageAltType == altType_MSL &&
-              (state == PRESSED || state == HELD || state == HELD_LONG)) {
+              (state == ButtonEvent::CLICKED || state == ButtonEvent::INCREMENTED)) {
             baro.adjustAltSetting(1, count);
             speaker.playSound(fx::neutral);
           }
           break;
         case Button::CENTER:
-          if (state == RELEASED)
+          if (state == ButtonEvent::CLICKED)
             settings.adjustDisplayField_navPage_alt(Button::CENTER);
-          else if (state == HELD && count == 1 && settings.disp_navPageAltType == altType_MSL) {
+          else if (state == ButtonEvent::INCREMENTED && count == 1 &&
+                   settings.disp_navPageAltType == altType_MSL) {
             if (baro.syncToGPSAlt()) {  // successful adjustment of altimeter setting to match
                                         // GPS altitude
               speaker.playSound(fx::enter);
@@ -516,74 +517,42 @@ void navigatePage_button(Button button, ButtonState state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) nav_cursor_move(button);
+          if (state == ButtonEvent::CLICKED) nav_cursor_move(button);
           break;
         case Button::LEFT:
-          if (state == RELEASED) navigatePage_destinationSelect(Button::LEFT);
+          if (state == ButtonEvent::CLICKED) navigatePage_destinationSelect(Button::LEFT);
           break;
         case Button::RIGHT:
-          if (state == RELEASED) navigatePage_destinationSelect(Button::RIGHT);
+          if (state == ButtonEvent::CLICKED) navigatePage_destinationSelect(Button::RIGHT);
           break;
         case Button::CENTER:
-          if (state == RELEASED) navigatePage_destinationSelect(Button::CENTER);
-          if (state == HELD) {
+          if (state == ButtonEvent::CLICKED) navigatePage_destinationSelect(Button::CENTER);
+          if (state == ButtonEvent::HELD) {
+            buttons.consumeButton();
             navigator.cancelNav();
             navigatePage_cursorPosition = cursor_navigatePage_none;
-            buttons.lockAfterHold();  // lock buttons so we don't turn off if user keeps holding
-                                      // button
           }
           break;
       }
       break;
-    /*
-    case cursor_navigatePage_userField1:
-            switch(button) {
-                    case Button::UP:
-                            break;
-                    case Button::DOWN:
-                            break;
-                    case Button::LEFT:
-                            break;
-                    case Button::RIGHT:
-                            break;
-                    case Button::CENTER:
-                            break;
-            }
-            break;
-    case cursor_navigatePage_userField2:
-            switch(button) {
-                    case Button::UP:
-                            break;
-                    case Button::DOWN:
-                            break;
-                    case Button::LEFT:
-                            break;
-                    case Button::RIGHT:
-                            break;
-                    case Button::CENTER:
-                            break;
-            }
-            break;
-            */
     case cursor_navigatePage_timer:
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) nav_cursor_move(button);
+          if (state == ButtonEvent::CLICKED) nav_cursor_move(button);
           break;
         case Button::LEFT:
           break;
         case Button::RIGHT:
           break;
         case Button::CENTER:
-          if (state == RELEASED && !flightTimer_isRunning()) {
+          if (state == ButtonEvent::CLICKED && !flightTimer_isRunning()) {
             flightTimer_start();
             navigatePage_cursorPosition = cursor_navigatePage_none;
-          } else if (state == HELD && flightTimer_isRunning()) {
+          } else if (state == ButtonEvent::HELD && flightTimer_isRunning()) {
+            buttons.consumeButton();
             flightTimer_stop();
             navigatePage_cursorPosition = cursor_navigatePage_none;
-            buttons.lockAfterHold();  // lock buttons so we don't turn off if user keeps holding
-                                      // button
           }
 
           break;

--- a/src/vario/ui/display/pages/primary/page_navigate.h
+++ b/src/vario/ui/display/pages/primary/page_navigate.h
@@ -9,6 +9,6 @@
 void navigatePage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void navigatePage_button(Button button, ButtonState state, uint8_t count);
+void navigatePage_button(Button button, ButtonEvent state, uint8_t count);
 
 #endif

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -210,7 +210,7 @@ void thermal_page_cursor_move(Button button) {
   }
 }
 
-void thermalPage_button(Button button, ButtonState state, uint8_t count) {
+void thermalPage_button(Button button, ButtonEvent state, uint8_t count) {
   // reset cursor time out count if a button is pushed
   thermal_page_cursor_timeCount = 0;
 
@@ -219,22 +219,22 @@ void thermalPage_button(Button button, ButtonState state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) thermal_page_cursor_move(button);
+          if (state == ButtonEvent::CLICKED) thermal_page_cursor_move(button);
           break;
         case Button::RIGHT:
-          if (state == RELEASED) {
+          if (state == ButtonEvent::CLICKED) {
             display.turnPage(PageAction::Next);
             speaker.playSound(fx::increase);
           }
           break;
         case Button::LEFT:
-          if (state == RELEASED) {
+          if (state == ButtonEvent::CLICKED) {
             display.turnPage(PageAction::Prev);
             speaker.playSound(fx::decrease);
           }
           break;
         case Button::CENTER:
-          if (state == HELD && count == 2) {
+          if (state == ButtonEvent::INCREMENTED && count == 2) {
             power.shutdown();
           }
           break;
@@ -244,26 +244,27 @@ void thermalPage_button(Button button, ButtonState state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) thermal_page_cursor_move(button);
+          if (state == ButtonEvent::CLICKED) thermal_page_cursor_move(button);
           break;
         case Button::LEFT:
           if (settings.disp_navPageAltType == altType_MSL &&
-              (state == PRESSED || state == HELD || state == HELD_LONG)) {
+              (state == ButtonEvent::CLICKED || state == ButtonEvent::INCREMENTED)) {
             baro.adjustAltSetting(-1, count);
             speaker.playSound(fx::neutral);
           }
           break;
         case Button::RIGHT:
           if (settings.disp_navPageAltType == altType_MSL &&
-              (state == PRESSED || state == HELD || state == HELD_LONG)) {
+              (state == ButtonEvent::CLICKED || state == ButtonEvent::INCREMENTED)) {
             baro.adjustAltSetting(1, count);
             speaker.playSound(fx::neutral);
           }
           break;
         case Button::CENTER:
-          if (state == RELEASED) {
+          if (state == ButtonEvent::CLICKED) {
             settings.adjustDisplayField_thermalPage_alt(Button::CENTER);
-          } else if (state == HELD && count == 1 && settings.disp_thmPageAltType == altType_MSL) {
+          } else if (state == ButtonEvent::INCREMENTED && count == 1 &&
+                     settings.disp_thmPageAltType == altType_MSL) {
             if (baro.syncToGPSAlt()) {  // successful adjustment of altimeter setting to match
                                         // GPS altitude
               speaker.playSound(fx::enter);
@@ -279,14 +280,14 @@ void thermalPage_button(Button button, ButtonState state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) thermal_page_cursor_move(button);
+          if (state == ButtonEvent::CLICKED) thermal_page_cursor_move(button);
           break;
         case Button::LEFT:
           break;
         case Button::RIGHT:
           break;
         case Button::CENTER:
-          if (state == RELEASED) settings.disp_thmPageUser1++;
+          if (state == ButtonEvent::CLICKED) settings.disp_thmPageUser1++;
           if (settings.disp_thmPageUser1 >= static_cast<int>(ThermalPageUserFields::NONE))
             settings.disp_thmPageUser1 = 0;
           break;
@@ -296,54 +297,37 @@ void thermalPage_button(Button button, ButtonState state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) thermal_page_cursor_move(button);
+          if (state == ButtonEvent::CLICKED) thermal_page_cursor_move(button);
           break;
         case Button::LEFT:
           break;
         case Button::RIGHT:
           break;
         case Button::CENTER:
-          if (state == RELEASED) settings.disp_thmPageUser2++;
+          if (state == ButtonEvent::CLICKED) settings.disp_thmPageUser2++;
           if (settings.disp_thmPageUser2 >= static_cast<int>(ThermalPageUserFields::NONE))
             settings.disp_thmPageUser2 = 0;
           break;
       }
       break;
-      /*
-case cursor_thermalPage_userField2:
-      switch(button) {
-              case Button::UP:
-                      break;
-              case Button::DOWN:
-                      break;
-              case Button::LEFT:
-                      break;
-              case Button::RIGHT:
-                      break;
-              case Button::CENTER:
-                      break;
-      }
-      break;
-      */
     case cursor_thermalPage_timer:
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) thermal_page_cursor_move(button);
+          if (state == ButtonEvent::CLICKED) thermal_page_cursor_move(button);
           break;
         case Button::LEFT:
           break;
         case Button::RIGHT:
           break;
         case Button::CENTER:
-          if (state == RELEASED && !flightTimer_isRunning()) {
+          if (state == ButtonEvent::CLICKED && !flightTimer_isRunning()) {
             flightTimer_start();
             thermal_page_cursor_position = cursor_thermalPage_none;
-          } else if (state == HELD && flightTimer_isRunning()) {
+          } else if (state == ButtonEvent::HELD && flightTimer_isRunning()) {
+            buttons.consumeButton();
             flightTimer_stop();
             thermal_page_cursor_position = cursor_thermalPage_none;
-            buttons.lockAfterHold();  // lock buttons so we don't turn off if user keeps holding
-                                      // button
           }
 
           break;

--- a/src/vario/ui/display/pages/primary/page_thermal.h
+++ b/src/vario/ui/display/pages/primary/page_thermal.h
@@ -9,7 +9,7 @@
 void thermalPage_draw(void);
 
 // handle button presses relative to what's shown on the display
-void thermalPage_button(Button button, ButtonState state, uint8_t count);
+void thermalPage_button(Button button, ButtonEvent state, uint8_t count);
 
 // draw the selectable user fields
 void drawUserField(uint8_t x, uint8_t y, uint8_t field, bool selected);

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -113,7 +113,7 @@ void cursor_move(Button button) {
   }
 }
 
-void thermalPageAdv_button(Button button, ButtonState state, uint8_t count) {
+void thermalPageAdv_button(Button button, ButtonEvent state, uint8_t count) {
   // reset cursor time out count if a button is pushed
   thermalAdvPage_cursor_timeCount = 0;
 
@@ -122,22 +122,22 @@ void thermalPageAdv_button(Button button, ButtonState state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) cursor_move(button);
+          if (state == ButtonEvent::CLICKED) cursor_move(button);
           break;
         case Button::RIGHT:
-          if (state == RELEASED) {
+          if (state == ButtonEvent::CLICKED) {
             display.turnPage(PageAction::Next);
             speaker.playSound(fx::increase);
           }
           break;
         case Button::LEFT:
-          if (state == RELEASED) {
+          if (state == ButtonEvent::CLICKED) {
             display.turnPage(PageAction::Prev);
             speaker.playSound(fx::decrease);
           }
           break;
         case Button::CENTER:
-          if (state == HELD && count == 2) {
+          if (state == ButtonEvent::INCREMENTED && count == 2) {
             power.shutdown();
           }
           break;
@@ -147,26 +147,27 @@ void thermalPageAdv_button(Button button, ButtonState state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) cursor_move(button);
+          if (state == ButtonEvent::CLICKED) cursor_move(button);
           break;
         case Button::LEFT:
           if (settings.disp_navPageAltType == altType_MSL &&
-              (state == PRESSED || state == HELD || state == HELD_LONG)) {
+              (state == ButtonEvent::CLICKED || state == ButtonEvent::INCREMENTED)) {
             baro.adjustAltSetting(1, count);
             speaker.playSound(fx::neutral);
           }
           break;
         case Button::RIGHT:
           if (settings.disp_navPageAltType == altType_MSL &&
-              (state == PRESSED || state == HELD || state == HELD_LONG)) {
+              (state == ButtonEvent::CLICKED || state == ButtonEvent::INCREMENTED)) {
             baro.adjustAltSetting(-1, count);
             speaker.playSound(fx::neutral);
           }
           break;
         case Button::CENTER:
-          if (state == RELEASED)
+          if (state == ButtonEvent::CLICKED)
             settings.adjustDisplayField_thermalPage_alt(Button::CENTER);
-          else if (state == HELD && count == 1 && settings.disp_thmPageAltType == altType_MSL) {
+          else if (state == ButtonEvent::INCREMENTED && count == 1 &&
+                   settings.disp_thmPageAltType == altType_MSL) {
             if (baro.syncToGPSAlt()) {  // successful adjustment of altimeter setting to match
                                         // GPS altitude
               speaker.playSound(fx::enter);
@@ -178,68 +179,24 @@ void thermalPageAdv_button(Button button, ButtonState state, uint8_t count) {
           break;
       }
       break;
-    /* case cursor_thermalPage_alt2:
-            switch(button) {
-                    case Button::UP:
-                            break;
-                    case Button::DOWN:
-                            break;
-                    case Button::LEFT:
-                            break;
-                    case Button::RIGHT:
-                            break;
-                    case Button::CENTER:
-                            break;
-            }
-            break;
-    case cursor_thermalPage_userField1:
-            switch(button) {
-                    case Button::UP:
-                            break;
-                    case Button::DOWN:
-                            break;
-                    case Button::LEFT:
-                            break;
-                    case Button::RIGHT:
-                            break;
-                    case Button::CENTER:
-                            break;
-            }
-            break;
-    case cursor_thermalPage_userField2:
-            switch(button) {
-                    case Button::UP:
-                            break;
-                    case Button::DOWN:
-                            break;
-                    case Button::LEFT:
-                            break;
-                    case Button::RIGHT:
-                            break;
-                    case Button::CENTER:
-                            break;
-            }
-            break;
-            */
     case cursor_thermalAdvPage_timer:
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == RELEASED) cursor_move(button);
+          if (state == ButtonEvent::CLICKED) cursor_move(button);
           break;
         case Button::LEFT:
           break;
         case Button::RIGHT:
           break;
         case Button::CENTER:
-          if (state == RELEASED && !flightTimer_isRunning()) {
+          if (state == ButtonEvent::CLICKED && !flightTimer_isRunning()) {
             flightTimer_start();
             thermalAdvPage_cursor_position = cursor_thermalAdvPage_none;
-          } else if (state == HELD && flightTimer_isRunning()) {
+          } else if (state == ButtonEvent::HELD && flightTimer_isRunning()) {
+            buttons.consumeButton();
             flightTimer_stop();
             thermalAdvPage_cursor_position = cursor_thermalAdvPage_none;
-            buttons.lockAfterHold();  // lock buttons so we don't turn off if user keeps holding
-                                      // button
           }
 
           break;

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.h
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.h
@@ -9,6 +9,6 @@
 void thermalPageAdv_draw(void);
 
 // handle button presses relative to what's shown on the display
-void thermalPageAdv_button(Button button, ButtonState state, uint8_t count);
+void thermalPageAdv_button(Button button, ButtonEvent state, uint8_t count);
 
 #endif

--- a/src/vario/ui/input/button_dispatcher.h
+++ b/src/vario/ui/input/button_dispatcher.h
@@ -8,12 +8,12 @@
 
 /// @brief Listens for button events on the message bus and then dispatches them to the appropriate
 /// UI element.
-class ButtonDispatcher : public etl::message_router<ButtonDispatcher, ButtonEvent> {
+class ButtonDispatcher : public etl::message_router<ButtonDispatcher, ButtonEventMessage> {
  public:
   void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
 
-  // etl::message_router<ButtonDispatcher, ButtonEvent>
-  void on_receive(const ButtonEvent& msg);
+  // etl::message_router<ButtonDispatcher, ButtonEventMessage>
+  void on_receive(const ButtonEventMessage& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
 };
 

--- a/src/vario/ui/input/buttons.h
+++ b/src/vario/ui/input/buttons.h
@@ -5,5 +5,24 @@
 // D pad button
 enum class Button : uint8_t { NONE, UP, DOWN, LEFT, RIGHT, CENTER };
 
-// D pad button state
-enum ButtonState { NO_STATE, PRESSED, RELEASED, HELD, HELD_LONG };
+// D pad button event
+enum class ButtonEvent : uint8_t {
+  // Button was initially pressed down (triggered after debouncing)
+  PRESSED,
+
+  // Button was pressed and then released without being held
+  CLICKED,
+
+  // Button was released after having been PRESSED
+  RELEASED,
+
+  // Button was held down for a short amount of time
+  HELD,
+
+  // Button was held down for a longer amount of time (always triggers after HELD)
+  HELD_LONG,
+
+  // Button was held down long enough to increment a counter while being held (see holdCount in
+  // event message)
+  INCREMENTED
+};


### PR DESCRIPTION
This PR re-architects the Buttons hardware abstraction layer to be a more traditional state machine as shown in [the new documentation](https://github.com/BenjaminPelletier/leaf/blob/buttons-rearch/src/vario/hardware/buttons.md).  In my evaluation, this simplifies things conceptually and clarifies exactly what to expect.

My motivation for this PR was that it was previously difficult for me to understand the contracts around button behavior -- especially and for instance the duality between "state" and "event" with regard to `ButtonState`.  For instance, it wasn't immediately obvious to me how this would avoid triggering adjustments continually via the first `if` statement since nothing about the state would seem to need to change after one loop of (RELEASED, LEFT), nor how the second `if` statement would ever be triggered since it doesn't seem possible to hold a non-button.
```cpp
if (state == RELEASED && dir != Button::NONE) settings.adjustTimeZone(dir);
if (state == HELD && dir == Button::NONE) settings.adjustTimeZone(dir);
```

Other changes made to achieve this goal were:
* Renaming `ButtonState` to `ButtonEvent` to match usage in discrete messages via message bus
* Changing `ButtonEvent` to a `class enum` to make limit the scope of member names

I looked at each usage of a `ButtonEvent` and tried to make sure the behavior shouldn't change with this PR.  For the usages that I had to fiddle with, I added them to a list to test specifically.  This is that list, and it might be worth the reviewer spot checking items from this list as they are the higher-risk places for having introduced an error in my evaluation.

* page_menu_altimeter
    * cursor_altimeter_adjustSetting
        * LEFT and RIGHT, CLICKED and INCREMENTED ✅
        * CENTER, held ✅
* page_menu_display
    * cursor_display_contrast
        * LEFT and RIGHT, CLICKED and INCREMENTED ✅
        * CENTER, held ✅
* page_menu_log
    * cursor_log_format
        * CLICKED ✅
* page_menu_system
    * cursor_system_timezone
        * CLICKED and INCREMENTED ✅
    * cursor_system_volume
        * CLICKED (action) and INCREMENTED (no action) ✅
    * cursor_system_about
        * CLICKED ✅
        * INCREMENTED (long-long hold) ✅
    * cursor_system_reset
        * Display filling up to reset upon INCREMENTED ✅
* page_navigate
    * cursor_navigatePage_alt1
        * LEFT and RIGHT, CLICKED and INCREMENTED ✅
        * CENTER INCREMENTED (medium hold) ✅
* page_thermal
    * cursor_thermalPage_alt1
        * LEFT and RIGHT, CLICKED and INCREMENTED ✅
        * CENTER INCREMENTED (medium hold) ✅
    * cursor_thermalPage_none
        * CENTER INCREMENTED (medium hold to shut down) ✅
* page_thermal_adv
    * cursor_thermalAdvPage_alt1
        * LEFT and RIGHT, CLICKED and INCREMENTED ✅ _Note: RIGHT lowers altitude, unlike other UI locations_
        * CENTER INCREMENTED (medium hold) ✅
    * cursor_thermalAdvPage_none
        * CENTER INCREMENTED (medium hold to shut down) ✅
* Charging page
    * CENTER INCREMENTED (medium hold to power on) ✅

Additionally, I followed the standard test procedure.  All of this was on 3.2.7+radio with leaf_3_2_7_dev.

After this PR, it would make sense to:

* Change button event handlers to say "event" rather than "state" (maybe use ButtonEventMessage directly)
* Change case of enum constants to Capitalized rather than ALL_CAPS
* Consider whether cases of `event == ButtonEvent::INCREMENTED && count == N` should be replaced with `event == ButtonEvent::HeldLong` (these places are essentially picking their own custom hold-long times -- it may be nicer if these timings were more consistent across the UI)

Those changes are not included because they are not critical and this PR is already very large.