### PR TITLE
Clean up baro: part 1

### DIFF
--- a/src/vario/comms/ble.cpp
+++ b/src/vario/comms/ble.cpp
@@ -205,10 +205,11 @@ void BLE::timerCallback(TimerHandle_t timer) {
 }
 
 void BLE::sendVarioUpdate() {
+  if (baro.state() != Barometer::State::Ready) return;
   NMEAString nmea;
   etl::string_stream stream(nmea);
-  stream << "$LK8EX1," << static_cast<int32_t>(baro.pressure) << "," << static_cast<uint>(baro.altF)
-         << "," << baro.climbRateFiltered << ","
+  stream << "$LK8EX1," << static_cast<int32_t>(baro.pressure()) << ","
+         << static_cast<uint>(baro.altF()) << "," << baro.climbRateFiltered << ","
          << "99,999,";  // Temperature in C.  If not available, send 99
                         // Battery voltage OR percentage.  If percentage, add 1000 (if 1014 is
                         // 14%). 999

--- a/src/vario/diagnostics/fatal_error.cpp
+++ b/src/vario/diagnostics/fatal_error.cpp
@@ -80,7 +80,7 @@ static void getBacktrace(char* buffer, size_t n) {
   esp_rom_install_channel_putc(1, putc_interception::putc_intercept);
 
   // Trigger backtrace print
-  esp_backtrace_print(16);
+  esp_backtrace_print(20);
 
   // Restore default UART output for ROM printf
   esp_rom_install_uart_printf();

--- a/src/vario/instruments/ambient.h
+++ b/src/vario/instruments/ambient.h
@@ -25,7 +25,7 @@ class Ambient : public etl::message_router<Ambient, AmbientUpdate>,
   void on_receive_unknown(const etl::imessage& msg) {}
 
  private:
-  void onUnexpectedState(const char* c, State s) const;
+  void onUnexpectedState(const char* action, State actual) const;
   friend struct StateAssertMixin<Ambient>;
 
   float temperature_;

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -118,11 +118,10 @@ void Barometer::on_receive(const PressureUpdate& msg) {
 }
 
 void Barometer::firstReading(const PressureUpdate& msg) {
+  state_ = State::Ready;
   setPressureAlt(msg.pressure);
   setAltInitial();
   setLaunchAlt();
-
-  state_ = State::Ready;
 }
 
 void Barometer::setLaunchAlt() {

--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -149,7 +149,7 @@ void IMU::init() {
   startupCycleCount_ = IMU_STARTUP_CYCLES;
 
   // setup kalman filter
-  kalmanvert_.init(millis() / 1000.0, baro.altF, 0.0);
+  kalmanvert_.init(millis() / 1000.0, baro.altF(), 0.0);
 
   tPrev_ = millis();
 }
@@ -161,12 +161,12 @@ void IMU::on_receive(const MotionUpdate& msg) {
   if (startupCycleCount_ > 0) {
     startupCycleCount_--;
     // submit accel = 0 to kalman filter and return
-    kalmanvert_.update(millis() / 1000.0, baro.altF, 0.0f);
+    kalmanvert_.update(millis() / 1000.0, baro.altF(), 0.0f);
     return;
   }
 
   // update kalman filter
-  kalmanvert_.update(millis() / 1000.0, baro.altF, accelVert_ * 9.80665f);
+  kalmanvert_.update(millis() / 1000.0, baro.altF(), accelVert_ * 9.80665f);
 
   String kalmanName = "kalman,";
   String kalmanEntryString = kalmanName + String(kalmanvert_.getPosition(), 8) + ',' +

--- a/src/vario/instruments/imu.h
+++ b/src/vario/instruments/imu.h
@@ -33,6 +33,8 @@ class IMU : public etl::message_router<IMU, MotionUpdate> {
   // Kalman filter object for vertical climb rate and position
   KalmanFilterPA kalmanvert_;
 
+  bool kalmanInitialized_ = false;
+
   uint8_t startupCycleCount_;
 
   double accelVert_;

--- a/src/vario/logbook/igc.cpp
+++ b/src/vario/logbook/igc.cpp
@@ -65,7 +65,7 @@ void Igc::log(unsigned long durationSec) {
 
   logger.writeBRecord(buf,  // Time in HHMMSS
                       latDegreeToStr(gps.location.lat()), lngDegreeToStr(gps.location.lng()), true,
-                      baro.alt / 100,  // cm to meters
+                      baro.alt() / 100,  // cm to meters
                       gps.altitude.meters(), toDigits((int)gps.fixInfo.error, 3));
 }
 

--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -137,11 +137,13 @@ bool flightTimer_autoStart() {
   }
 
   // check if current altitude has changed enough from startup to trigger timer start
-  int32_t altDifference = baro.altAboveInitial();
-  if (altDifference < 0) altDifference *= -1;
-  if (altDifference > AUTO_START_MIN_ALT) {
-    startTheTimer = true;
-    Serial.println("****************************** autoStart TRUE via alt");
+  if (baro.state() == Barometer::State::Ready) {
+    int32_t altDifference = baro.altAboveInitial();
+    if (altDifference < 0) altDifference *= -1;
+    if (altDifference > AUTO_START_MIN_ALT) {
+      startTheTimer = true;
+      Serial.println("****************************** autoStart TRUE via alt");
+    }
   }
 
   // Serial.print("S T A R T   Counter: ");

--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -89,8 +89,8 @@ void log_update() {
         if (settings.vario_altSyncToGPS) baro.syncToGPSAlt();
 
         // starting values
-        baro.resetLaunchAlt();
-        logbook.alt_start = baro.altAtLaunch;
+        baro.setLaunchAlt();
+        logbook.alt_start = baro.altAtLaunch();
 
         // get first set of log values
         log_captureValues();
@@ -137,7 +137,7 @@ bool flightTimer_autoStart() {
   }
 
   // check if current altitude has changed enough from startup to trigger timer start
-  int32_t altDifference = baro.alt - baro.altInitial;
+  int32_t altDifference = baro.altAboveInitial();
   if (altDifference < 0) altDifference *= -1;
   if (altDifference > AUTO_START_MIN_ALT) {
     startTheTimer = true;
@@ -165,7 +165,7 @@ bool flightTimer_autoStop() {
   // thresholds.
 
   // First check if altitude is stable
-  int32_t altDifference = baro.alt - autoStopAltitude;
+  int32_t altDifference = baro.alt() - autoStopAltitude;
   if (altDifference < 0) altDifference *= -1;
   if (altDifference < AUTO_STOP_MAX_ALT) {
     // then check if GPS speed is slow enough
@@ -181,7 +181,7 @@ bool flightTimer_autoStop() {
 
     // reset the comparison altitude to present altitude, since it's still changing
   } else {
-    autoStopAltitude = baro.alt;
+    autoStopAltitude = baro.alt();
   }
 
   // Serial.print(" ** STOP ** Counter: ");
@@ -192,8 +192,8 @@ bool flightTimer_autoStop() {
   // Serial.println(stopTheTimer);
 
   if (stopTheTimer) {
-    baro.altInitial = baro.alt;  // reset initial alt (to enable properly checking again for
-                                 // auto-start conditions)
+    // reset initial alt (to enable properly checking again for auto-start conditions)
+    baro.setAltInitial();
   }
 
   return stopTheTimer;
@@ -243,7 +243,7 @@ void flightTimer_stop() {
   }
 
   // ending values
-  logbook.alt_end = baro.alt;
+  logbook.alt_end = baro.alt();
   flight->end(logbook);
   // TODO:  A much cooler end flight sound.  Perhaps even an easter egg?
   speaker.playSound(fx::confirm);
@@ -271,8 +271,8 @@ String flightTimer_getString() {
 }
 
 void log_captureValues() {
-  logbook.alt = baro.altAdjusted;
-  logbook.alt_above_launch = baro.altAboveLaunch;
+  logbook.alt = baro.altAdjusted();
+  logbook.alt_above_launch = baro.altAboveLaunch();
   logbook.climb = baro.climbRateFiltered;
   logbook.speed = gps.speed.mps();
   if (ambient.state() == Ambient::State::Ready) {

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -293,7 +293,7 @@ bool Power::autoOff() {
   // thresholds.
 
   // First check if altitude is stable
-  int32_t altDifference = baro.alt - autoOffAltitude_;
+  int32_t altDifference = baro.alt() - autoOffAltitude_;
   if (altDifference < 0) altDifference *= -1;
   if (altDifference < AUTO_OFF_MAX_ALT) {
     // then check if GPS speed is slow enough

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -147,13 +147,6 @@ void Power::initPeripherals() {
   display.init();
   Serial.println(" - Finished display");
   ms5611.init();
-  baro.init();
-  Serial.println("     Waiting for first pressure reading...");
-  // TODO: don't block here; instead, have clients recognize and handle a not-fully-initialized baro
-  // appropriately (#192)
-  while (!baro.hasFirstReading()) {
-    ms5611.update();
-  }
   Serial.println(" - Finished Baro");
   ICM20948::getInstance().init();
   imu.init();
@@ -191,12 +184,6 @@ void Power::wakePeripherals() {
   lc86g.wake();
   Serial.println(" - waking baro and IMU");
   baro.wake();
-  Serial.println("     waiting for first pressure reading...");
-  // TODO: don't block here; instead, have clients recognize and handle a not-fully-initialized baro
-  // appropriately
-  while (!baro.hasFirstReading()) {
-    ms5611.update();
-  }
   imu.wake();
   Serial.println(" - waking speaker");
   speaker.unMute();

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -314,7 +314,6 @@ void TaskManager::doNecessaryTasks(void) {
   // when we read ADC, the MS5611 won't be ready.
   if (performTask.baro) {
     ms5611.update();
-    baro.update();
     performTask.baro = false;
   }
   if (performTask.buttons) {

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -285,6 +285,11 @@ void display_alt(uint8_t cursor_x, uint8_t cursor_y, const uint8_t* font, int32_
 
   u8g2.setCursor(cursor_x, cursor_y);
   u8g2.setFont(font);
+  if (displayAlt < -9999) {
+    // Altitude is unavailable
+    u8g2.print(" ---");
+    return;
+  }
 
   bool negativeVal = false;
 
@@ -550,20 +555,12 @@ void display_unsignedClimbRate_short(uint8_t x, uint8_t y, int16_t displayClimbR
   u8g2.setDrawColor(1);
 }
 
-void display_altAboveLaunch(uint8_t x, uint8_t y, int32_t aboveLaunchAlt) {
+void display_altAboveLaunch(uint8_t x, uint8_t y) {
   u8g2.setCursor(x, y - 16);
   u8g2.setFont(leaf_5h);
   u8g2.print("ABOVE LAUNCH");
+  int32_t aboveLaunchAlt = baro.state() == Barometer::State::Ready ? baro.altAdjusted() : -99999;
   display_alt(x, y, leaf_8x14, aboveLaunchAlt);
-}
-
-void display_altAboveLaunch(uint8_t x, uint8_t y, int32_t aboveLaunchAlt, const uint8_t* font) {
-  u8g2.setFont(font);
-  uint8_t h = u8g2.getMaxCharHeight();
-  u8g2.setCursor(x, y - h - 2);
-  u8g2.setFont(leaf_5h);
-  u8g2.print("ABOVE LAUNCH");
-  display_alt(x, y, font, aboveLaunchAlt);
 }
 
 void display_accel(uint8_t x, uint8_t y, float accel) {

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -256,7 +256,7 @@ void display_alt_type(uint8_t cursor_x, uint8_t cursor_y, const uint8_t* font, u
 
   switch (altType) {
     case altType_MSL:
-      displayAlt = baro.altAdjusted;
+      displayAlt = baro.altAdjusted();
       break;
     case altType_AGL:
       break;
@@ -264,7 +264,7 @@ void display_alt_type(uint8_t cursor_x, uint8_t cursor_y, const uint8_t* font, u
       displayAlt = 100 * gps.altitude.meters();  // gps returns float in m, convert to int32_t in cm
       break;
     case altType_aboveLaunch:
-      displayAlt = baro.altAboveLaunch;
+      displayAlt = baro.altAboveLaunch();
       break;
     case altType_aboveWaypoint:
       displayAlt = navigator.altAboveWaypoint;

--- a/src/vario/ui/display/display_fields.h
+++ b/src/vario/ui/display/display_fields.h
@@ -18,8 +18,7 @@ void display_heading(uint8_t cursor_x, uint8_t cursor_y, bool degSymbol);
 void display_headingTurn(uint8_t cursor_x, uint8_t cursor_y);
 
 void display_alt(uint8_t cursor_x, uint8_t cursor_y, const uint8_t* font, int32_t displayAlt);
-void display_altAboveLaunch(uint8_t x, uint8_t y, int32_t aboveLaunchAlt);
-void display_altAboveLaunch(uint8_t x, uint8_t y, int32_t aboveLaunchAlt, const uint8_t* font);
+void display_altAboveLaunch(uint8_t x, uint8_t y);
 
 void display_alt_type(uint8_t cursor_x, uint8_t cursor_y, const uint8_t* font, uint8_t altType);
 void print_alt_label(uint8_t altType);

--- a/src/vario/ui/display/pages/menu/page_menu_altimeter.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_altimeter.cpp
@@ -66,7 +66,7 @@ void AltimeterMenuPage::draw() {
     // Standard Altitude Value
     u8g2.setCursor(label_indent, start_y += 15);
     u8g2.print("Std:");
-    display_alt(40, start_y, leaf_6x12, baro.alt);
+    display_alt(40, start_y, leaf_6x12, baro.alt());
     if (settings.units_alt)
       u8g2.print("ft");
     else
@@ -75,7 +75,7 @@ void AltimeterMenuPage::draw() {
     // Adjusted Altimeter Value
     u8g2.setCursor(label_indent, start_y += 15);
     u8g2.print("Adj:");
-    display_alt(40, start_y, leaf_6x12, baro.altAdjusted);
+    display_alt(40, start_y, leaf_6x12, baro.altAdjusted());
     if (settings.units_alt)
       u8g2.print("ft");
     else

--- a/src/vario/ui/display/pages/menu/page_menu_altimeter.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_altimeter.cpp
@@ -66,7 +66,8 @@ void AltimeterMenuPage::draw() {
     // Standard Altitude Value
     u8g2.setCursor(label_indent, start_y += 15);
     u8g2.print("Std:");
-    display_alt(40, start_y, leaf_6x12, baro.alt());
+    int32_t stdAlt = baro.state() == Barometer::State::Ready ? baro.alt() : -99999;
+    display_alt(40, start_y, leaf_6x12, stdAlt);
     if (settings.units_alt)
       u8g2.print("ft");
     else
@@ -75,7 +76,8 @@ void AltimeterMenuPage::draw() {
     // Adjusted Altimeter Value
     u8g2.setCursor(label_indent, start_y += 15);
     u8g2.print("Adj:");
-    display_alt(40, start_y, leaf_6x12, baro.altAdjusted());
+    int32_t adjAlt = baro.state() == Barometer::State::Ready ? baro.altAdjusted() : -99999;
+    display_alt(40, start_y, leaf_6x12, adjAlt);
     if (settings.units_alt)
       u8g2.print("ft");
     else

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -473,6 +473,7 @@ void navigatePage_button(Button button, ButtonEvent state, uint8_t count) {
         case Button::CENTER:
           if (state == ButtonEvent::INCREMENTED && count == 2) {
             power.shutdown();
+            return;  // Don't refresh the display; we're shutting down
           }
           break;
       }
@@ -559,4 +560,5 @@ void navigatePage_button(Button button, ButtonEvent state, uint8_t count) {
       }
       break;
   }
+  display.update();
 }

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -318,7 +318,7 @@ void navigatePage_draw() {
     if (navigatePage_cursorPosition == cursor_navigatePage_alt1) {
       display_selectionBox(49, 94, 96 - 49, 17, 5);
     }
-    // display_altAboveLaunch(24, 129, baro.altAboveLaunch);
+    // display_altAboveLaunch(24, 129);
 
     ///////////////////////////////////////////////////
     // Waypoint Info **********************************

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -128,7 +128,7 @@ void thermalPage_draw() {
 void drawUserField(uint8_t x, uint8_t y, uint8_t field, bool selected) {
   switch (field) {
     case static_cast<int>(ThermalPageUserFields::ABOVE_LAUNCH):
-      display_altAboveLaunch(x, y, baro.altAboveLaunch());
+      display_altAboveLaunch(x, y);
       break;
     case static_cast<int>(ThermalPageUserFields::GLIDE):
       // Glide Ratio

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -128,7 +128,7 @@ void thermalPage_draw() {
 void drawUserField(uint8_t x, uint8_t y, uint8_t field, bool selected) {
   switch (field) {
     case static_cast<int>(ThermalPageUserFields::ABOVE_LAUNCH):
-      display_altAboveLaunch(x, y, baro.altAboveLaunch);
+      display_altAboveLaunch(x, y, baro.altAboveLaunch());
       break;
     case static_cast<int>(ThermalPageUserFields::GLIDE):
       // Glide Ratio

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -236,6 +236,7 @@ void thermalPage_button(Button button, ButtonEvent state, uint8_t count) {
         case Button::CENTER:
           if (state == ButtonEvent::INCREMENTED && count == 2) {
             power.shutdown();
+            return;  // Don't refresh the display; we're shutting down
           }
           break;
       }
@@ -334,4 +335,5 @@ void thermalPage_button(Button button, ButtonEvent state, uint8_t count) {
       }
       break;
   }
+  display.update();
 }

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -139,6 +139,7 @@ void thermalPageAdv_button(Button button, ButtonEvent state, uint8_t count) {
         case Button::CENTER:
           if (state == ButtonEvent::INCREMENTED && count == 2) {
             power.shutdown();
+            return;  // Don't refresh the display; we're shutting down
           }
           break;
       }
@@ -203,4 +204,5 @@ void thermalPageAdv_button(Button button, ButtonEvent state, uint8_t count) {
       }
       break;
   }
+  display.update();
 }

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -76,7 +76,7 @@ void thermalPageAdv_draw() {
     display_climbRate(20, 108, leaf_8x14, baro.climbRateFiltered);
 
     // altitude above launch
-    display_altAboveLaunch(24, 132, baro.altAboveLaunch());
+    display_altAboveLaunch(24, 132);
 
     // User Fields ****************************************************
     uint8_t userFieldsTop = 136;

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -76,7 +76,7 @@ void thermalPageAdv_draw() {
     display_climbRate(20, 108, leaf_8x14, baro.climbRateFiltered);
 
     // altitude above launch
-    display_altAboveLaunch(24, 132, baro.altAboveLaunch);
+    display_altAboveLaunch(24, 132, baro.altAboveLaunch());
 
     // User Fields ****************************************************
     uint8_t userFieldsTop = 136;

--- a/src/vario/ui/input/button_dispatcher.cpp
+++ b/src/vario/ui/input/button_dispatcher.cpp
@@ -81,15 +81,12 @@ void ButtonDispatcher::on_receive(const ButtonEventMessage& msg) {
 
   } else if (currentPage == MainPage::Thermal) {
     thermalPage_button(msg.button, msg.event, msg.holdCount);
-    display.update();
 
   } else if (currentPage == MainPage::ThermalAdv) {
     thermalPageAdv_button(msg.button, msg.event, msg.holdCount);
-    display.update();
 
   } else if (currentPage == MainPage::Nav) {
     navigatePage_button(msg.button, msg.event, msg.holdCount);
-    display.update();
 
   } else if (currentPage != MainPage::Charging) {  // NOT CHARGING PAGE (i.e., our debug test page)
     switch (msg.button) {


### PR DESCRIPTION
Currently, `baro`'s state variables are exposed for read (and write!) at any time regardless of whether they are valid.  This makes the sequencing of device initialization, sleeping, waking, and shutdown all subject to accidentally accessing and using information when it's not valid (and, in fact, we were doing this in some places).

This PR addresses this issue and works toward #192 by tracking `baro`'s operational state (Uninitialized, WaitingForFirstReading, Ready), protecting all data with accessor methods, and ensuring that data is not accessed while baro is the wrong state.

With this capability, `baro` is changed from an update-driven pipeline to an event-driven pipeline (the single event type being pressure measurements), including making `init()` private and automatically calling it when necessary to transition from Uninitialized to WaitingForFirstReading.  This allows the removal of two blocking operations in initialization where `baro` waited for a first measurement to arrive from the pressure sensor, which helps #192 and removes a showstopper for reliable external simulation behavior.

Along these lines, IMU is adjusted to wait to action incoming messages until data from the barometer is available.

While testing, I discovered that sometimes pages would be "displayed" once more after `power.shutdown()` -- this PR should fix at least most of that behavior.

This PR does not protect the climb rate information on the `baro` as it is already quite large.  A follow-up PR will apply similar protections to baro climb rate information.

Tested by power on and off in many different scenarios, logging a flight without and with GPS followed by more power cycling (this is where I found the most esoteric bug), and generally trying to provoke inappropriate access to baro data from the thermal thermalAdv, nav, and altimeter pages.  3.2.7+radio with leaf_3_2_7_dev.