### PR TITLE
Ignore invalid/incomplete MotionUpdates

### DIFF
--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -64,7 +64,7 @@ IMU::IMU()
                   pow(ACCELERATION_MEASURE_STANDARD_DEVIATION, 2)),
       gravityInitCount_(GRAVITY_INIT_SAMPLES) {}
 
-void IMU::processQuaternion(const MotionUpdate& m) {
+void IMU::processMotion(const MotionUpdate& m) {
   // Scale to +/- 1
   double magnitude = ((m.qx * m.qx) + (m.qy * m.qy) + (m.qz * m.qz));
   if (magnitude >= 1.0) magnitude = 1.0;
@@ -179,8 +179,14 @@ void IMU::on_receive(const MotionUpdate& msg) {
     // We can't do anything without simultaneous barometer-measured altitude
     return;
   }
+  if (!msg.hasAcceleration || !msg.hasOrientation) {
+    // We need to use both acceleration and orientation.
+    // In the future, we could potentially collect them separately, but that seems unnecessary given
+    // that they almost always occur together.
+    return;
+  }
 
-  processQuaternion(msg);
+  processMotion(msg);
 
   if (validAccelVert_) {
     // update kalman filter

--- a/src/vario/instruments/imu.h
+++ b/src/vario/instruments/imu.h
@@ -33,7 +33,7 @@ class IMU : public etl::message_router<IMU, MotionUpdate>, public IMessageSource
   float getVelocity();
 
  private:
-  void processQuaternion(const MotionUpdate& m);
+  void processMotion(const MotionUpdate& m);
 
   etl::imessage_bus* bus_ = nullptr;
 


### PR DESCRIPTION
#226 added sanity checks to sensor inputs and flagged when a MotionUpdate didn't contain valid information in accel and/or orientation, but the IMU still uses all MotionUpdates regardless of whether they contain valid data.  This PR hopefully fixes that.

It also improves the name processQuaternion to processMotion since a big part of the routine is handling acceleration (not just orientation from the quaternion).