### PR TITLE
Convert AHT20 into a state machine

### DIFF
--- a/src/vario/comms/udp_message_server.cpp
+++ b/src/vario/comms/udp_message_server.cpp
@@ -136,13 +136,13 @@ void UDPMessageServer::onComment(const char* line, size_t len) {
 void UDPMessageServer::onCommand(const char* line, size_t len) {
   if (equals_const(line, len, "!Disconnect sensors")) {
     Serial.println("Disconnecting HW sensors via UDP");
-    AHT20::getInstance().stopPublishing();
+    aht20.stopPublishing();
     ICM20948::getInstance().stopPublishing();
     lc86g.stopPublishing();
     ms5611.stopPublishing();
   } else if (equals_const(line, len, "!Reconnect sensors")) {
     Serial.println("Reconnecting HW sensors via UDP");
-    AHT20::getInstance().publishTo(bus_);
+    aht20.publishTo(bus_);
     ICM20948::getInstance().publishTo(bus_);
     lc86g.publishTo(bus_);
     ms5611.publishTo(bus_);

--- a/src/vario/hardware/aht20.cpp
+++ b/src/vario/hardware/aht20.cpp
@@ -3,6 +3,9 @@
 #include "diagnostics/fatal_error.h"
 #include "dispatch/message_types.h"
 #include "hardware/Leaf_I2C.h"
+#include "utils/magic_enum.h"
+
+AHT20 aht20;
 
 #define DEBUG_TEMPRH 0  // flag for outputting debugf messages on UBS serial port
 
@@ -16,107 +19,154 @@ enum registers {
   sfe_aht20_reg_measure = 0xAC,
 };
 
-void AHT20::init() {
-  bool success = true;
+void AHT20::beginInit() {
+  assertState("AHT20::beginInit", State::Uninitialized);
 
   if (!isConnected()) {
     fatalError("AHT20 temp humidity sensor not found (isConnected is false)");
-  } else {
-    if (DEBUG_TEMPRH) Serial.println("Temp_RH - AHT20 Temp Humidity sensor FOUND!");
-
-    // Wait 40 ms after power-on before reading temp or humidity. Datasheet pg 8
-    delay(40);
-
-    // Check if the calibrated bit is set. If not, init the sensor.
-    if (!isCalibrated()) {
-      // Send 0xBE0800
-      initialize();
-
-      // Immediately trigger a measurement. Send 0xAC3300
-      triggerMeasurement();
-
-      delay(75);  // Wait for measurement to complete
-
-      uint8_t counter = 0;
-      while (isBusy()) {
-        delay(1);
-        if (counter++ > 100) {
-          // Give up after 100ms
-          fatalError(
-              "AHT20 initialization failure: initial measurement did not complete after 175ms");
-        }
-      }
-
-      // This calibration sequence is not completely proven. It's not clear how and when the cal bit
-      // clears This seems to work but it's not easily testable
-      if (!isCalibrated()) {
-        fatalError(
-            "AHT20 initialization failure: device indicates not calibrated after calibration and "
-            "initial measurement");
-      }
-    }
-
-    // Mark all datums as fresh (not read before)
-    sensorQueried_.temperature = true;
-    sensorQueried_.humidity = true;
-
-    // Get a fresh initial measurement
-    update();
-    delay(100);
-    update();
   }
 
-  if (DEBUG_TEMPRH) {
-    Serial.println("Temp_RH - SUCCESS: AHT20 Temp Humidity sensor calibrated!");
+  if (DEBUG_TEMPRH) Serial.println("Temp_RH - AHT20 Temp Humidity sensor FOUND!");
+
+  // Wait 40 ms after power-on before reading temp or humidity. Datasheet pg 8
+  tLastAction_ = millis();
+  state_ = State::WaitingForPowerOn;
+}
+
+void AHT20::waitForPowerOn() {
+  assertState("AHT20::waitForPowerOn", State::WaitingForPowerOn);
+
+  if (millis() - tLastAction_ < 40) {
+    return;
+  }
+
+  // Check if the calibrated bit is set. If not, init the sensor.
+  if (!isCalibrated()) {
+    // Send 0xBE0800
+    initialize();
+
+    // Immediately trigger a measurement.
+    triggerMeasurement(State::WaitingForCalMeasurement, State::WaitingForPowerOn);
+    return;
+  }
+
+  startFirstMeasurement();
+}
+
+void AHT20::waitForCalMeasurement() {
+  assertState("AHT20::waitForCalMeasurement", State::WaitingForCalMeasurement);
+
+  if (millis() - tLastAction_ < 75) {
+    return;
+  }
+
+  if (!isBusy()) {
+    // This calibration sequence is not completely proven. It's not clear how and when the cal bit
+    // clears This seems to work but it's not easily testable
+    if (!isCalibrated()) {
+      fatalError(
+          "AHT20 initialization failure: device indicates not calibrated after calibration and "
+          "initial measurement");
+    }
+    startFirstMeasurement();
+    return;
+  }
+
+  if (millis() - tLastAction_ > 175) {
+    // Give up after 100ms
+    fatalError("AHT20 initialization failure: initial measurement did not complete after 175ms");
+  }
+}
+
+void AHT20::startFirstMeasurement() {
+  assertState("AHT20::startFirstMeasurement", State::WaitingForPowerOn,
+              State::WaitingForCalMeasurement);
+
+  // Get a fresh initial measurement
+  dtMeasurement_ = 100;  // Wait 100ms for first measurement
+  triggerMeasurement(State::WaitingForInitialMeasurement, State::Uninitialized);
+  if (state_ == State::Uninitialized) {
+    fatalError("AHT20 first measurement could not be started");
   }
 }
 
 const unsigned long MEASUREMENT_PERIOD_MS = 75;
 
-// don't call more often than every 1-2 seconds, or sensor will heat up slightly above
-// ambient
 void AHT20::update() {
-  if (!currentlyMeasuring_) {
-    // measurements must first be triggered, then >75ms later can be read
-    triggerMeasurement();  // if we haven't yet processed a prior measurement, don't
-                           // trigger a new one
-    measurementInitiated_ = millis();
-    currentlyMeasuring_ = true;
-  } else if (millis() - measurementInitiated_ > MEASUREMENT_PERIOD_MS && !isBusy()) {
-    readData();
-    float temperature = ((float)sensorData_.temperature / 1048576) * 200 - 50;
-    temperature += TEMP_OFFSET;
-    float rh = ((float)sensorData_.humidity / 1048576) * 100;
-    currentlyMeasuring_ = false;
-    if (DEBUG_TEMPRH) {
-      Serial.print("Temp_RH - Temp: ");
-      Serial.print(temperature);
-      Serial.print("  Humidity: ");
-      Serial.println(rh);
-    }
-    etl::imessage_bus* bus = bus_;
-    if (bus) {
-      bool sane = true;
-      if (isnan(temperature) | isinf(temperature) || temperature < -90 || temperature > 180) {
-        char msg[100];
-        snprintf(msg, sizeof(msg), "AHT20 invalid temp %X", sensorData_.temperature);
-        Serial.println(msg);
-        bus->receive(CommentMessage(msg));
-        sane = false;
-      }
-      if (isnan(rh) || isinf(rh) || rh < 0 || rh > 100) {
-        char msg[100];
-        snprintf(msg, sizeof(msg), "AHT20 invalid RH %X", sensorData_.humidity);
-        Serial.println(msg);
-        bus->receive(CommentMessage(msg));
-        sane = false;
-      }
-      if (sane) {
-        bus->receive(AmbientUpdate(temperature, rh));
-      }
-    }
+  if (state_ == State::Uninitialized) {
+    beginInit();
+  } else if (state_ == State::WaitingForPowerOn) {
+    waitForPowerOn();
+  } else if (state_ == State::WaitingForCalMeasurement) {
+    waitForCalMeasurement();
+  } else if (state_ == State::WaitingForInitialMeasurement) {
+    completeMeasurement();
+  } else if (state_ == State::Idle) {
+    maybeTriggerMeasurement();
+  } else if (state_ == State::Measuring) {
+    completeMeasurement();
   } else {
+    fatalError("AHT20::update with unsupported state %s (%u)", nameOf(state_).c_str(), state_);
+  }
+}
+
+void AHT20::maybeTriggerMeasurement() {
+  assertState("AHT20::maybeTriggerMeasurement", State::Idle);
+
+  // don't call more often than every 1-2 seconds, or sensor will heat up slightly above
+  // ambient
+  if (millis() - tLastAction_ > 1000) {
+    dtMeasurement_ = MEASUREMENT_PERIOD_MS;
+    triggerMeasurement(State::Measuring, State::Idle);
+  }
+}
+
+void AHT20::completeMeasurement() {
+  assertState("AHT20::completeMeasurement", State::Measuring, State::WaitingForInitialMeasurement);
+
+  if (millis() - tLastAction_ <= dtMeasurement_) {
+    return;
+  }
+  if (isBusy()) {
     if (DEBUG_TEMPRH) Serial.println("Temp_RH - missed values due to sensor busy");
+    return;
+  }
+
+  SensorData sensorData;
+  if (!readData(sensorData)) {
+    Serial.println("Temp_RH did not successfully readData");
+    return;
+  }
+  float temperature = ((float)sensorData.temperature / 1048576) * 200 - 50;
+  temperature += TEMP_OFFSET;
+  float rh = ((float)sensorData.humidity / 1048576) * 100;
+  state_ = State::Idle;
+  if (DEBUG_TEMPRH) {
+    Serial.print("Temp_RH - Temp: ");
+    Serial.print(temperature);
+    Serial.print("  Humidity: ");
+    Serial.println(rh);
+  }
+  etl::imessage_bus* bus = bus_;
+  if (bus) {
+    bool sane = true;
+    if (isnan(temperature) | isinf(temperature) || temperature < -90 || temperature > 180) {
+      char msg[100];
+      snprintf(msg, sizeof(msg), "AHT20 invalid temp %X", sensorData.temperature);
+      Serial.println(msg);
+      bus->receive(CommentMessage(msg));
+      sane = false;
+    }
+    if (isnan(rh) || isinf(rh) || rh < 0 || rh > 100) {
+      char msg[100];
+      snprintf(msg, sizeof(msg), "AHT20 invalid RH %X", sensorData.humidity);
+      Serial.println(msg);
+      bus->receive(CommentMessage(msg));
+      sane = false;
+    }
+    if (sane) {
+      bus->receive(AmbientUpdate(temperature, rh));
+    }
   }
 }
 
@@ -127,58 +177,42 @@ bool AHT20::softReset() {
   return false;
 }
 
-bool AHT20::available() {
-  if (!measurementStarted_) {
-    triggerMeasurement();
-    measurementStarted_ = true;
-    return (false);
+bool AHT20::readData(SensorData& sensorData) {
+  sensorData.humidity = 0;
+  sensorData.temperature = 0;
+
+  if (Wire.requestFrom(ADDR_AHT20, (uint8_t)6) <= 0) {
+    return false;
   }
 
-  if (isBusy()) {
-    return (false);
-  }
+  Wire.read();  // Read and discard state
 
-  readData();
-  measurementStarted_ = false;
-  return (true);
+  uint32_t incoming = 0;
+  incoming |= (uint32_t)Wire.read() << (8 * 2);
+  incoming |= (uint32_t)Wire.read() << (8 * 1);
+  uint8_t midByte = Wire.read();
+
+  incoming |= midByte;
+  sensorData.humidity = incoming >> 4;
+
+  sensorData.temperature = (uint32_t)midByte << (8 * 2);
+  sensorData.temperature |= (uint32_t)Wire.read() << (8 * 1);
+  sensorData.temperature |= (uint32_t)Wire.read() << (8 * 0);
+
+  // Need to get rid of data in bits > 20
+  sensorData.temperature = sensorData.temperature & ~(0xFFF00000);
+
+  return true;
 }
 
-void AHT20::readData() {
-  // Clear previous data
-  sensorData_.temperature = 0;
-  sensorData_.humidity = 0;
-
-  if (Wire.requestFrom(ADDR_AHT20, (uint8_t)6) > 0) {
-    Wire.read();  // Read and discard state
-
-    uint32_t incoming = 0;
-    incoming |= (uint32_t)Wire.read() << (8 * 2);
-    incoming |= (uint32_t)Wire.read() << (8 * 1);
-    uint8_t midByte = Wire.read();
-
-    incoming |= midByte;
-    sensorData_.humidity = incoming >> 4;
-
-    sensorData_.temperature = (uint32_t)midByte << (8 * 2);
-    sensorData_.temperature |= (uint32_t)Wire.read() << (8 * 1);
-    sensorData_.temperature |= (uint32_t)Wire.read() << (8 * 0);
-
-    // Need to get rid of data in bits > 20
-    sensorData_.temperature = sensorData_.temperature & ~(0xFFF00000);
-
-    // Mark data as fresh
-    sensorQueried_.temperature = false;
-    sensorQueried_.humidity = false;
-  }
-}
-
-bool AHT20::triggerMeasurement() {
+void AHT20::triggerMeasurement(State onSuccess, State onFailure) {
   Wire.beginTransmission(ADDR_AHT20);
   Wire.write(sfe_aht20_reg_measure);
   Wire.write((uint8_t)0x33);
   Wire.write((uint8_t)0x00);
-  if (Wire.endTransmission() == 0) return true;
-  return false;
+  bool success = Wire.endTransmission() == 0;
+  tLastAction_ = millis();
+  state_ = success ? onSuccess : onFailure;
 }
 
 bool AHT20::initialize() {
@@ -212,4 +246,8 @@ bool AHT20::isConnected() {
   if (Wire.endTransmission() == 0) return true;
 
   return false;
+}
+
+void AHT20::onUnexpectedState(const char* action, State actual) const {
+  fatalError("%s while %s (%u)", action, nameOf(actual).c_str(), actual);
 }

--- a/src/vario/main.cpp
+++ b/src/vario/main.cpp
@@ -59,7 +59,7 @@ void setup() {
 
   if (!settings.dev_startDisconnected) {
     Serial.println("Connecting hardware devices to bus");
-    AHT20::getInstance().publishTo(&bus);
+    aht20.publishTo(&bus);
     ICM20948::getInstance().publishTo(&bus);
     lc86g.publishTo(&bus);
     ms5611.publishTo(&bus);

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -147,8 +147,6 @@ void Power::initPeripherals() {
   Serial.println(" - Finished Baro");
   ICM20948::getInstance().init();
   Serial.println(" - Finished IMU");
-  AHT20::getInstance().init();
-  Serial.println(" - Finished Temp Humid");
 
   // then put devices to sleep if we're in PowerState::OffUSB
   // (plugged into USB but vario not actively turned on)

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -349,7 +349,7 @@ void TaskManager::doNecessaryTasks(void) {
     performTask.display = false;
   }
   if (performTask.tempRH) {
-    AHT20::getInstance().update();
+    aht20.update();
     performTask.tempRH = false;
   }
   if (performTask.sdCard) {


### PR DESCRIPTION
This PR makes the AHT20 class fully maintain its own state per #192.  This means the higher-level system does not need to decide when to `init` it and when to `update` it (implicitly maintaining/tracking an "initialized" state for aht20) -- instead, it just calls `update` and this results in initialization as needed.  One benefit of this approach is that all `delay` statements are removed which means the separate initialization steps could proceed in parallel with initialization of other devices.

Some slight behavior changes are made: before, the failure of certain operations was ignored whereas explicit action is now taken in those cases (readData, triggerMeasurement).

Another change in this PR is that the `getInstance()` pattern is replaced with a plain global `aht20` instance for the reasons mentioned in #219 and #222 (avoid delayed static initialization of the singleton in `getInstance()`).

Tested 2880a69bea6c8202c04d14b2c918165e2911709e using the standard test procedure, plus I manipulated the temperature and humidity and ensured the values changed on thermal_adv page.  leaf_3_2_7_release on 3.2.7+radio