### PR TITLE
Add Charge Current Monitor

### DIFF
--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -39,10 +39,12 @@ class Power {
     int8_t batteryPercent;  // battery percentage remaining from 0-100%
     uint16_t batteryMV;     // milivolts battery voltage (typically between 3200 and 4200)
     uint16_t batteryADC;    // ADC raw output from ESP32 input pin
+    uint16_t battMvCal;     // Calibrated battery voltage (milivolts)
     bool charging = false;  // if system is being charged or not
     bool USBinput = false;  // if system is plugged into USB power or not
     PowerState onState = PowerState::Off;
     PowerInputLevel inputCurrent = PowerInputLevel::i500mA;
+    uint16_t chargeCurrentMA;  // measured charge current in mA (if used -- versions 3.2.6+)
   };
 
   const Info& info() { return info_; }

--- a/src/vario/ui/display/pages/primary/page_charging.cpp
+++ b/src/vario/ui/display/pages/primary/page_charging.cpp
@@ -30,8 +30,29 @@ void chargingPage_draw() {
 
     display_batt_charging_fullscreen(48, 17);
 
+    // Battery Stats
+    u8g2.setFont(leaf_5x8);
+    uint8_t yPos = 124;
+    if (info.batteryPercent > 22) {
+      u8g2.setDrawColor(0);
+    } else {
+      u8g2.setDrawColor(1);
+      yPos = 35;
+    }
+    u8g2.setCursor(35, yPos);
+#ifdef ISET
+    u8g2.print(info.chargeCurrentMA);
+    u8g2.print("mA ");
+#endif
+    u8g2.setCursor(30, yPos + 10);
+    u8g2.print(info.battMvCal);
+    u8g2.print("mV");
+    u8g2.setDrawColor(1);
+
+    // Show Input Current limit (not actually charge current)
     u8g2.setFont(leaf_6x12);
-    u8g2.setCursor(5, 157);
+    u8g2.setCursor(10, 157);
+    u8g2.print("Input: ");
     if (info.inputCurrent == PowerInputLevel::i100mA)
       u8g2.print("100mA");
     else if (info.inputCurrent == PowerInputLevel::i500mA)
@@ -41,11 +62,7 @@ void chargingPage_draw() {
     else if (info.inputCurrent == PowerInputLevel::Standby)
       u8g2.print(" OFF");
 
-    u8g2.print(" ");
-    u8g2.print(info.batteryMV);
-    u8g2.print("mV");
-
-    // Display the current version
+    // Display the current SW version
     u8g2.setCursor(0, 172);
     u8g2.setFont(leaf_5x8);
     u8g2.print("v");

--- a/src/vario/ui/display/pages/primary/page_charging.cpp
+++ b/src/vario/ui/display/pages/primary/page_charging.cpp
@@ -52,7 +52,7 @@ void chargingPage_draw() {
     // Show Input Current limit (not actually charge current)
     u8g2.setFont(leaf_6x12);
     u8g2.setCursor(10, 157);
-    u8g2.print("Input: ");
+    u8g2.print("Limit: ");
     if (info.inputCurrent == PowerInputLevel::i100mA)
       u8g2.print("100mA");
     else if (info.inputCurrent == PowerInputLevel::i500mA)

--- a/src/vario/ui/display/pages/primary/page_debug.cpp
+++ b/src/vario/ui/display/pages/primary/page_debug.cpp
@@ -65,11 +65,15 @@ void debugPage_draw() {
     u8g2.print((float)info.batteryMV / 1000, 3);
     u8g2.print("v");
 
+    u8g2.setCursor(x, y += 10);
+    u8g2.print(info.chargeCurrentMA);
+    u8g2.print("mA");
+
     // Altimeter Setting
-    u8g2.setCursor(65, 26);
+    u8g2.setCursor(65, 36);
     u8g2.setFont(leaf_5h);
     u8g2.print("AltSet:");
-    u8g2.setCursor(65, 39);
+    u8g2.setCursor(65, 49);
     u8g2.setFont(leaf_6x12);
     u8g2.print(baro.altimeterSetting);
 

--- a/vario/hardware/hardware_changes.md
+++ b/vario/hardware/hardware_changes.md
@@ -7,6 +7,10 @@ Brief summary of hardware changes
 
 ## PCBA
 
+### v3.2.7
+This version is identical to v3.2.6, except the IO_expander address pins were incorrectly wired in v3.2.6.  This version fixes that.
++ IO Expander Address: IOEX_ADDR = 0x20 (same as v3.2.5)
+
 ### v3.2.6
 + Added 10pin connector for Sharp Memory-in-Pixel display
 + IMU rotated 90deg clockwise (+X is "forward" now)
@@ -59,6 +63,7 @@ Brief summary of hardware changes
 | B6 P16 |GPS_RESET   | N/C         |
 | B7 P17 |GPS_BAK_EN  | N/C         |
 
++ Note: IO Expander Address pins wired incorrectly, so IOEX_ADDR = 0x26 for this version (not 0x20 as in v3.2.5).
 
 ### v3.2.5
 
@@ -129,14 +134,18 @@ Chip is configured with I2C address: 0x20
 + 10-pin 64px wide LCD display
 
 ## Plastic Case
+### v3.2.7
++ Add notch for I2C connector (interferred with battery rib in case v3.2.6)
++ Adjust Caddy-to-Case clearance for non-painted parts, preparing for injection mold
++ Add draft angles on certain faces, preparing for injection mold
++ Adjust rubber switch cap design
+
 ### v3.2.6
-(These are all still TODO items)
 + Shrink Temp/Humidity isolation slot
 + Add button-protecting ribs
 + Solidify decision on PCB thickness and adjust for it
 + Move battery ribs to new PCB_v3.2.6 position
 + Make version for both with and without antenna
-+ Make version for Sharp Memory-in-pixel display
 + Increase caddy snap-angle to nearly 90deg
 + Adjust baseplate caddy for adjusted battery and slot positions
 


### PR DESCRIPTION
read ISET pin ADC and convert to actual charge current in mA.

Also add HW-calibrated ADC for battery voltage (but currently not acted upon; still using manual calibration curve.. Need to test and see if HW-calibration is more uniform across many devices before switching to use that value).