### PR TITLE
Limit leaf_version.h to one compilation unit

### DIFF
--- a/src/vario/comms/ota.cpp
+++ b/src/vario/comms/ota.cpp
@@ -5,14 +5,14 @@
 
 #include <stdexcept>
 
-#include "leaf_version.h"
+#include "system/version_info.h"
 #include "ui/settings/settings.h"
 
 String getLatestTagVersion() {
   Serial.print("[OTA] Getting latest tag version from ");
-  Serial.println(OTA_VERSIONS_URL);
+  Serial.println(LeafVersionInfo::otaVersionsUrl());
   HTTPClient http;
-  http.begin(OTA_VERSIONS_URL);
+  http.begin(LeafVersionInfo::otaVersionsUrl());
   http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
   int httpCode = http.GET();
   if (httpCode != HTTP_CODE_OK) {
@@ -23,8 +23,9 @@ String getLatestTagVersion() {
   JsonDocument doc;
   deserializeJson(doc, payload);
 
-  String tagVersion = doc["latest_tag_versions"][HARDWARE_VARIANT];
-  Serial.printf("[OTA] Latest tag version for %s is %s\n", HARDWARE_VARIANT, tagVersion);
+  String tagVersion = doc["latest_tag_versions"][LeafVersionInfo::hardwareVariant()];
+  Serial.printf("[OTA] Latest tag version for %s is %s\n", LeafVersionInfo::hardwareVariant(),
+                tagVersion);
   return tagVersion;
 }
 
@@ -36,7 +37,7 @@ String getLatestTagVersion() {
 */
 void PerformOTAUpdate(const char* tag) {
   char url[120];
-  snprintf(url, sizeof(url), OTA_BIN_URL, tag);
+  snprintf(url, sizeof(url), LeafVersionInfo::otaBinUrl(), tag);
   Serial.print("[OTA] Starting OTA from ");
   Serial.println(url);
   HTTPClient http;

--- a/src/vario/diagnostics/fatal_error.cpp
+++ b/src/vario/diagnostics/fatal_error.cpp
@@ -9,7 +9,7 @@
 #include <stdarg.h>
 
 #include "hardware/buttons.h"
-#include "leaf_version.h"
+#include "system/version_info.h"
 #include "ui/audio/sound_effects.h"
 #include "ui/audio/speaker.h"
 #include "ui/display/display.h"
@@ -65,7 +65,7 @@ bool useFile() {
 
   // Write the version information to know what generated this fatal error
   fatal_error_file.print("Firmware version: ");
-  fatal_error_file.println(FIRMWARE_VERSION);
+  fatal_error_file.println(LeafVersionInfo::firmwareVersion());
 
   return fatal_error_file;
 }

--- a/src/vario/leaf_version.h
+++ b/src/vario/leaf_version.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// To optimize iterative build speed, do not include this file directly; instead, use accessor
+// functions in system/version_info.h.
+
 // The values here do not matter; they are set automatically
 // at build time via src/scripts/versioning.py:
 // ---------------------------------------------------------------

--- a/src/vario/logbook/igc.cpp
+++ b/src/vario/logbook/igc.cpp
@@ -7,7 +7,7 @@
 #include "FS.h"
 #include "instruments/baro.h"
 #include "instruments/gps.h"
-#include "leaf_version.h"
+#include "system/version_info.h"
 #include "time.h"
 #include "ui/settings/settings.h"
 #include "utils/string_utils.h"
@@ -86,9 +86,9 @@ bool Igc::startFlight() {
   // Overwrite from file if set in the Pilot descriptor
   setPilotFromFile();
 
-  logger.firmware_version = FIRMWARE_VERSION;
+  logger.firmware_version = LeafVersionInfo::firmwareVersion();
   logger.hardware_version = "Leaf1";
-  logger.logger_type = (String) "Leaf1," + FIRMWARE_VERSION;
+  logger.logger_type = (String) "Leaf1," + LeafVersionInfo::firmwareVersion();
   logger.gps_type = "GNSS LC86G";
   logger.pressure_type = "MS5611";
   logger.time_zone = (String)(settings.system_timeZone / 60);

--- a/src/vario/logging/buslog.cpp
+++ b/src/vario/logging/buslog.cpp
@@ -4,8 +4,8 @@
 #include <time.h>
 
 #include "instruments/gps.h"
-#include "leaf_version.h"
 #include "storage/sd_card.h"
+#include "system/version_info.h"
 #include "ui/settings/settings.h"
 #include "utils/string_utils.h"
 
@@ -62,7 +62,7 @@ bool BusLogger::startLog() {
     return false;
   }
 
-  file_.printf("V%s\n", FIRMWARE_VERSION);
+  file_.printf("V%s\n", LeafVersionInfo::firmwareVersion());
 
   tStart_ = millis();
 

--- a/src/vario/system/version_info.cpp
+++ b/src/vario/system/version_info.cpp
@@ -1,0 +1,11 @@
+#include "system/version_info.h"
+
+#include "leaf_version.h"
+
+// --- canonical C-string getters (no heap, no static ctors, no Arduino.h) ---
+const char* LeafVersionInfo::firmwareVersion() { return FIRMWARE_VERSION; }
+const char* LeafVersionInfo::hardwareVariant() { return HARDWARE_VARIANT; }
+const char* LeafVersionInfo::tagVersion() { return TAG_VERSION; }
+const char* LeafVersionInfo::otaVersionsUrl() { return OTA_VERSIONS_URL; }
+const char* LeafVersionInfo::otaBinUrl() { return OTA_BIN_URL; }
+bool LeafVersionInfo::otaAlwaysUpdate() { return OTA_ALWAYS_UPDATE; }

--- a/src/vario/system/version_info.h
+++ b/src/vario/system/version_info.h
@@ -1,0 +1,12 @@
+#pragma once
+
+struct LeafVersionInfo {
+  // Primary accessors (no heap)
+
+  static const char* firmwareVersion();
+  static const char* hardwareVariant();
+  static const char* tagVersion();
+  static const char* otaVersionsUrl();
+  static const char* otaBinUrl();
+  static bool otaAlwaysUpdate();
+};

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -11,7 +11,6 @@
 #include "hardware/Leaf_SPI.h"
 #include "instruments/baro.h"
 #include "instruments/gps.h"
-#include "leaf_version.h"
 #include "logging/log.h"
 #include "navigation/gpx.h"
 #include "power.h"

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -7,11 +7,11 @@
 #include "instruments/ambient.h"
 #include "instruments/baro.h"
 #include "instruments/gps.h"
-#include "leaf_version.h"
 #include "logging/log.h"
 #include "navigation/gpx.h"
 #include "power.h"
 #include "storage/sd_card.h"
+#include "system/version_info.h"
 #include "time.h"
 #include "ui/display/display.h"
 #include "ui/display/fonts.h"
@@ -1099,6 +1099,6 @@ void display_on_splash() {
     u8g2.setFont(leaf_5x8);
     u8g2.setCursor(0, 192);
     u8g2.print("v");
-    u8g2.print(FIRMWARE_VERSION);
+    u8g2.print(LeafVersionInfo::firmwareVersion());
   } while (u8g2.nextPage());
 }

--- a/src/vario/ui/display/pages/dialogs/page_menu_about.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_menu_about.cpp
@@ -1,9 +1,10 @@
 #include "ui/display/pages/dialogs/page_menu_about.h"
 
 #include "WiFi.h"
-#include "comms/fanet_radio.h"
 #include "esp_mac.h"
-#include "leaf_version.h"
+
+#include "comms/fanet_radio.h"
+#include "system/version_info.h"
 #include "ui/display/display.h"
 #include "ui/display/fonts.h"
 
@@ -16,7 +17,7 @@ void PageMenuAbout::draw_extra() {
   u8g2.print("Ver: ");
   u8g2.setCursor(5, y += offset);
   u8g2.setFont(leaf_5x8);
-  u8g2.print(FIRMWARE_VERSION);
+  u8g2.print(LeafVersionInfo::firmwareVersion());
   y += offset;
 
   u8g2.setFont(leaf_6x12);

--- a/src/vario/ui/display/pages/menu/system/page_menu_system_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/system/page_menu_system_wifi.cpp
@@ -1,10 +1,11 @@
 #include "ui/display/pages/menu/system/page_menu_system_wifi.h"
 
 #include "WiFi.h"
+
 #include "comms/ble.h"
 #include "comms/ota.h"
-#include "leaf_version.h"
 #include "power.h"
+#include "system/version_info.h"
 #include "ui/display/display.h"
 #include "ui/display/fonts.h"
 #include "ui/settings/settings.h"
@@ -166,7 +167,7 @@ void PageMenuSystemWifiUpdate::shown() {
 
   log_lines.clear();
   log_lines.push_back("*CURRENT VERSION:");
-  log_lines.push_back((String) "  " + FIRMWARE_VERSION);
+  log_lines.push_back((String) "  " + LeafVersionInfo::firmwareVersion());
   log_lines.push_back("*CONNECTING TO WIFI...");
 }
 
@@ -203,14 +204,15 @@ void PageMenuSystemWifiUpdate::loop() {
         *wifi_state = WifiState::ERROR;
         break;
       }
-      if (latest_version_ == TAG_VERSION && !OTA_ALWAYS_UPDATE) {
+      if (latest_version_ == LeafVersionInfo::tagVersion() && !LeafVersionInfo::otaAlwaysUpdate()) {
         log_lines.push_back("*YOU'RE UP TO DATE!");
         log_lines.push_back("*REBOOT REQUIRED");
         *wifi_state = WifiState::OTA_UP_TO_DATE;
       } else {
         log_lines.push_back("*NEW VERSION AVAILABLE!");
         log_lines.push_back("*UPDATING TO:");
-        log_lines.push_back((String) "   " + latest_version_ + " for " + HARDWARE_VARIANT);
+        log_lines.push_back((String) "   " + latest_version_ + " for " +
+                            LeafVersionInfo::hardwareVariant());
         log_lines.push_back("(this will take a while)");
         log_lines.push_back("*WILL REBOOT WHEN DONE");
         *wifi_state = WifiState::OTA_UPDATING;

--- a/src/vario/ui/display/pages/primary/page_charging.cpp
+++ b/src/vario/ui/display/pages/primary/page_charging.cpp
@@ -2,9 +2,9 @@
 #include <U8g2lib.h>
 
 #include "hardware/buttons.h"
-#include "leaf_version.h"
 #include "power.h"
 #include "storage/sd_card.h"
+#include "system/version_info.h"
 #include "ui/audio/sound_effects.h"
 #include "ui/audio/speaker.h"
 #include "ui/display/display.h"
@@ -49,7 +49,7 @@ void chargingPage_draw() {
     u8g2.setCursor(0, 172);
     u8g2.setFont(leaf_5x8);
     u8g2.print("v");
-    u8g2.print(FIRMWARE_VERSION);
+    u8g2.print(LeafVersionInfo::firmwareVersion());
 
     // SD Card Mounted
     u8g2.setCursor(12, 191);


### PR DESCRIPTION
Currently, version information in leaf_version.h changes a lot -- any change in git status, a local change relative to a commit, etc all result in a change to leaf_version.h.  Because many compilation units (e.g., ota, igc, buslog, display, display_fields, various pages) depend on leaf_version.h, this means these many compilation units need to be rebuilt frequently.  This PR should improve this situation by having all those compilation units access version information through functions in a new compilation unit (version_info), which means that only the new compilation unit will need to be recompiled when leaf_version.h changes.  Everywhere else assumes the version information will be available from a function in a different compilation unit that will be stitched together at link time, so version information consumers don't need to be rebuilt when leaf_version.h changes.  The new compilation unit (version_info) will be rebuilt every time leaf_version.h changes (which is very often), but it is designed to build very fast -- it does not import the mountain of content in Arduino.h and contains only minimal basic functions.

Tested be5ffff38c57cef87bedc5c8ca9ae96d0a3eb5ca via the standard test procedure; leaf_3_2_7_release on 3.2.7+radio.