### PR TITLE
Show fatal error message as multi-line text

### DIFF
--- a/src/vario/diagnostics/fatal_error.cpp
+++ b/src/vario/diagnostics/fatal_error.cpp
@@ -14,6 +14,7 @@
 #include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 #include "ui/display/fonts.h"
+#include "ui/display/utils.h"
 #include "ui/input/buttons.h"
 #include "ui/settings/settings.h"
 
@@ -119,8 +120,7 @@ void displayFatalError(char* msg) {
     u8g2.print("FATAL ERROR");
 
     u8g2.setFont(leaf_5x8);
-    u8g2.setCursor(0, 36);
-    u8g2.print(msg);  // TODO: wrap words to multiple lines
+    printMultiLine(msg, 0, 20, u8g2.getDisplayWidth(), 162 - 20 - u8g2.getMaxCharHeight());
 
     u8g2.setFont(leaf_5x8);
     u8g2.setCursor(0, 163);

--- a/src/vario/hardware/buttons.cpp
+++ b/src/vario/hardware/buttons.cpp
@@ -140,7 +140,7 @@ void Buttons::update() {
     }
 
   } else {
-    fatalError("Buttons::update found unsupported state '%s'", nameOf(state_));
+    fatalError("Buttons::update found unsupported state '%s' (%u)", nameOf(state_).c_str(), state_);
   }
 }
 

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -125,7 +125,7 @@ void Barometer::on_receive(const PressureUpdate& msg) {
     setPressureAlt(msg.pressure);  // calculate Pressure Altitude adjusted for temperature
     filterAltitude();
   } else {
-    fatalError("Barometer state %s in on_receive", nameOf(state_));
+    fatalError("Barometer state %s (%u) in on_receive", nameOf(state_).c_str(), state_);
   }
 }
 
@@ -187,7 +187,7 @@ void Barometer::wake() {
 // ^^^ Device Management ^^^
 
 void Barometer::onUnexpectedState(const char* action, State actual) const {
-  fatalError("%s while %s (%u)", action, nameOf(actual).c_str(), static_cast<uint8_t>(actual));
+  fatalError("%s while %s (%u)", action, nameOf(actual).c_str(), actual);
 }
 
 // vvv Device reading & data processing vvv

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -142,8 +142,8 @@ void TaskManager::update() {
   else if (info.onState == PowerState::OffUSB)
     updateWhileCharging();
   else
-    fatalError("Unsupported onState '%s' (%d) in TaskManager::update()", nameOf(info.onState),
-               info.onState);
+    fatalError("Unsupported onState '%s' (%u) in TaskManager::update()",
+               nameOf(info.onState).c_str(), info.onState);
 }
 
 void TaskManager::updateWhileCharging() {

--- a/src/vario/ui/audio/speaker.cpp
+++ b/src/vario/ui/audio/speaker.cpp
@@ -55,7 +55,7 @@ void Speaker::setVolume(SoundChannel channel, SpeakerVolume volume) {
   } else if (channel == SoundChannel::Vario) {
     varioVolume_ = volume;
   } else {
-    fatalError("Channel %s invalid in Speaker::setVolume", nameOf(channel));
+    fatalError("Channel %s (%u) invalid in Speaker::setVolume", nameOf(channel).c_str(), channel);
   }
 }
 
@@ -194,7 +194,7 @@ bool Speaker::update() {
   if (state_ == State::Uninitialized) {
     init();
   } else if (state_ != State::Active) {
-    fatalError("Unsupported Speaker::update state %d", nameOf(state_));
+    fatalError("Unsupported Speaker::update state %d (%u)", nameOf(state_).c_str(), state_);
   }
 
   unsigned long tNow = millis();

--- a/src/vario/ui/display/utils.cpp
+++ b/src/vario/ui/display/utils.cpp
@@ -1,0 +1,235 @@
+#include "ui/display/utils.h"
+
+#include <U8g2lib.h>
+#include <stddef.h>
+#include <string.h>
+#include <cstdint>
+
+#include "ui/display/display.h"
+
+/**
+ * Print `str` into a box whose top-left corner is (x,y).
+ * - If width==0, lines are only broken on '\n' (no width constraint).
+ * - If height==0, vertical space is unbounded.
+ * - Wrap whole words when they fit; otherwise wrap by the maximum number of characters that fit.
+ * - Treat '\n' as a hard line break; ignore '\r'.
+ * - Returns the index into `str` just beyond the last character that was printed.
+ */
+size_t printMultiLine(const char* str, int16_t x, int16_t y, uint16_t width, uint16_t height) {
+  if (!str) return 0;
+
+  const size_t n = strlen(str);
+  const bool limitWidth = (width > 0);
+  const bool limitHeight = (height > 0);
+
+  // Recommended vertical metrics: baseline at top + ascent, line step = ascent - descent
+  const int16_t ascent = u8g2.getAscent();
+  const int16_t descent = u8g2.getDescent();    // usually negative
+  const int16_t lineHeight = ascent - descent;  // e.g. 12 - (-2) = 14
+  int16_t baselineY = y + ascent;
+
+  if (limitHeight && baselineY > (int32_t)y + height) {
+    return 0;  // no room for even one line
+  }
+
+  // Small helper: copy a slice [s,e) from `str` into `dst`, stripping '\r'.
+  auto copy_slice_no_cr = [](char* dst, size_t dst_cap, const char* src, size_t s,
+                             size_t e) -> size_t {
+    size_t out = 0;
+    for (size_t i = s; i < e && out + 1 < dst_cap; ++i) {
+      char c = src[i];
+      if (c == '\r') continue;
+      dst[out++] = c;
+    }
+    dst[out] = '\0';
+    return out;
+  };
+
+  size_t i = 0;
+  size_t lastPrintedIdx = 0;
+  bool printedAnything = false;
+
+  while (i < n) {
+    if (printedAnything) {
+      baselineY += lineHeight;
+      if (limitHeight && baselineY > (int32_t)y + height) break;
+    }
+
+    // Width-unlimited: print until newline or end (ignoring CRs)
+    if (!limitWidth) {
+      // Skip leading CRs on this line
+      while (i < n && str[i] == '\r') ++i;
+
+      size_t j = i;
+      while (j < n && str[j] != '\n') ++j;
+
+      u8g2.setCursor(x, baselineY);
+      for (size_t k = i; k < j; ++k) {
+        if (str[k] == '\r') continue;
+        u8g2.write((uint8_t)str[k]);
+      }
+
+      if (j > i) {
+        lastPrintedIdx = j - 1;
+        printedAnything = true;
+      }
+      i = (j < n && str[j] == '\n') ? (j + 1) : j;
+      continue;
+    }
+
+    // -------- Width-limited path: build a line by *measuring exactly what we'll print* ----------
+    // Skip CRs and leading spaces/tabs at the start of a line
+    while (i < n && (str[i] == '\r' || str[i] == ' ' || str[i] == '\t')) ++i;
+
+    // Hard break on newline (empty visual line)
+    if (i < n && str[i] == '\n') {
+      ++i;
+      continue;
+    }
+    if (i >= n) break;
+
+    // We'll accumulate the exact characters that will be printed into this line buffer.
+    // Keep it reasonably large; with a 96px width and tiny fonts, 256 is plenty.
+    static constexpr size_t LINEBUF_MAX = 256;
+    char lineBuf[LINEBUF_MAX];
+    size_t lineLen = 0;  // current length in lineBuf
+    lineBuf[0] = '\0';
+
+    size_t scan = i;
+    size_t lineEndOriginal =
+        i;  // index right after the last character from `str` that we decided to print
+
+    auto fits_width = [&](const char* s) -> bool {
+      if (!limitWidth) return true;
+      int w = u8g2.getStrWidth(s);
+      return w <= (int)width;
+    };
+
+    // Attempt to add as many words (with a single inter-word space) as fit
+    bool firstWord = true;
+    while (scan < n && str[scan] != '\n') {
+      // Find next word [ws,we): a run of non-space/tab/CR/newline
+      size_t ws = scan;
+      // skip inter-word whitespace (space/tab/CR) but not newline
+      while (ws < n && (str[ws] == ' ' || str[ws] == '\t' || str[ws] == '\r')) ++ws;
+      if (ws >= n || str[ws] == '\n') break;
+
+      size_t we = ws;
+      while (we < n) {
+        char c = str[we];
+        if (c == '\n' || c == '\r' || c == ' ' || c == '\t') break;
+        ++we;
+      }
+
+      // Build a trial buffer = current line + (space if needed) + word
+      char trial[LINEBUF_MAX];
+      // start with existing line
+      size_t tlen = 0;
+      for (size_t q = 0; q < lineLen && tlen + 1 < LINEBUF_MAX; ++q) trial[tlen++] = lineBuf[q];
+
+      if (!firstWord && tlen + 1 < LINEBUF_MAX) trial[tlen++] = ' ';
+      // append word (without CR)
+      for (size_t q = ws; q < we && tlen + 1 < LINEBUF_MAX; ++q) {
+        char c = str[q];
+        if (c == '\r') continue;
+        trial[tlen++] = c;
+      }
+      trial[tlen] = '\0';
+
+      if (fits_width(trial)) {
+        // Accept whole word
+        memcpy(lineBuf, trial, tlen + 1);
+        lineLen = tlen;
+        lineEndOriginal = we;
+
+        // Advance scan to after this word and skip trailing whitespace (except newline)
+        scan = we;
+        while (scan < n) {
+          char c = str[scan];
+          if (c == '\r' || c == ' ' || c == '\t') {
+            ++scan;
+            continue;
+          }
+          break;
+        }
+        firstWord = false;
+        continue;
+      } else {
+        // Word doesn't fit. If it's the first on the line, split it by characters to the max width.
+        if (firstWord) {
+          // Try to add as many characters from [ws,we) as fit.
+          size_t best = 0;
+          // We'll grow trial one character at a time (still efficient for tiny lines on
+          // microcontrollers).
+          for (size_t take = 1; ws + take <= we; ++take) {
+            // trial = (line is empty, maybe) + first 'take' chars of the word
+            tlen = 0;
+            if (!firstWord && tlen + 1 < LINEBUF_MAX) trial[tlen++] = ' ';
+            for (size_t q = ws; q < ws + take && tlen + 1 < LINEBUF_MAX; ++q) {
+              char c = str[q];
+              if (c == '\r') continue;
+              trial[tlen++] = c;
+            }
+            trial[tlen] = '\0';
+            if (fits_width(trial))
+              best = take;
+            else
+              break;
+          }
+          if (best > 0) {
+            // Commit the partial word
+            tlen = 0;
+            if (!firstWord && tlen + 1 < LINEBUF_MAX) trial[tlen++] = ' ';
+            for (size_t q = ws; q < ws + best && tlen + 1 < LINEBUF_MAX; ++q) {
+              char c = str[q];
+              if (c == '\r') continue;
+              trial[tlen++] = c;
+            }
+            trial[tlen] = '\0';
+            memcpy(lineBuf, trial, tlen + 1);
+            lineLen = tlen;
+            lineEndOriginal = ws + best;
+          }
+        }
+        // Finish this line (either we split first word or nothing else fits)
+        break;
+      }
+    }
+
+    // If nothing fit (extremely narrow width), try to place at least one printable char
+    if (lineLen == 0) {
+      if (i < n && str[i] != '\n') {
+        // try the next non-CR char only
+        char one[2] = {0, 0};
+        size_t j = i;
+        while (j < n && str[j] == '\r') ++j;
+        if (j < n && str[j] != '\n') {
+          one[0] = str[j];
+          if (!limitWidth || fits_width(one)) {
+            lineBuf[0] = one[0];
+            lineBuf[1] = '\0';
+            lineLen = 1;
+            lineEndOriginal = j + 1;
+          }
+        }
+      }
+      if (lineLen == 0) break;  // truly nothing can be printed
+    }
+
+    // Print the built line
+    u8g2.setCursor(x, baselineY);
+    u8g2.print(lineBuf);
+
+    if (lineLen > 0) {
+      lastPrintedIdx = lineEndOriginal - 1;
+      printedAnything = true;
+    }
+
+    // Advance source index to just after what we printed
+    i = lineEndOriginal;
+    // Consume a hard newline if it's next
+    if (i < n && str[i] == '\n') ++i;
+  }
+
+  return printedAnything ? (lastPrintedIdx + 1) : 0;
+}

--- a/src/vario/ui/display/utils.h
+++ b/src/vario/ui/display/utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <stddef.h>
+#include <cstdint>
+
+size_t printMultiLine(const char* str, int16_t x, int16_t y, uint16_t width = 0,
+                      uint16_t height = 0);


### PR DESCRIPTION
Currently, any text longer than a single line gets cut off on the fatal error screen, and this usually hides some of the most important information from the user until they can retrieve the text file written to the SD card.  This PR fixes this problem by adding a multi-line display printer with word wrapping, and using that to print the fatal error message text.

This PR also fixes some fatal error messages so that they will print correctly (c_str) and provide numerical enum values if/when there is no string.

Tested by intentionally introducing a fatal error with very long text and observing its behavior.  Tested 5fcae78e30b6bf738f02074389b82f1c5baf1bd9 with the standard test procedure.  leaf_3_2_7_release on 3.2.7+radio