### PR TITLE
Simplify Speaker logic and reduce edge cases

### DIFF
--- a/src/vario/ui/audio/dynamic_effects.h
+++ b/src/vario/ui/audio/dynamic_effects.h
@@ -1,55 +1,33 @@
 #pragma once
 
-#define FX_NOTE_SAMPLE_COUNT 2  // number of samples to play per FX Note
+constexpr uint8_t FX_NOTE_SAMPLE_COUNT = 2;  // number of samples to play per FX Note
 
 // each "beep beep" cycle is a "measure", made up of play-length followed by rest-length, then
 // repeat
 
-// FOR APPROACH #2 (time-adjusted speaker timer)
 // CLIMB TONE DEFINITIONS
-// #define CLIMB_AUDIO_THRESHOLD  10 	// don't play unless climb rate is over this value (cm/s)
-#define CLIMB_MAX 800       // above this cm/s climb rate, note doesn't get higher
-#define CLIMB_NOTE_MIN 523  // min tone pitch in Hz for >0 climb
-#define CLIMB_NOTE_MAX \
-  1568  // max tone pitch in Hz for CLIMB_MAX (when vario peaks and starts holding a solid tone)
-#define CLIMB_NOTE_MAXMAX \
-  2093  // max tone pitch in Hz when vario is truly pegged, even in solid-tone mode
-#define CLIMB_PLAY_MAX 60   // 1200 	// ms play per measure (at min climb)
-#define CLIMB_PLAY_MIN 2    // 200   // ms play per measure (at max climb)
-#define CLIMB_REST_MAX 100  // 1000		// ms silence per measure (at min climb)
-#define CLIMB_REST_MIN 2    // 100		// ms silence per measure (at max climb)
+constexpr int32_t CLIMB_MAX = 800;       // above this cm/s climb rate, note doesn't get higher
+constexpr int32_t CLIMB_NOTE_MIN = 523;  // min tone pitch in Hz for >0 climb
+// max tone pitch in Hz for CLIMB_MAX (when vario peaks and starts holding a solid tone)
+constexpr int32_t CLIMB_NOTE_MAX = 1568;
+// max tone pitch in Hz when vario is truly pegged, even in solid-tone mode
+constexpr uint16_t CLIMB_NOTE_MAXMAX = 2093;
 
 // SINK TONE DEFINITIONS
-// #define SINK_ALARM           -200   // cm/s sink rate that triggers sink alarm audio
-#define SINK_MAX -800      // at this sink rate, tone doesn't get lower
-#define SINK_NOTE_MIN 392  // highest tone pitch for sink >  settings.vario_sinkAlarm
-#define SINK_NOTE_MAX \
-  196  // lowest tone pitch for sink @ SINK_MAX (when vario bottoms out and starts holding a solid
-       // tone)
-#define SINK_NOTE_MAXMAX \
-  131  // bottom tone pitch for sink (when vario is truly pegged, even in solid tone mode)
-
-#define SINK_PLAY_MIN 100  // 1200   // ms play per measure (at min sink)
-#define SINK_PLAY_MAX 2    // 2000 	// ms play per measure (at max sink)
-#define SINK_REST_MIN 100  // 1000		// silence samples (at min sink)
-#define SINK_REST_MAX 2    // 1000		// silence samples (at max sink)
+constexpr int32_t SINK_MAX = -800;      // at this sink rate, tone doesn't get lower
+constexpr int32_t SINK_NOTE_MIN = 392;  // highest tone pitch for sink >  settings.vario_sinkAlarm
+// lowest tone pitch for sink @ SINK_MAX (when vario bottoms out and starts holding a solid tone)
+constexpr int32_t SINK_NOTE_MAX = 196;
+// bottom tone pitch for sink (when vario is truly pegged, even in solid tone mode)
+constexpr uint16_t SINK_NOTE_MAXMAX = 131;
 
 // FOR APPROACH #1 (fixed sample-size length speaker timer)
-#define CLIMB_PLAY_SAMPLES_MAX 10
-#define CLIMB_PLAY_SAMPLES_MIN 1
-#define CLIMB_REST_SAMPLES_MAX 6
-#define CLIMB_REST_SAMPLES_MIN 1
+constexpr uint16_t CLIMB_PLAY_SAMPLES_MAX = 10;
+constexpr uint16_t CLIMB_PLAY_SAMPLES_MIN = 1;
+constexpr uint16_t CLIMB_REST_SAMPLES_MAX = 6;
+constexpr uint16_t CLIMB_REST_SAMPLES_MIN = 1;
 
-#define SINK_PLAY_SAMPLES_MIN 8  // play 8, rest 20, flytec 4030
-#define SINK_PLAY_SAMPLES_MAX 8
-#define SINK_REST_SAMPLES_MIN 20
-#define SINK_REST_SAMPLES_MAX 20
-
-// LiftyAir DEFINITIONS    (for air rising slower than your sinkrate, so net climbrate is negative,
-// but not as bad as it would be in still air)
-#define LIFTYAIR_TONE_MIN 180  // min pitch tone for lift air @ -(setting)m/s
-#define LIFTYAIR_TONE_MAX 150  // max pitch tone for lifty air @ .1m/s climb
-#define LIFTYAIR_PLAY 1        //
-#define LIFTYAIR_GAP 1
-#define LIFTYAIR_REST_MAX 20
-#define LIFTYAIR_REST_MIN 10
+constexpr int32_t SINK_PLAY_SAMPLES_MIN = 8;  // play 8, rest 20, flytec 4030
+constexpr int32_t SINK_PLAY_SAMPLES_MAX = 8;
+constexpr int32_t SINK_REST_SAMPLES_MIN = 20;
+constexpr int32_t SINK_REST_SAMPLES_MAX = 20;

--- a/src/vario/ui/audio/speaker.cpp
+++ b/src/vario/ui/audio/speaker.cpp
@@ -96,11 +96,6 @@ void Speaker::setVolume(SpeakerVolume volume, bool force) {
 
 void Speaker::playSound(sound_t sound) {
   assertState("Speaker::playSound", State::Uninitialized, State::Active);
-  if (speakerMute_) {
-    // Do not actually play sound
-    Serial.printf("%d playSound %d MUTED\n", millis(), sound);
-    return;
-  }
   Serial.printf("%d playSound %d\n", millis(), sound);
   soundPlaying_ = sound;
   playingSound_ = true;

--- a/src/vario/ui/audio/speaker.cpp
+++ b/src/vario/ui/audio/speaker.cpp
@@ -30,16 +30,17 @@ void Speaker::init(void) {
   if (!SPEAKER_VOLA_IOEX) pinMode(SPEAKER_VOLA, OUTPUT);
   if (!SPEAKER_VOLB_IOEX) pinMode(SPEAKER_VOLB, OUTPUT);
 
-  tLastUpdate_ = millis();
+  tLastUpdate_ = NOTE_DURATION_MS * (millis() / NOTE_DURATION_MS);
   state_ = State::Active;
-  setVolume(varioVolume_);
+  setVolume(varioVolume_, true);
 }
 
 void Speaker::mute() {
   assertState("Speaker::mute", State::Uninitialized, State::Active);
-  updateVarioNote(0);  // ensure we clear vario note
+  playingSound_ = false;  // clear FX sound
+  updateVarioNote(0);     // clear vario note
   if (state_ != State::Uninitialized) {
-    ledcWriteTone(SPEAKER_PIN, 0);  // mute speaker pin
+    playTone(0);  // mute speaker pin
   }
   speakerMute_ = true;
 }
@@ -59,8 +60,13 @@ void Speaker::setVolume(SoundChannel channel, SpeakerVolume volume) {
   }
 }
 
-void Speaker::setVolume(SpeakerVolume volume) {
+void Speaker::setVolume(SpeakerVolume volume, bool force) {
   assertState("Speaker::setVolume", State::Active);
+
+  if (currentVolume_ == volume && !force) {
+    // Already at specified volume; no need to change
+    return;
+  }
 
   // This routine isn't applicable for certain hardware variants
   if (SPEAKER_VOLA == NC || SPEAKER_VOLB == NC) return;
@@ -85,10 +91,16 @@ void Speaker::setVolume(SpeakerVolume volume) {
     default:
       fatalError("Speaker set to invalid volume %d", (uint8_t)volume);
   }
+  currentVolume_ = volume;
 }
 
 void Speaker::playSound(sound_t sound) {
   assertState("Speaker::playSound", State::Uninitialized, State::Active);
+  if (speakerMute_) {
+    // Do not actually play sound
+    Serial.printf("%d playSound %d MUTED\n", millis(), sound);
+    return;
+  }
   Serial.printf("%d playSound %d\n", millis(), sound);
   soundPlaying_ = sound;
   playingSound_ = true;
@@ -166,111 +178,123 @@ void Speaker::updateVarioNote(int32_t verticalRate) {
   varioRestSamples_ = newVarioRestSamples;
 }
 
-void Speaker::debugPrint() {
-  static int microsLast = 0;
-  static int millisLast = 0;
-
-  int timeNowMillis = millis();
-  int timeNowMicros = micros();
-
-  Serial.print(timeNowMillis);
-  Serial.print(" : ");
-  Serial.print(timeNowMillis - millisLast);
-  microsLast = timeNowMicros;
-  millisLast = timeNowMillis;
-
-  Serial.print("  SPKR UPDT -- Note: ");
-  Serial.print(varioNote_);
-  Serial.print(" Play: ");
-
-  Serial.print(varioPlaySamples_);
-
-  Serial.print(" Rest: ");
-  Serial.print(varioRestSamples_);
-  Serial.println(" !");
-}
-
 bool Speaker::update() {
   if (state_ == State::Uninitialized) {
     init();
-  } else if (state_ != State::Active) {
+  }
+  if (state_ != State::Active) {
     fatalError("Unsupported Speaker::update state %d (%u)", nameOf(state_).c_str(), state_);
   }
 
-  unsigned long tNow = millis();
-  if (tNow - tLastUpdate_ < NOTE_DURATION_MS - TIMING_TOLERANCE_MS) {
-    // Nothing to do yet; we need to wait longer.
-    // ...but return true if a sound is still playing
-    return playingSound_;
-  }
-  tLastUpdate_ += NOTE_DURATION_MS;
-
-  // only play sound if speaker is not muted
+  // If speaker is muted, ensure silence and don't play sound
   if (speakerMute_) {
+    playTone(0);
     return false;
   }
 
-  // prioritize sound effects from UI & Button etc before we get to vario beeps
-  // but only play soundFX if system volume is on
+  if (!shouldUpdate()) {
+    return playingSound_;
+  }
+
   if (playingSound_ && fxVolume_ != SpeakerVolume::Off) {
-    setVolume(fxVolume_);
-    if (*soundPlaying_ != note::END) {
-      if (*soundPlaying_ != fxNoteLast_) {
-        // only change pwm if it's a different note, otherwise we get a little audio blip between
-        // the same notes
-        ledcWriteTone(SPEAKER_PIN, *soundPlaying_);
-      }
-      fxNoteLast_ = *soundPlaying_;  // save last note
+    // prioritize sound effects from UI & Button etc before we get to vario beeps
+    // but only play soundFX if system volume is on
+    return updateSound();
 
-      // if we've played this note for enough samples
-      if (++fxSampleCount_ >= FX_NOTE_SAMPLE_COUNT) {
-        soundPlaying_++;
-        fxSampleCount_ = 0;  // and reset sample count
-      }
-      return true;
-
-    } else {  // Else, we're at END_OF_TONE
-      ledcWriteTone(SPEAKER_PIN, 0);
-      playingSound_ = false;
-      fxNoteLast_ = note::NONE;
-      setVolume(varioVolume_);  // return to vario volume in prep for beeps
-      return false;
-    }
-
-    // if there's a vario note to play, and the vario volume isn't zero
   } else if (varioNote_ != note::NONE && varioVolume_ != SpeakerVolume::Off) {
-    //  Handle the beeps and rests of a vario sound "measure"
-    if (betweenVarioBeeps_) {
-      ledcWriteTone(SPEAKER_PIN, 0);  // "play" silence since we're resting between beeps
+    // if there's a vario note to play, and the vario volume isn't zero
+    updateVario();
+    return false;
 
-      // stop playing rest if we've done it long enough
-      if (++varioRestSampleCount_ >= varioRestSamples_) {
-        varioRestSampleCount_ = 0;
-        varioNoteLast_ = note::NONE;
-        betweenVarioBeeps_ = false;  // next time through we want to play sound
-      }
-
-    } else {
-      if (varioNote_ != varioNoteLast_) {
-        // play the note, but only if different, otherwise we get a little audio blip between the
-        // same successive notes (happens when vario is pegged and there's no rest period between)
-        ledcWriteTone(SPEAKER_PIN, varioNote_);
-      }
-      varioNoteLast_ = varioNote_;
-
-      if (++varioPlaySampleCount_ >= varioPlaySamples_) {
-        varioPlaySampleCount_ = 0;
-        if (varioRestSamples_)
-          betweenVarioBeeps_ = true;  // next time through we want to play sound
-      }
-    }
   } else {
-    // play silence (if timer is configured for auto-reload, we have to do this here because
-    // sound_varioNote might have been set to 0 while we were beeping, and then we'll keep beeping)
-    ledcWriteTone(SPEAKER_PIN, 0);
+    // play silence
+    playTone(0);
   }
 
   return false;
+}
+
+bool Speaker::shouldUpdate() {
+  unsigned long tNow = millis();
+  // Nominally wait NOTE_DURATION_MS intervals between updates, but allow an update to happen up to
+  // TIMING_TOLERANCE_MS before its actual target time.  In diagrams below, NOTE_DURATION_MS
+  // intervals are |, tLastUpdate_ is x, tNow is y, and tLastUpdate_ should be updated to z.
+  // TIMING_TOLERANCE_MS is one character wide.
+  // x-------y-|---------|---------|---------| (no action)
+  // x--------y|---------z---------|---------|
+  // x---------y---------z---------|---------|
+  // x---------|y--------z---------|---------|
+  // x---------|-y-------z---------|---------|
+  // x---------|-------y-z---------|---------|
+  // x---------|--------y|---------z---------|
+  // x---------|---------y---------z---------|
+  // x---------|---------|y--------z---------|
+  // x---------|---------|-y-------z---------|
+
+  // n is the number of NOTE_DURATION_MS intervals that have elapsed, or almost elapsed, since
+  // tLastUpdate_
+  uint32_t n = (tNow + TIMING_TOLERANCE_MS - tLastUpdate_) / NOTE_DURATION_MS;
+  if (n == 0) {
+    // Nothing to do yet; we need to wait longer.
+    return false;
+  }
+  if (n >= 2) {
+    Serial.printf("Speaker::update skipped %d intervals\n", n - 1);
+  }
+  tLastUpdate_ += n * NOTE_DURATION_MS;
+  return true;
+}
+
+bool Speaker::updateSound() {
+  setVolume(fxVolume_);
+  if (*soundPlaying_ != note::END) {
+    playTone(*soundPlaying_);
+    fxNoteLast_ = *soundPlaying_;  // save last note
+
+    // if we've played this note for enough samples
+    if (++fxSampleCount_ >= FX_NOTE_SAMPLE_COUNT) {
+      soundPlaying_++;
+      fxSampleCount_ = 0;  // and reset sample count
+    }
+    return true;
+
+  } else {  // Else, we're at END_OF_TONE
+    playTone(0);
+    playingSound_ = false;
+    fxNoteLast_ = note::NONE;
+    return false;
+  }
+}
+
+void Speaker::updateVario() {
+  setVolume(varioVolume_);
+  //  Handle the beeps and rests of a vario sound "measure"
+  if (betweenVarioBeeps_) {
+    playTone(0);  // "play" silence since we're resting between beeps
+
+    // stop playing rest if we've done it long enough
+    if (++varioRestSampleCount_ >= varioRestSamples_) {
+      varioRestSampleCount_ = 0;
+      varioNoteLast_ = note::NONE;
+      betweenVarioBeeps_ = false;  // next time through we want to play sound
+    }
+
+  } else {
+    playTone(varioNote_);
+    varioNoteLast_ = varioNote_;
+
+    if (++varioPlaySampleCount_ >= varioPlaySamples_) {
+      varioPlaySampleCount_ = 0;
+      if (varioRestSamples_) betweenVarioBeeps_ = true;  // next time through we want to play sound
+    }
+  }
+}
+
+void Speaker::playTone(uint32_t freq) {
+  if (freq != lastTone_) {
+    ledcWriteTone(SPEAKER_PIN, freq);
+    lastTone_ = freq;
+  }
 }
 
 void Speaker::onUnexpectedState(const char* action, State actual) const {

--- a/src/vario/ui/audio/speaker.h
+++ b/src/vario/ui/audio/speaker.h
@@ -26,7 +26,8 @@ class Speaker : private StateAssertMixin<Speaker> {
 
   State state() const { return state_; }
 
-  // Cancel any sound playing and do not play any sounds until unmuted
+  // Cancel any sound playing and do not play any sounds until unmuted (though do play any sound
+  // "played" while muted as soon as Speaker is unMuted)
   void mute();
 
   // Resume normal sounds (previous volume levels, etc)


### PR DESCRIPTION
This PR attempts to "simplify" (often in the eye of the beholder) Speaker logic in an effort to reduce edge cases and make it easier to reason about what must (and must not) happen under various conditions.  One known issue these changes should address is fixing behavior when Speaker::update hasn't been called in a long time and is then called -- that logic is factored out into shouldUpdate and documented to hopefully be as clear as practical.  Conceptual subroutines of `update()` are broken out into actual subroutines to hopefully help make reason about behavior easier.

Many `#define`s are changed to stricter and more-inspectable `constexpr`s.  `tLastUpdate_` is constrained to always (according to intention) fall on a multiple of `NOTE_DURATION_MS`.  Hardware volume change is only performed when the volume actually needs to be changed.  `volatile` is removed as none of these variables were accessed in an ISR.

Tested 9ddb5420c3b51f83c5c0ef9e202619240b60625e with standard test procedure on leaf_3_2_7_release and 3.2.7+radio.  I also ran around after getting a GPS fix to hear vario noises and they seemed reasonable.