### PR TITLE
219 [Crash] In flight Crash

### DIFF
--- a/src/vario/comms/debug_webserver.cpp
+++ b/src/vario/comms/debug_webserver.cpp
@@ -49,7 +49,7 @@ void webserver_setup() {
   server.on("/fanet", HTTP_GET, []() {
     etl::string<1024> str;
     etl::string_stream ss(str);
-    auto& radio = FanetRadio::getInstance();
+    auto& radio = fanetRadio;
     auto protocol = radio.protocol;
 
     // Lock the radio while we poke around their private parts
@@ -68,7 +68,7 @@ void webserver_setup() {
        << "Current Time: " << ms << endl
        << endl
        << "-- STATS -- " << endl
-       << "State: " << FanetRadio::getInstance().getState().c_str() << "\n"
+       << "State: " << fanetRadio.getState().c_str() << "\n"
        << "rx: " << radioStats.rx << "\n"
        << "txSuccess: " << radioStats.txSuccess << "\n"
        << "txFailed: " << radioStats.txFailed << "\n"

--- a/src/vario/comms/fanet_radio.cpp
+++ b/src/vario/comms/fanet_radio.cpp
@@ -13,9 +13,8 @@
 #include "logging/log.h"
 #include "utils/lock_guard.h"
 
-// Singleton instance declaration.  Needs to be outside of static method
-// for use in an ISR.
-FanetRadio FanetRadio::instance_;
+// Singleton instance declaration.
+FanetRadio fanetRadio;
 
 // Initial detection of Fanet module (hw3.2.6+)
 bool FanetRadio::detectFanet() {
@@ -44,7 +43,7 @@ bool FanetRadio::detectFanet() {
 volatile bool FanetRadio::frameSending = false;
 
 ICACHE_RAM_ATTR void FanetRadio::onRxIsr() {
-  auto& fanet = FanetRadio::getInstance();
+  auto& fanet = fanetRadio;
   // If this interrupt was called just to say a transmission has been completed,
 
   // there's no need to wake anyone up to process is
@@ -66,7 +65,7 @@ ICACHE_RAM_ATTR void FanetRadio::onRxIsr() {
 }
 
 void FanetRadio::taskRadioNameTx(void* pvParameters) {
-  auto& fanet = FanetRadio::getInstance();
+  auto& fanet = fanetRadio;
 
   while (true) {
     if (fanet.state == FanetRadioState::RUNNING) {
@@ -91,7 +90,7 @@ void FanetRadio::taskRadioNameTx(void* pvParameters) {
 /// @brief Responsible for reading packets from Radio and processing them in the manager
 /// @param pvParameters
 void FanetRadio::taskRadioRx(void* pvParameters) {
-  auto& fanet = FanetRadio::getInstance();
+  auto& fanet = fanetRadio;
 
   while (true) {
     if (fanet.state == FanetRadioState::RUNNING) {
@@ -165,7 +164,6 @@ void FanetRadio::processRxPacket() {
 }
 
 void FanetRadio::taskRadioTx(void* pvParameters) {
-  auto& fanetRadio = FanetRadio::getInstance();
   // auto& manager = *fanetRadio.manager;
   auto& radio = *fanetRadio.radio;
 

--- a/src/vario/comms/fanet_radio.cpp
+++ b/src/vario/comms/fanet_radio.cpp
@@ -13,6 +13,10 @@
 #include "logging/log.h"
 #include "utils/lock_guard.h"
 
+// Singleton instance declaration.  Needs to be outside of static method
+// for use in an ISR.
+FanetRadio FanetRadio::instance_;
+
 // Initial detection of Fanet module (hw3.2.6+)
 bool FanetRadio::detectFanet() {
 #ifdef FANET_CAPABLE

--- a/src/vario/comms/fanet_radio.h
+++ b/src/vario/comms/fanet_radio.h
@@ -81,10 +81,7 @@ class FanetRadio : public etl::message_router<FanetRadio, GpsReading>,
   }
 
   /// @brief Gets the instance of the Fanet Radio handler
-  static FanetRadio& getInstance() {
-    static FanetRadio instance;
-    return instance;
-  }
+  static FanetRadio& getInstance() { return instance_; }
 
   // Handle GPS Packet updates
   void on_receive(const GpsReading& msg);
@@ -163,6 +160,9 @@ class FanetRadio : public etl::message_router<FanetRadio, GpsReading>,
   etl::optional<FANET::GroundTrackingPayload::TrackingType::enum_type> trackingMode = etl::nullopt;
 
   FanetNeighbors neighbors;  // The neighbor table with more info than the protocol class
+
+  // Singleton instance
+  static FanetRadio instance_;
 
 #ifdef LORA_SX1262
   Module radioModule = Module((uint32_t)SX1262_NSS, SX1262_DIO1, SX1262_RESET, SX1262_BUSY);

--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -232,7 +232,7 @@ void flightTimer_start() {
   logbook.logStartedAt = millis() / 1000;
 
   // Start the Fanet radio
-  FanetRadio::getInstance().begin(settings.fanet_region);
+  fanetRadio.begin(settings.fanet_region);
 }
 
 // stop timer
@@ -253,7 +253,7 @@ void flightTimer_stop() {
   logbook = FlightStats();  // Reset the flight stats
 
   // Stop the Fanet radio
-  FanetRadio::getInstance().end();
+  fanetRadio.end();
 }
 
 void flightTimer_toggle() {

--- a/src/vario/main.cpp
+++ b/src/vario/main.cpp
@@ -47,9 +47,9 @@ void setup() {
   Serial.println(" - Finished SPI");
 
 #ifdef FANET_CAPABLE
-  FanetRadio::getInstance().subscribe(&bus);
-  FanetRadio::getInstance().setup();
-  FanetRadio::getInstance().publishTo(&bus);
+  fanetRadio.subscribe(&bus);
+  fanetRadio.setup();
+  fanetRadio.publishTo(&bus);
 #endif
 
   // grab user settings (or populate defaults if no saved settings)

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -774,7 +774,7 @@ void display_fanet_icon(const uint8_t& x, const uint8_t& y) {
 #endif
 
   // If the radio is missing, don't bother rendering it at all
-  if (FanetRadio::getInstance().getState() == FanetRadioState::UNINSTALLED) {
+  if (fanetRadio.getState() == FanetRadioState::UNINSTALLED) {
     return;
   }
 
@@ -782,7 +782,7 @@ void display_fanet_icon(const uint8_t& x, const uint8_t& y) {
   u8g2.setFont(leaf_icons);
   u8g2.setCursor(x, y);
 
-  switch (FanetRadio::getInstance().getState()) {
+  switch (fanetRadio.getState()) {
     case FanetRadioState::UNINITIALIZED:
       u8g2.print(char(0x55));  // Bar icon
       break;

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
@@ -32,7 +32,7 @@ void PageFanetGround::show(FanetGroundTrackingMode mode) {
   push_page(&getInstance());
 
   // Set our tracking mode to ground tracking.
-  auto& radio = FanetRadio::getInstance();
+  auto& radio = fanetRadio;
   radio.begin(settings.fanet_region);
   switch (mode) {
     case FanetGroundTrackingMode::WALKING:
@@ -58,7 +58,7 @@ const char* PageFanetGround::get_title() const { return "Ground Tracking"; }
 
 void PageFanetGround::closed(bool removed_from_Stack) {
   // Ground tracking should only occur while we're showing this page.
-  if (removed_from_Stack) FanetRadio::getInstance().end();
+  if (removed_from_Stack) fanetRadio.end();
 }
 
 void PageFanetGround::draw_extra() {
@@ -101,9 +101,8 @@ void PageFanetGround::draw_extra() {
     // This really, really shouldn't be done in a Display object
     // but whatever, we'll refactor later.
     // TODO:  Delete me
-    FanetRadio::getInstance().setCurrentLocation(gps.location.lat(), gps.location.lng(),
-                                                 gps.altitude.meters(), gps.course.deg(),
-                                                 baro.climbRate() / 100.0f, gps.speed.kmph());
+    fanetRadio.setCurrentLocation(gps.location.lat(), gps.location.lng(), gps.altitude.meters(),
+                                  gps.course.deg(), baro.climbRate() / 100.0f, gps.speed.kmph());
   }
 }
 

--- a/src/vario/ui/display/pages/fanet/page_fanet_neighbors.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_neighbors.cpp
@@ -10,7 +10,7 @@ void PageFanetNeighbors::show() {
 }
 
 void PageFanetNeighbors::draw_extra() {
-  const auto neighbors = FanetRadio::getInstance().getNeighborTable();
+  const auto neighbors = fanetRadio.getNeighborTable();
 
   constexpr auto x = 3;
   constexpr auto yOffset = 10;

--- a/src/vario/ui/display/pages/fanet/page_fanet_stats.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_stats.cpp
@@ -8,11 +8,11 @@
 void PageFanetStats::show() { push_page(&getInstance()); }
 
 void PageFanetStats::draw_extra() {
-  auto radioStats = FanetRadio::getInstance().getStats();
+  auto radioStats = fanetRadio.getStats();
 
   constexpr int yOffset = 35;
   etl::array<etl::pair<String, String>, 13> stats{
-      etl::pair{(String) "State", FanetRadio::getInstance().getState().c_str()},
+      etl::pair{(String) "State", fanetRadio.getState().c_str()},
       etl::pair{(String) "rx", String(radioStats.rx)},
       etl::pair{(String) "txSuccess", String(radioStats.txSuccess)},
       etl::pair{(String) "txFailed", String(radioStats.txFailed)},

--- a/src/vario/ui/display/pages/primary/page_menu_main.cpp
+++ b/src/vario/ui/display/pages/primary/page_menu_main.cpp
@@ -115,7 +115,7 @@ void MainMenuPage::draw_main_menu() {
 #ifndef FANET_CAPABLE
         continue;  // skip drawing this menu item
 #else
-        if (FanetRadio::getInstance().getState() == FanetRadioState::UNINSTALLED) {
+        if (fanetRadio.getState() == FanetRadioState::UNINSTALLED) {
           continue;
         }
 #endif
@@ -193,7 +193,7 @@ void MainMenuPage::menu_item_action(Button button) {
                           "    :(\n");
         break;
 #endif
-        if (FanetRadio::getInstance().getState() == FanetRadioState::UNINSTALLED) {
+        if (fanetRadio.getState() == FanetRadioState::UNINSTALLED) {
           // If the FANET radio is uninstalled, show a warning message
           PageMessage::show("Fanet",
                             "Fanet radio\n"
@@ -233,7 +233,7 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonEvent state, uint8_t
 #ifndef FANET_CAPABLE
           cursor_prev();  // skip fanet menu if not available
 #else
-          if (FanetRadio::getInstance().getState() == FanetRadioState::UNINSTALLED) {
+          if (fanetRadio.getState() == FanetRadioState::UNINSTALLED) {
             cursor_prev();  // skip fanet menu if not available
           }
 #endif
@@ -250,7 +250,7 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonEvent state, uint8_t
 #ifndef FANET_CAPABLE
           cursor_next();  // skip fanet menu if not available
 #else
-          if (FanetRadio::getInstance().getState() == FanetRadioState::UNINSTALLED) {
+          if (fanetRadio.getState() == FanetRadioState::UNINSTALLED) {
             cursor_next();  // skip fanet menu if not available
           }
 #endif


### PR DESCRIPTION
In-flight Crash solved caused by FANET RX frame ISR path using static function variables.

https://github.com/DangerMonkeys/leaf/issues/219

Tested by running units for 2.5 hours, and going for a walk, observing no crashes this time.