### PR TITLE
Improve SinkAlarm Setting handling and valid values

### DIFF
--- a/src/vario/ui/audio/speaker.cpp
+++ b/src/vario/ui/audio/speaker.cpp
@@ -80,6 +80,13 @@ void Speaker::updateVarioNote(int32_t verticalRate) {
   uint16_t newVarioPlaySamples;
   uint16_t newVarioRestSamples;
 
+  int sinkAlarm_cms;
+  if (settings.vario_sinkAlarm_units) {
+    sinkAlarm_cms = settings.vario_sinkAlarm * 100 / 196.85;  // convert fpm to cm/s
+  } else {
+    sinkAlarm_cms = settings.vario_sinkAlarm * 100;  // convert m/s to cm/s
+  }
+
   if (verticalRate > settings.vario_climbStart) {
     // first clamp to thresholds if climbRate is over the max
     if (verticalRate >= CLIMB_MAX) {
@@ -98,8 +105,7 @@ void Speaker::updateVarioNote(int32_t verticalRate) {
     }
 
     // if we trigger sink threshold
-  } else if (verticalRate <
-             (settings.vario_sinkAlarm * 100)) {  // convert sink alarm 'm/s' setting to cm/s
+  } else if (verticalRate < sinkAlarm_cms) {
     // first clamp to thresholds if sinkRate is over the max
     if (verticalRate <= SINK_MAX) {
       newVarioNote = SINK_NOTE_MIN - verticalRate * (SINK_NOTE_MIN - SINK_NOTE_MAX) / SINK_MAX;

--- a/src/vario/ui/display/pages/menu/page_menu_units.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_units.cpp
@@ -106,7 +106,7 @@ void UnitsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count)
       if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_alt);
       break;
     case cursor_units_climb:
-      if (state == RELEASED) {
+      if (state == ButtonEvent::CLICKED) {
         settings.toggleBoolNeutral(&settings.units_climb);  // change climb units as user reqested
         settings.adjustSinkAlarmUnits(
             settings.units_climb);  // and change sink-alarm units to match

--- a/src/vario/ui/display/pages/menu/page_menu_units.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_units.cpp
@@ -106,7 +106,11 @@ void UnitsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count)
       if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_alt);
       break;
     case cursor_units_climb:
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_climb);
+      if (state == RELEASED) {
+        settings.toggleBoolNeutral(&settings.units_climb);  // change climb units as user reqested
+        settings.adjustSinkAlarmUnits(
+            settings.units_climb);  // and change sink-alarm units to match
+      }
       break;
     case cursor_units_speed:
       if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_speed);

--- a/src/vario/ui/display/pages/menu/page_menu_vario.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.cpp
@@ -101,13 +101,18 @@ void VarioMenuPage::draw() {
           }
           break;
         case cursor_vario_sinkalarm:
-          if (settings.vario_sinkAlarm == 0) {
+          if (settings.vario_sinkAlarm > -1.0f) {
             u8g2.print("OFF");
           } else {
+            // confirm sink alarm setting is in the same units as climb units setting
+            if (settings.vario_sinkAlarm_units != settings.units_climb) {
+              settings.adjustSinkAlarmUnits(settings.units_climb);
+            }
+
             // now print the value
             if (settings.units_climb) {
               // handle the extra digit required if we hit -1000fpm or more
-              if (settings.vario_sinkAlarm <= -5) {
+              if (settings.vario_sinkAlarm <= -1000.0f) {
                 u8g2.setCursor(u8g2.getCursorX() - 7,
                                u8g2.getCursorY());  // scootch over to make room
 
@@ -121,9 +126,9 @@ void VarioMenuPage::draw() {
               }
 
               // now print the value as usual
-              u8g2.print(settings.vario_sinkAlarm * 200);  // m/s->fpm
+              u8g2.print(float(settings.vario_sinkAlarm), 0);  // fpm
             } else {
-              u8g2.print(float(settings.vario_sinkAlarm), 1);  // m/s->m/s
+              u8g2.print(float(settings.vario_sinkAlarm), 1);  // m/s
             }
           }
           break;

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -132,8 +132,8 @@ void Settings::retrieve() {
   leafPrefs.begin("varioPrefs", RO_MODE);
 
   // Vario Settings
-  vario_sinkAlarm = leafPrefs.getFloat("SINK_ALARM_VAL");
-  vario_sinkAlarm_units = leafPrefs.getBool("SINK_ALARM_UNIT");
+  vario_sinkAlarm = leafPrefs.getFloat("SINK_ALARM_VAL", DEF_SINK_ALARM);
+  vario_sinkAlarm_units = leafPrefs.getBool("SINK_ALARM_UNIT", DEF_SINK_ALARM_UNITS);
   vario_sensitivity.readFrom(leafPrefs);
   vario_climbAvg = leafPrefs.getChar("CLIMB_AVERAGE");
   vario_climbStart = leafPrefs.getChar("CLIMB_START");

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -333,24 +333,24 @@ void Settings::adjustSinkAlarm(Button dir) {
 
   // then increase or decrease index based on button direction
   if (dir == Button::RIGHT) {
-    sound = fx_increase;
+    sound = fx::increase;
     if (++index >= n) {
       index = 0;
-      sound = fx_cancel;
+      sound = fx::cancel;
     }
   } else {
-    sound = fx_decrease;
+    sound = fx::decrease;
     if (index == 0) {
       index = n - 1;
     } else if (--index == 0) {
-      sound = fx_cancel;
+      sound = fx::cancel;
     }
   }
 
   // now set the new sink alarm value
   vario_sinkAlarm = SINK_ALARM_OPTIONS[opt][index];
 
-  speaker_playSound(sound);
+  speaker.playSound(sound);
   // TODO: really needed? speaker_updateClimbToneParameters();	// call to adjust sinkRateSpread
   // according to new  vario_sinkAlarm value
 }

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -63,6 +63,7 @@ void Settings::factoryResetVario() {
 void Settings::loadDefaults() {
   // Vario Settings
   vario_sinkAlarm = DEF_SINK_ALARM;
+  vario_sinkAlarm_units = DEF_SINK_ALARM_UNITS;
   vario_sensitivity.loadDefault();
   vario_climbAvg = DEF_CLIMB_AVERAGE;
   vario_climbStart = DEF_CLIMB_START;
@@ -126,7 +127,8 @@ void Settings::retrieve() {
   leafPrefs.begin("varioPrefs", RO_MODE);
 
   // Vario Settings
-  vario_sinkAlarm = leafPrefs.getChar("SINK_ALARM");
+  vario_sinkAlarm = leafPrefs.getFloat("SINK_ALARM");
+  vario_sinkAlarm_units = leafPrefs.getBool("SINK_ALARM_UNIT");
   vario_sensitivity.readFrom(leafPrefs);
   vario_climbAvg = leafPrefs.getChar("CLIMB_AVERAGE");
   vario_climbStart = leafPrefs.getChar("CLIMB_START");
@@ -203,7 +205,8 @@ void Settings::save() {
   leafPrefs.putBool("nvsInitVario", true);
 
   // Vario Settings
-  leafPrefs.putChar("SINK_ALARM", vario_sinkAlarm);
+  leafPrefs.putFloat("SINK_ALARM", vario_sinkAlarm);
+  leafPrefs.putBool("SINK_ALARM_UNIT", vario_sinkAlarm_units);
   vario_sensitivity.putInto(leafPrefs);
   leafPrefs.putChar("CLIMB_AVERAGE", vario_climbAvg);
   leafPrefs.putChar("CLIMB_START", vario_climbStart);
@@ -307,28 +310,79 @@ void Settings::adjustContrast(Button dir) {
 void Settings::adjustSinkAlarm(Button dir) {
   sound_t sound = fx::neutral;
 
-  if (dir == Button::RIGHT) {
-    sound = fx::increase;
-    if (++vario_sinkAlarm > 0) {
-      vario_sinkAlarm =
-          SINK_ALARM_MAX;  // if we were at 0 and now are at positive 1, go back to max sink rate
-    } else if (vario_sinkAlarm > SINK_ALARM_MIN) {
-      sound = fx::cancel;
-      vario_sinkAlarm = 0;  // if we were at MIN (say, -2), jump to 0 (off)
-    }
-  } else {
-    sound = fx::decrease;
-    if (--vario_sinkAlarm < SINK_ALARM_MAX) {
-      sound = fx::cancel;
-      vario_sinkAlarm = 0;  // if we were at max, wrap back to 0
-    } else if (vario_sinkAlarm > SINK_ALARM_MIN) {
-      vario_sinkAlarm = SINK_ALARM_MIN;  // if we were at 0, and dropped to -1, but still greater
-                                         // than the min (-2), jump to -2
+  // first find index of best-matching setting in the valid options array
+  uint8_t index = 0;
+  for (uint8_t i = 0; i < sizeof(sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0]); i++) {
+    if (vario_sinkAlarm >= -0.1f + sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0][i]) {
+      index = i;
+      break;
     }
   }
-  speaker.playSound(sound);
+  Serial.print("first read of index: ");
+  Serial.println(index);
+
+  Serial.print("size of array: ");
+  Serial.println(sizeof(sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0]) /
+                 sizeof(sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0][0]));
+
+  // then increase or decrease index based on button direction
+  if (dir == Button::RIGHT) {
+    sound = fx_increase;
+    if (++index >= sizeof(sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0]) /
+                       sizeof(sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0][0])) {
+      index = 0;
+      sound = fx_cancel;
+
+      Serial.print("index at RIGHT cancel: ");
+      Serial.println(index);
+    }
+  } else {
+    sound = fx_decrease;
+    if (index == 0) {
+      index = sizeof(sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0]) /
+                  sizeof(sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0][0]) -
+              1;
+    } else if (--index == 0) {
+      sound = fx_cancel;
+
+      Serial.print("index at LEFT cancel: ");
+      Serial.println(index);
+    }
+  }
+
+  // now set the new sink alarm value
+  vario_sinkAlarm = sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0][index];
+
+  Serial.print("index at END: ");
+  Serial.println(index);
+
+  speaker_playSound(sound);
   // TODO: really needed? speaker_updateClimbToneParameters();	// call to adjust sinkRateSpread
   // according to new  vario_sinkAlarm value
+}
+
+void Settings::adjustSinkAlarmUnits(bool units) {
+  if (units == vario_sinkAlarm_units)
+    return;  // no change
+  else {
+    // first find index of best-matching setting in the valid options array
+    uint8_t index = 0;
+    for (uint8_t i = 0; i < sizeof(sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0]); i++) {
+      if (vario_sinkAlarm >= -0.1f + sinkAlarmOptions_[vario_sinkAlarm_units ? 1 : 0][i]) {
+        index = i;
+        break;
+      }
+    }
+
+    // then switch units
+    if (units) {  // switching to fpm
+      vario_sinkAlarm = sinkAlarmOptions_[1][index];
+      vario_sinkAlarm_units = true;
+    } else {  // switching to m/s
+      vario_sinkAlarm = sinkAlarmOptions_[0][index];
+      vario_sinkAlarm_units = false;
+    }
+  }
 }
 
 void Settings::adjustVarioAverage(Button dir) {

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -211,9 +211,9 @@ setting | samples | time avg
   void toggleBoolOnOff(bool* switchSetting);
 
  private:
-  float sinkAlarmOptions_[2][10] = {
-      {0, -1.25, -1.5, -1.75, -2.0, -2.5, -3.0, -4.0, -5.0, -6.0},  // m/s
-      {0, -250, -300, -350, -400, -500, -600, -800, -1000, -1200}   // fpm
+  float sinkAlarmOptions_[2][11] = {
+      {0, -1.2, -1.4, -1.6, -1.8, -2.0, -2.5, -3.0, -4.0, -5.0, -6.0},   // m/s
+      {0, -240, -280, -320, -360, -400, -500, -600, -800, -1000, -1200}  // fpm
   };
 };
 extern Settings settings;

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -16,9 +16,6 @@ typedef uint8_t SettingLogFormat;
 
 // Setting bounds and definitions
 // Vario
-// Sink Alarm
-#define SINK_ALARM_MAX -6  // m/s sink
-#define SINK_ALARM_MIN -2
 
 // Lifty Air Thermal Sniffer
 #define LIFTY_AIR_MAX -8  // 0.1 m/s - sinking less than this will trigger
@@ -38,12 +35,13 @@ typedef uint8_t SettingLogFormat;
 
 // Default Settings
 // Default Vario Settings
-#define DEF_SINK_ALARM -2    // m/s sink
-#define DEF_VARIO_SENSE 3    // 3 = 1 second avg (up and down 1/4 sec from there)
-#define DEF_CLIMB_AVERAGE 1  // in units of 5-seconds.  (def = 1 = 5sec)
-#define DEF_CLIMB_START 5    // cm/s when climb note begins
-#define DEF_VOLUME_VARIO 1   // 0=off, 1=low, 2=med, 3=high
-#define DEF_QUIET_MODE 0     // 0 = off, 1 = on (ON means no beeping until flight recording)
+#define DEF_SINK_ALARM -2       // m/s sink
+#define DEF_SINK_ALARM_UNITS 0  // 0 = m/s, 1 = fpm
+#define DEF_VARIO_SENSE 3       // 3 = 1 second avg (up and down 1/4 sec from there)
+#define DEF_CLIMB_AVERAGE 1     // in units of 5-seconds.  (def = 1 = 5sec)
+#define DEF_CLIMB_START 5       // cm/s when climb note begins
+#define DEF_VOLUME_VARIO 1      // 0=off, 1=low, 2=med, 3=high
+#define DEF_QUIET_MODE 0        // 0 = off, 1 = on (ON means no beeping until flight recording)
 // 0 == linear pitch interpolation; 1 == major C-scale for climb, minor scale for descent
 #define DEF_VARIO_TONES 0
 // In units of 10 cm/s (a sink rate of only 30cm/s means the air itself is going up).  '0' is off.
@@ -111,15 +109,8 @@ typedef uint8_t SettingLogFormat;
 class Settings {
  public:
   // Vario Settings
-  int8_t vario_sinkAlarm;
-  /* Vario Sensitivity
-  setting | samples | time avg
-      1   |   20    | 20/20 second (1 second moving average)
-      2   |   12    | 12/20 second
-      3   |   6     |  6/20 second
-      4   |   3     |  3/20 second
-      5   |   1     |  1/20 second (single sample -- instant)
-  */
+  float vario_sinkAlarm;
+  bool vario_sinkAlarm_units;
   CharSetting<1, 3, 5> vario_sensitivity{"vSensitivity"};
   int8_t vario_climbAvg;
   int8_t vario_climbStart;
@@ -129,6 +120,16 @@ class Settings {
   int8_t vario_liftyAir;
   float vario_altSetting;
   bool vario_altSyncToGPS;
+
+  /* Vario Sensitivity
+setting | samples | time avg
+    1   |   20    | 20/20 second (1 second moving average)
+    2   |   12    | 12/20 second
+    3   |   6     |  6/20 second
+    4   |   3     |  3/20 second
+    5   |   1     |  1/20 second (single sample -- instant)
+*/
+  Setting<int8_t, 1, 5, 3> vario_sensitivity;
 
   // GPS & Track Log Settings
   bool distanceFlownType;
@@ -194,6 +195,7 @@ class Settings {
   // adjust-settings functions
   void adjustContrast(Button dir);
   void adjustSinkAlarm(Button dir);
+  void adjustSinkAlarmUnits(bool units);
   void adjustVarioAverage(Button dir);
   void adjustClimbAverage(Button dir);
   void adjustClimbStart(Button dir);
@@ -207,6 +209,12 @@ class Settings {
 
   void toggleBoolNeutral(bool* boolSetting);
   void toggleBoolOnOff(bool* switchSetting);
+
+ private:
+  float sinkAlarmOptions_[2][10] = {
+      {0, -1.25, -1.5, -1.75, -2.0, -2.5, -3.0, -4.0, -5.0, -6.0},  // m/s
+      {0, -250, -300, -350, -400, -500, -600, -800, -1000, -1200}   // fpm
+  };
 };
 extern Settings settings;
 

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -111,7 +111,6 @@ class Settings {
   // Vario Settings
   float vario_sinkAlarm;
   bool vario_sinkAlarm_units;
-  CharSetting<1, 3, 5> vario_sensitivity{"vSensitivity"};
   int8_t vario_climbAvg;
   int8_t vario_climbStart;
   int8_t vario_volume;
@@ -129,7 +128,7 @@ setting | samples | time avg
     4   |   3     |  3/20 second
     5   |   1     |  1/20 second (single sample -- instant)
 */
-  Setting<int8_t, 1, 5, 3> vario_sensitivity;
+  CharSetting<1, 3, 5> vario_sensitivity{"vSensitivity"};
 
   // GPS & Track Log Settings
   bool distanceFlownType;

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -35,7 +35,7 @@ typedef uint8_t SettingLogFormat;
 
 // Default Settings
 // Default Vario Settings
-#define DEF_SINK_ALARM -2       // m/s sink
+#define DEF_SINK_ALARM -1.6f    // m/s sink
 #define DEF_SINK_ALARM_UNITS 0  // 0 = m/s, 1 = fpm
 #define DEF_VARIO_SENSE 3       // 3 = 1 second avg (up and down 1/4 sec from there)
 #define DEF_CLIMB_AVERAGE 1     // in units of 5-seconds.  (def = 1 = 5sec)

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -209,12 +209,6 @@ setting | samples | time avg
 
   void toggleBoolNeutral(bool* boolSetting);
   void toggleBoolOnOff(bool* switchSetting);
-
- private:
-  float sinkAlarmOptions_[2][11] = {
-      {0, -1.2, -1.4, -1.6, -1.8, -2.0, -2.5, -3.0, -4.0, -5.0, -6.0},   // m/s
-      {0, -240, -280, -320, -360, -400, -500, -600, -800, -1000, -1200}  // fpm
-  };
 };
 extern Settings settings;
 


### PR DESCRIPTION
Add valid SinkAlarm settings in both m/s and fpm
Increase setting choices between -1.4 and -2m/s (-280fpm and -400 fpm) by user request
Improve behavior if no pref key is found (properly load default setting)