### PR TITLE
0.1.0 bugfixes

### DIFF
--- a/src/vario/instruments/ambient.h
+++ b/src/vario/instruments/ambient.h
@@ -9,10 +9,10 @@ class Ambient : public etl::message_router<Ambient, AmbientUpdate> {
   void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
 
   // Get the most recent temperature in degrees Celsius
-  float getTemp() { return relativeHumidity_; }
+  float getTemp() { return temperature_; }
 
   // Get the most recent relative humidity in percent
-  float getHumidity() { return temperature_; }
+  float getHumidity() { return relativeHumidity_; }
 
   // etl::message_router<Ambient, AmbientUpdate>
   void on_receive(const AmbientUpdate& msg);

--- a/src/vario/ui/audio/speaker.cpp
+++ b/src/vario/ui/audio/speaker.cpp
@@ -180,6 +180,13 @@ void speaker_updateVarioNote(int32_t verticalRate) {
   uint16_t sound_vario_play_samplesTEMP;
   uint16_t sound_vario_rest_samplesTEMP;
 
+  int sinkAlarm_cms;
+  if (settings.vario_sinkAlarm_units) {
+    sinkAlarm_cms = settings.vario_sinkAlarm * 100 / 196.85;  // convert fpm to cm/s
+  } else {
+    sinkAlarm_cms = settings.vario_sinkAlarm * 100;  // convert m/s to cm/s
+  }
+
   if (verticalRate > settings.vario_climbStart) {
     // first clamp to thresholds if climbRate is over the max
     if (verticalRate >= CLIMB_MAX) {
@@ -200,8 +207,7 @@ void speaker_updateVarioNote(int32_t verticalRate) {
     }
 
     // if we trigger sink threshold
-  } else if (verticalRate <
-             (settings.vario_sinkAlarm * 100)) {  // convert sink alarm 'm/s' setting to cm/s
+  } else if (verticalRate < sinkAlarm_cms) {
     // first clamp to thresholds if sinkRate is over the max
     if (verticalRate <= SINK_MAX) {
       sound_varioNoteTEMP =

--- a/src/vario/ui/display/pages/menu/page_menu_units.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_units.cpp
@@ -105,7 +105,11 @@ void UnitsMenuPage::setting_change(Button dir, ButtonState state, uint8_t count)
       if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_alt);
       break;
     case cursor_units_climb:
-      if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_climb);
+      if (state == RELEASED) {
+        settings.toggleBoolNeutral(&settings.units_climb);  // change climb units as user reqested
+        settings.adjustSinkAlarmUnits(
+            settings.units_climb);  // and change sink-alarm units to match
+      }
       break;
     case cursor_units_speed:
       if (state == RELEASED) settings.toggleBoolNeutral(&settings.units_speed);

--- a/src/vario/ui/display/pages/menu/page_menu_vario.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.cpp
@@ -100,13 +100,18 @@ void VarioMenuPage::draw() {
           }
           break;
         case cursor_vario_sinkalarm:
-          if (settings.vario_sinkAlarm == 0) {
+          if (settings.vario_sinkAlarm > -1.0f) {
             u8g2.print("OFF");
           } else {
+            // confirm sink alarm setting is in the same units as climb units setting
+            if (settings.vario_sinkAlarm_units != settings.units_climb) {
+              settings.adjustSinkAlarmUnits(settings.units_climb);
+            }
+
             // now print the value
             if (settings.units_climb) {
               // handle the extra digit required if we hit -1000fpm or more
-              if (settings.vario_sinkAlarm <= -5) {
+              if (settings.vario_sinkAlarm <= -1000.0f) {
                 u8g2.setCursor(u8g2.getCursorX() - 7,
                                u8g2.getCursorY());  // scootch over to make room
 
@@ -120,9 +125,9 @@ void VarioMenuPage::draw() {
               }
 
               // now print the value as usual
-              u8g2.print(settings.vario_sinkAlarm * 200);  // m/s->fpm
+              u8g2.print(float(settings.vario_sinkAlarm), 0);  // fpm
             } else {
-              u8g2.print(float(settings.vario_sinkAlarm), 1);  // m/s->m/s
+              u8g2.print(float(settings.vario_sinkAlarm), 1);  // m/s
             }
           }
           break;

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -15,9 +15,6 @@ typedef uint8_t SettingLogFormat;
 
 // Setting bounds and definitions
 // Vario
-// Sink Alarm
-#define SINK_ALARM_MAX -6  // m/s sink
-#define SINK_ALARM_MIN -2
 
 // Lifty Air Thermal Sniffer
 #define LIFTY_AIR_MAX -8  // 0.1 m/s - sinking less than this will trigger
@@ -37,12 +34,13 @@ typedef uint8_t SettingLogFormat;
 
 // Default Settings
 // Default Vario Settings
-#define DEF_SINK_ALARM -2    // m/s sink
-#define DEF_VARIO_SENSE 3    // 3 = 1 second avg (up and down 1/4 sec from there)
-#define DEF_CLIMB_AVERAGE 1  // in units of 5-seconds.  (def = 1 = 5sec)
-#define DEF_CLIMB_START 5    // cm/s when climb note begins
-#define DEF_VOLUME_VARIO 1   // 0=off, 1=low, 2=med, 3=high
-#define DEF_QUIET_MODE 0     // 0 = off, 1 = on (ON means no beeping until flight recording)
+#define DEF_SINK_ALARM -2       // m/s sink
+#define DEF_SINK_ALARM_UNITS 0  // 0 = m/s, 1 = fpm
+#define DEF_VARIO_SENSE 3       // 3 = 1 second avg (up and down 1/4 sec from there)
+#define DEF_CLIMB_AVERAGE 1     // in units of 5-seconds.  (def = 1 = 5sec)
+#define DEF_CLIMB_START 5       // cm/s when climb note begins
+#define DEF_VOLUME_VARIO 1      // 0=off, 1=low, 2=med, 3=high
+#define DEF_QUIET_MODE 0        // 0 = off, 1 = on (ON means no beeping until flight recording)
 // 0 == linear pitch interpolation; 1 == major C-scale for climb, minor scale for descent
 #define DEF_VARIO_TONES 0
 // In units of 10 cm/s (a sink rate of only 30cm/s means the air itself is going up).  '0' is off.
@@ -176,16 +174,8 @@ class Settings {
  public:
   // Global Variables for Current Settings
   // Vario Settings
-  int8_t vario_sinkAlarm;
-  /* Vario Sensitivity
-  setting | samples | time avg
-      1   |   20    | 20/20 second (1 second moving average)
-      2   |   12    | 12/20 second
-      3   |   6     |  6/20 second
-      4   |   3     |  3/20 second
-      5   |   1     |  1/20 second (single sample -- instant)
-  */
-  Setting<int8_t, 1, 5, 3> vario_sensitivity;
+  float vario_sinkAlarm;
+  bool vario_sinkAlarm_units;
   int8_t vario_climbAvg;
   int8_t vario_climbStart;
   int8_t vario_volume;
@@ -194,6 +184,16 @@ class Settings {
   int8_t vario_liftyAir;
   float vario_altSetting;
   bool vario_altSyncToGPS;
+
+  /* Vario Sensitivity
+setting | samples | time avg
+    1   |   20    | 20/20 second (1 second moving average)
+    2   |   12    | 12/20 second
+    3   |   6     |  6/20 second
+    4   |   3     |  3/20 second
+    5   |   1     |  1/20 second (single sample -- instant)
+*/
+  Setting<int8_t, 1, 5, 3> vario_sensitivity;
 
   // GPS & Track Log Settings
   bool distanceFlownType;
@@ -253,6 +253,7 @@ class Settings {
   // adjust-settings functions
   void adjustContrast(Button dir);
   void adjustSinkAlarm(Button dir);
+  void adjustSinkAlarmUnits(bool units);
   void adjustVarioAverage(Button dir);
   void adjustClimbAverage(Button dir);
   void adjustClimbStart(Button dir);
@@ -266,6 +267,12 @@ class Settings {
 
   void toggleBoolNeutral(bool* boolSetting);
   void toggleBoolOnOff(bool* switchSetting);
+
+ private:
+  float sinkAlarmOptions_[2][10] = {
+      {0, -1.25, -1.5, -1.75, -2.0, -2.5, -3.0, -4.0, -5.0, -6.0},  // m/s
+      {0, -250, -300, -350, -400, -500, -600, -800, -1000, -1200}   // fpm
+  };
 };
 extern Settings settings;
 

--- a/src/vario/utils/string_utils.cpp
+++ b/src/vario/utils/string_utils.cpp
@@ -104,7 +104,7 @@ String formatSpeed(float speed, bool units, bool showUnits) {
   else
     speed *= 3.6f;  // convert to kph
 
-  snprintf(buffer, sizeof(buffer), "%3d", speed);
+  snprintf(buffer, sizeof(buffer), "%.0f", speed);
 
   String result = String(buffer);
   if (showUnits) result += String(unitSymbol);


### PR DESCRIPTION
A few bug fixes and a feature tweak to the 0.1.0 release.  This will become release 0.1.1 so current demo units in the field can update.

* cherry pick the max-speed display on the Flight Summary Page fix
* temperature/humidity flip-flop bug fix
* added sink alarm values between -1.4m/s and -2m/s by user request, and re-architected sink alarm setting to properly capture "round number" values in both m/s and fpm, depending on user preference setting