### PR TITLE
Clean up Speaker encapsulation

### DIFF
--- a/src/vario/diagnostics/fatal_error.cpp
+++ b/src/vario/diagnostics/fatal_error.cpp
@@ -201,7 +201,7 @@ void fatalError(const char* msg, ...) {
 
   // Play fatal error sound
   speaker.unMute();
-  settings.system_volume = 3;
+  speaker.setVolume(Speaker::SoundChannel::FX, SpeakerVolume::High);
   speaker.playSound(fx::fatalerror);
   while (speaker.update()) {
     delay(10);

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -122,10 +122,6 @@ void Power::initPeripherals() {
   Serial.print("init_peripherals: ");
   Serial.println(nameOf(info_.onState));
 
-  // initialize speaker to play sound (so user knows they can let go of the power button)
-  speaker.init();
-  Serial.println(" - Finished Speaker");
-
   if (info_.onState == PowerState::On) {
     latchOn();
     speaker.playSound(fx::enter);

--- a/src/vario/ui/audio/audio_tests.cpp
+++ b/src/vario/ui/audio/audio_tests.cpp
@@ -136,16 +136,16 @@ void speaker_playPiano(void) {
         n = note::E6;
         break;
       case '0':
-        speaker.setVolume(SpeakerVolume::Off);
+        speaker.setVolume(Speaker::SoundChannel::FX, SpeakerVolume::Off);
         break;
       case '1':
-        speaker.setVolume(SpeakerVolume::Low);
+        speaker.setVolume(Speaker::SoundChannel::FX, SpeakerVolume::Low);
         break;
       case '2':
-        speaker.setVolume(SpeakerVolume::Medium);
+        speaker.setVolume(Speaker::SoundChannel::FX, SpeakerVolume::Medium);
         break;
       case '3':
-        speaker.setVolume(SpeakerVolume::High);
+        speaker.setVolume(Speaker::SoundChannel::FX, SpeakerVolume::High);
         break;
       case '4':
         speaker.playSound(fx::buttonpress);

--- a/src/vario/ui/audio/speaker.h
+++ b/src/vario/ui/audio/speaker.h
@@ -5,39 +5,55 @@
 #include "hardware/configuration.h"
 #include "ui/audio/dynamic_effects.h"
 #include "ui/audio/notes.h"
+#include "ui/audio/sound_effects.h"
+#include "utils/state_assert_mixin.h"
 
 using sound_t = const note::note_t*;
 
 enum class SpeakerVolume : uint8_t { Off = 0, Low = 1, Medium = 2, High = 3 };
 
-class Speaker {
+class Speaker : private StateAssertMixin<Speaker> {
  public:
-  void init();
+  enum class State : uint8_t { Uninitialized, Active };
+
+  enum class SoundChannel : uint8_t { FX, Vario };
+
+  State state() const { return state_; }
+
+  // Do not play any sounds until unmuted
   void mute();
+
+  // Resume normal sounds (previous volume levels, etc)
   void unMute();
 
-  void setVolume(SpeakerVolume volume);
+  // Play sounds on the specified channel at the specified volume
+  void setVolume(SoundChannel channel, SpeakerVolume volume);
 
   // Update the sound the vario plays according to climb/sink rate in cm/s
   void updateVarioNote(int32_t verticalRate);
 
-  // Call every 10ms to play notes.  Returns true if there are notes left to play.
+  // Call periodically to play sounds.  Returns true if there are notes left to play.
   bool update();
 
+  // Set the specified sound to be played
   void playSound(sound_t sound);
 
+  // Set the specified note to be played once as a sound
   void playNote(note::note_t note);
+
   void debugPrint();
 
  private:
-  // count timer cycles so we only update note every 4th time
-  uint8_t speakerTimerCount_ = 0;
+  State state_;
 
-  SpeakerVolume speakerVolume_ = SpeakerVolume::Low;
+  unsigned long tLastUpdate_;
+
+  SpeakerVolume fxVolume_ = SpeakerVolume::Low;
+  SpeakerVolume varioVolume_ = SpeakerVolume::Low;
   bool speakerMute_ = false;  // use to mute sound for various charging & sleep states
 
   // volatile pointer to the sound sample to play
-  volatile sound_t soundPlaying_;
+  volatile sound_t soundPlaying_ = fx::silence;
 
   // notes we should play, and if we're currently playing
   volatile note::note_t varioNote_ = note::NONE;      // note to play for vario beeps
@@ -69,6 +85,13 @@ class Speaker {
   // this is to allow playing single notes by changing single_note[0], while
   // still having a NOTE_END terminator following.
   uint16_t singleNote_[2] = {0, note::END};
+
+  void init();
+
+  void setVolume(SpeakerVolume volume);
+
+  void onUnexpectedState(const char* action, State actual) const;
+  friend struct StateAssertMixin<Speaker>;
 };
 
 extern Speaker speaker;

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -73,6 +73,7 @@ void Settings::loadDefaults() {
   vario_climbAvg = DEF_CLIMB_AVERAGE;
   vario_climbStart = DEF_CLIMB_START;
   vario_volume = DEF_VOLUME_VARIO;
+  speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)vario_volume);
   vario_quietMode = DEF_QUIET_MODE;
   vario_tones = DEF_VARIO_TONES;
   vario_liftyAir = DEF_LIFTY_AIR;
@@ -90,6 +91,7 @@ void Settings::loadDefaults() {
   // System Settings
   system_timeZone = DEF_TIME_ZONE;
   system_volume = DEF_VOLUME_SYSTEM;
+  speaker.setVolume(Speaker::SoundChannel::FX, (SpeakerVolume)system_volume);
   system_ecoMode = DEF_ECO_MODE;
   system_autoOff = DEF_AUTO_OFF;
   system_wifiOn = DEF_WIFI_ON;
@@ -138,6 +140,7 @@ void Settings::retrieve() {
   vario_climbAvg = leafPrefs.getChar("CLIMB_AVERAGE");
   vario_climbStart = leafPrefs.getChar("CLIMB_START");
   vario_volume = leafPrefs.getChar("VOLUME_VARIO");
+  speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)vario_volume);
   vario_quietMode = leafPrefs.getBool("QUIET_MODE");
   vario_tones = leafPrefs.getBool("VARIO_TONES");
   vario_liftyAir = leafPrefs.getChar("LIFTY_AIR");
@@ -155,6 +158,7 @@ void Settings::retrieve() {
   // System Settings
   system_timeZone = leafPrefs.getShort("TIME_ZONE");
   system_volume = leafPrefs.getChar("VOLUME_SYSTEM");
+  speaker.setVolume(Speaker::SoundChannel::FX, (SpeakerVolume)system_volume);
   system_ecoMode = leafPrefs.getBool("ECO_MODE");
   system_autoOff = leafPrefs.getBool("AUTO_OFF");
   system_wifiOn = leafPrefs.getBool("WIFI_ON");
@@ -478,6 +482,8 @@ void Settings::adjustVolumeVario(Button dir) {
     if (vario_volume > VOLUME_MAX) {
       vario_volume = VOLUME_MAX;
       sound = fx::doubleClick;
+    } else {
+      speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)vario_volume);
     }
   } else {
     sound = fx::decrease;
@@ -486,6 +492,8 @@ void Settings::adjustVolumeVario(Button dir) {
       vario_volume = 0;
       sound = fx::cancel;  // even if vario volume is set to 0, the system volume may still be
                            // turned on, so we have a sound for turning vario off
+    } else {
+      speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)vario_volume);
     }
   }
   speaker.playSound(sound);
@@ -499,6 +507,8 @@ void Settings::adjustVolumeSystem(Button dir) {
     if (system_volume > VOLUME_MAX) {
       system_volume = VOLUME_MAX;
       sound = fx::doubleClick;
+    } else {
+      speaker.setVolume(Speaker::SoundChannel::FX, (SpeakerVolume)system_volume);
     }
   } else {
     sound = fx::decrease;
@@ -507,6 +517,8 @@ void Settings::adjustVolumeSystem(Button dir) {
       system_volume = 0;
       sound = fx::cancel;  // we have this line of code for completeness, but the speaker will be
                            // turned off for system sounds so you won't hear it
+    } else {
+      speaker.setVolume(Speaker::SoundChannel::FX, (SpeakerVolume)system_volume);
     }
   }
   speaker.playSound(sound);


### PR DESCRIPTION
This PR attempts to more strongly encapsulate and protect speaker behaviors, including managing state internally to work toward #192.  This includes:
* Maintaining volume within Speaker class rather than reaching out to settings (settings -> Speaker rather than Speaker -> settings)
* Initializing automatically when needed (keeping track of state internally to know when initialization is needed or not needed)
* Adjusting volume as needed internally based on "channel" volumes set externally
* Allowing update() to be called at any (sufficient) rate and still achieve the same desired behavior
* Ensuring public methods are explicit about what states Speaker may be in when they're called

Tested 96c933212bb023a6b6e44a6f01f3cc18981e219f via the standard test procedure, plus waited for a fix and then moved around, navigated menus, and started and ended a flight.  leaf_3_2_7_release on 3.2.7+radio