### PR TITLE
Add sensor sanity checks and improve access logic and assertions

### DIFF
--- a/src/vario/hardware/icm_20948.cpp
+++ b/src/vario/hardware/icm_20948.cpp
@@ -99,8 +99,10 @@ void ICM20948::update() {
             isnan(update.qy) || isinf(update.qy) || update.qy < -1.1 || update.qy > 1.1 ||
             isnan(update.qz) || isinf(update.qz) || update.qz < -1.1 || update.qz > 1.1) {
           char msg[100];
-          snprintf(msg, sizeof(msg), "ICM20948 invalid orientation Q1=%X; Q2=%X; Q3=%X",
-                   data.Quat9.Data.Q1, data.Quat9.Data.Q2, data.Quat9.Data.Q3);
+          snprintf(msg, sizeof(msg),
+                   "ICM20948 invalid orientation Q1=%X; Q2=%X; Q3=%X (%.2f, %.2f, %.2f)",
+                   data.Quat9.Data.Q1, data.Quat9.Data.Q2, data.Quat9.Data.Q3, update.qx, update.qy,
+                   update.qz);
           Serial.println(msg);
           bus->receive(CommentMessage(msg));
           update.hasOrientation = false;
@@ -113,8 +115,10 @@ void ICM20948::update() {
             isnan(update.ay) || isinf(update.ay) || update.ay < -1000 || update.ay > 1000 ||
             isnan(update.az) || isinf(update.az) || update.az < -1000 || update.az > 1000) {
           char msg[100];
-          snprintf(msg, sizeof(msg), "ICM20948 invalid acceleration X=%X; Y=%X; Z=%X",
-                   data.Raw_Accel.Data.X, data.Raw_Accel.Data.Y, data.Raw_Accel.Data.Z);
+          snprintf(msg, sizeof(msg),
+                   "ICM20948 invalid acceleration X=%X; Y=%X; Z=%X (%.2f, %.2f, %.2f)",
+                   data.Raw_Accel.Data.X, data.Raw_Accel.Data.Y, data.Raw_Accel.Data.Z, update.ax,
+                   update.ay, update.az);
           Serial.println(msg);
           bus->receive(CommentMessage(msg));
           update.hasAcceleration = false;

--- a/src/vario/hardware/ms5611.cpp
+++ b/src/vario/hardware/ms5611.cpp
@@ -195,13 +195,6 @@ void MS5611::sendUpdate(const PressureUpdate& update) {
     bus->receive(CommentMessage(msg));
     return;
   }
-  if (update.t < -90 || update.t > 180) {
-    char msg[100];
-    snprintf(msg, sizeof(msg), "MS5611 invalid temp %d", update.t);
-    Serial.println(msg);
-    bus->receive(CommentMessage(msg));
-    return;
-  }
   bus->receive(update);
 }
 

--- a/src/vario/hardware/ms5611.h
+++ b/src/vario/hardware/ms5611.h
@@ -79,6 +79,7 @@ class MS5611 : public IMessageSource, IPollable {
   uint32_t baroADCStartTime_ = 0;
 
   PressureUpdate getUpdate();
+  void sendUpdate(const PressureUpdate& update);
 };
 
 // Singleton sensor instance

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -187,7 +187,7 @@ void Barometer::wake() {
 // ^^^ Device Management ^^^
 
 void Barometer::onUnexpectedState(const char* action, State actual) const {
-  fatalError("%s while %s", action, nameOf(actual));
+  fatalError("%s while %s (%u)", action, nameOf(actual).c_str(), static_cast<uint8_t>(actual));
 }
 
 // vvv Device reading & data processing vvv

--- a/src/vario/math/kalman.cpp
+++ b/src/vario/math/kalman.cpp
@@ -18,6 +18,19 @@ void KalmanFilterPA::init(double initialTime, double initialPosition, double ini
   initialized_ = true;
 }
 
+double KalmanFilterPA::getPosition() {
+  if (!initialized_) fatalError("KalmanFilter::getPosition before initialized");
+  return p_;
+}
+double KalmanFilterPA::getVelocity() {
+  if (!initialized_) fatalError("KalmanFilter::getVelocity before initialized");
+  return v_;
+}
+double KalmanFilterPA::getAcceleration() {
+  if (!initialized_) fatalError("KalmanFilter::getAcceleration before initialized");
+  return a_;
+}
+
 void KalmanFilterPA::update(double measuredTime, double measuredPosition,
                             double measuredAcceleration) {
   if (isnan(measuredTime) || isinf(measuredTime) || isnan(measuredPosition) ||

--- a/src/vario/math/kalman.h
+++ b/src/vario/math/kalman.h
@@ -8,9 +8,10 @@ class KalmanFilterPA {
 
   void update(double measuredTime, double measuredPosition, double measuredAcceleration);
 
-  double getPosition() { return p_; }
-  double getVelocity() { return v_; }
-  double getAcceleration() { return a_; }
+  bool initialized() { return initialized_; }
+  double getPosition();
+  double getVelocity();
+  double getAcceleration();
 
  private:
   void init(double initialTime, double initialPosition, double initialAcceleration);
@@ -27,13 +28,13 @@ class KalmanFilterPA {
   double t_;
 
   // Current position
-  double p_;
+  double p_ = 0;
 
   // Current velocity
-  double v_;
+  double v_ = 0;
 
   // Current acceleration
-  double a_;
+  double a_ = 0;
 
   // Covariance matrix
   double p11_, p21_, p12_, p22_;


### PR DESCRIPTION
This PR attempts to partially address #221 by mostly eliminating outlandish sensor values occasionally observed (e.g., quaternion axis value of 1e30++).  It also adds a few more fatal-error assertions to potentially catch any remaining issues sooner.  Finally, it fixes a few conditions under which invalid state information was being improperly accessed (discovered during testing).

Tested 942dff9bad5914d910844004b82dcb7a71d55cbe using standard test procedure with leaf_3_2_7_release on 3.2.7+radio.