### PR TITLE
Ensure bus subscription succeeds

### DIFF
--- a/src/vario/comms/ble.h
+++ b/src/vario/comms/ble.h
@@ -2,11 +2,12 @@
 
 #include <NimBLEDevice.h>
 #include "TinyGPSPlus.h"
+
+#include "dispatch/message_sink.h"
 #include "dispatch/message_types.h"
-#include "etl/message_router.h"
 
 // FreeRTOS Task for handling Bluetooth Operations
-class BLE : public etl::message_router<BLE, GpsMessage, FanetPacket> {
+class BLE : public MessageSink<BLE, GpsMessage, FanetPacket> {
  public:
   static BLE& get();
 
@@ -22,10 +23,9 @@ class BLE : public etl::message_router<BLE, GpsMessage, FanetPacket> {
   /// @brief ends the service, tears down bluetooth resources
   void end();
 
-  // On Receive handlers for the message router.
+  // MessageSink<BLE, GpsMessage, FanetPacket>
   void on_receive(const GpsMessage& msg);
   void on_receive(const FanetPacket& msg);
-
   void on_receive_unknown(const etl::imessage& msg) {}
 
  private:
@@ -34,8 +34,7 @@ class BLE : public etl::message_router<BLE, GpsMessage, FanetPacket> {
         pService(nullptr),
         pCharacteristic(nullptr),
         pAdvertising(nullptr),
-        started(false),
-        message_router(0) {}
+        started(false) {}
 
   bool started;  // Bluetooth advertising started
 

--- a/src/vario/comms/fanet_radio.cpp
+++ b/src/vario/comms/fanet_radio.cpp
@@ -240,8 +240,14 @@ void FanetRadio::setupFanetHandler() {
 }
 
 void FanetRadio::subscribe(etl::imessage_bus* bus) {
-  bus->subscribe(*this);
-  bus->subscribe(neighbors);  // Subscribe the neighbors to any FanetPacket updates
+  if (!bus->subscribe(*this)) {
+    fatalError("FanetRadio couldn't subscribe to message bus");
+  };
+
+  // Subscribe the neighbors to any FanetPacket updates
+  if (!bus->subscribe(neighbors)) {
+    fatalError("FanetRadio couldn't subscribe neighbors to message bus");
+  }
 }
 
 void FanetRadio::setup() {

--- a/src/vario/diagnostics/buttons.h
+++ b/src/vario/diagnostics/buttons.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include "etl/message_bus.h"
-
+#include "dispatch/message_sink.h"
 #include "dispatch/message_types.h"
 
-class ButtonMonitor : public etl::message_router<ButtonMonitor, ButtonEventMessage> {
+class ButtonMonitor : public MessageSink<ButtonMonitor, ButtonEventMessage> {
  public:
-  void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
-
-  // etl::message_router<ButtonMonitor, ButtonEventMessage>
+  // MessageSink<ButtonMonitor, ButtonEventMessage>
   void on_receive(const ButtonEventMessage& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
 };

--- a/src/vario/dispatch/message_sink.h
+++ b/src/vario/dispatch/message_sink.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "etl/message_bus.h"
+
+#include "diagnostics/fatal_error.h"
+
+template <typename TDerived, typename... TMessageTypes>
+class MessageSink : public etl::message_router<TDerived, TMessageTypes...> {
+ public:
+  // Subscribe to messages from the specified bus.
+  void subscribeTo(etl::imessage_bus* bus) {
+    bool success = bus->subscribe(*this);
+    if (!success) {
+      fatalError("Message bus subscription failed");
+    }
+  }
+};

--- a/src/vario/instruments/ambient.h
+++ b/src/vario/instruments/ambient.h
@@ -1,18 +1,14 @@
 #pragma once
 
-#include "etl/message_bus.h"
-
+#include "dispatch/message_sink.h"
 #include "dispatch/message_types.h"
 #include "utils/state_assert_mixin.h"
 
-class Ambient : public etl::message_router<Ambient, AmbientUpdate>,
-                private StateAssertMixin<Ambient> {
+class Ambient : public MessageSink<Ambient, AmbientUpdate>, private StateAssertMixin<Ambient> {
  public:
   enum class State : uint8_t { NoData, Ready, Stale };
 
   State state() const;
-
-  void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
 
   // Get the most recent temperature in degrees Celsius
   float temp() const;
@@ -20,7 +16,7 @@ class Ambient : public etl::message_router<Ambient, AmbientUpdate>,
   // Get the most recent relative humidity in percent
   float humidity() const;
 
-  // etl::message_router<Ambient, AmbientUpdate>
+  // MessageSink<Ambient, AmbientUpdate>
   void on_receive(const AmbientUpdate& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
 

--- a/src/vario/instruments/baro.h
+++ b/src/vario/instruments/baro.h
@@ -6,8 +6,8 @@
 #pragma once
 
 #include <Arduino.h>
-#include "etl/message_bus.h"
 
+#include "dispatch/message_sink.h"
 #include "dispatch/message_source.h"
 #include "dispatch/message_types.h"
 #include "hardware/power_control.h"
@@ -21,7 +21,7 @@
 
 // Barometer reporting altitude, adjusted altitude, climb rate, and other information.
 // Requires a pressure source.
-class Barometer : public etl::message_router<Barometer, PressureUpdate>,
+class Barometer : public MessageSink<Barometer, PressureUpdate>,
                   public IMessageSource,
                   public IPowerControl,
                   private StateAssertMixin<Barometer> {
@@ -30,9 +30,7 @@ class Barometer : public etl::message_router<Barometer, PressureUpdate>,
 
   State state() const { return state_; }
 
-  void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
-
-  // etl::message_router<Barometer, PressureUpdate>
+  // MessageSink<Barometer, PressureUpdate>
   void on_receive(const PressureUpdate& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
 

--- a/src/vario/instruments/gps.h
+++ b/src/vario/instruments/gps.h
@@ -18,6 +18,7 @@
 #define gps_h
 
 #include <TinyGPSPlus.h>
+#include "dispatch/message_sink.h"
 #include "dispatch/message_source.h"
 #include "dispatch/message_types.h"
 #include "etl/message_bus.h"
@@ -49,9 +50,7 @@ struct NMEASentenceContents {
 
 // enum time_formats {hhmmss, }
 
-class LeafGPS : public TinyGPSPlus,
-                IMessageSource,
-                public etl::message_router<LeafGPS, GpsMessage> {
+class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, GpsMessage> {
  public:
   LeafGPS();
 
@@ -63,11 +62,9 @@ class LeafGPS : public TinyGPSPlus,
   void publishTo(etl::imessage_bus* bus) { bus_ = bus; }
   void stopPublishing() { bus_ = nullptr; }
 
-  // etl::message_router<LeafGPS, GpsMessage>
+  // MessageSink<LeafGPS, GpsMessage>
   void on_receive(const GpsMessage& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
-
-  void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
 
   // Gets a calendar time from GPS in UTC time.
   // See references such as https://en.cppreference.com/w/c/chrono/strftime

--- a/src/vario/instruments/imu.h
+++ b/src/vario/instruments/imu.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <Arduino.h>
-#include "etl/message_bus.h"
 
+#include "dispatch/message_sink.h"
 #include "dispatch/message_source.h"
 #include "dispatch/message_types.h"
 #include "math/kalman.h"
@@ -10,15 +10,13 @@
 #define POSITION_MEASURE_STANDARD_DEVIATION 0.1f
 #define ACCELERATION_MEASURE_STANDARD_DEVIATION 0.3f
 
-class IMU : public etl::message_router<IMU, MotionUpdate>, public IMessageSource {
+class IMU : public MessageSink<IMU, MotionUpdate>, public IMessageSource {
  public:
   IMU();
 
   void wake();
 
-  void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
-
-  // etl::message_router<IMU, MotionUpdate>
+  // MessageSink<IMU, MotionUpdate>
   void on_receive(const MotionUpdate& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
 

--- a/src/vario/main.cpp
+++ b/src/vario/main.cpp
@@ -71,7 +71,7 @@ void setup() {
   udpMessageServer.publishTo(&bus);
 #endif
 
-  baro.subscribe(&bus);
+  baro.subscribeTo(&bus);
   baro.publishTo(&bus);
 
   // Initialize anything left over on the Task Manager System
@@ -87,25 +87,23 @@ void setup() {
   }
 
   // Connect GPS instrument to message bus sourcing lines of text that should be NMEA sentences
-  gps.subscribe(&bus);
+  gps.subscribeTo(&bus);
   // Publish parsed GPS messages to message bus
   gps.publishTo(&bus);
 
   // Connect ambient environment instrument to message bus sourcing ambient environment updates
-  ambient.subscribe(&bus);
+  ambient.subscribeTo(&bus);
 
   // Connect IMU instrument to message bus sourcing motion updates
-  imu.subscribe(&bus);
+  imu.subscribeTo(&bus);
   imu.publishTo(&bus);
 
-  windEstimator.subscribe(&bus);
+  windEstimator.subscribeTo(&bus);
 
-  // Subscribe modules that need bus updates.
-  // This should not exceed the bus router limit.
-  bus.subscribe(BLE::get());
+  BLE::get().subscribeTo(&bus);
 
-  buttonMonitor.subscribe(&bus);
-  buttonDispatcher.subscribe(&bus);
+  buttonMonitor.subscribeTo(&bus);
+  buttonDispatcher.subscribeTo(&bus);
 
   // Provide bus logger access to the bus
   busLog.setBus(&bus);

--- a/src/vario/ui/input/button_dispatcher.h
+++ b/src/vario/ui/input/button_dispatcher.h
@@ -1,18 +1,16 @@
 #pragma once
 
 #include <Arduino.h>
-#include "etl/message_bus.h"
 
+#include "dispatch/message_sink.h"
 #include "dispatch/message_types.h"
 #include "hardware/configuration.h"
 
 /// @brief Listens for button events on the message bus and then dispatches them to the appropriate
 /// UI element.
-class ButtonDispatcher : public etl::message_router<ButtonDispatcher, ButtonEventMessage> {
+class ButtonDispatcher : public MessageSink<ButtonDispatcher, ButtonEventMessage> {
  public:
-  void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
-
-  // etl::message_router<ButtonDispatcher, ButtonEventMessage>
+  // MessageSink<ButtonDispatcher, ButtonEventMessage>
   void on_receive(const ButtonEventMessage& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
 };

--- a/src/vario/wind_estimate/wind_estimate.h
+++ b/src/vario/wind_estimate/wind_estimate.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "dispatch/message_sink.h"
 #include "instruments/gps.h"
 
 // bin definitions for storing sample points
@@ -54,11 +55,9 @@ struct WindEstimate {
   bool validEstimate = false;
 };
 
-class WindEstimator : public etl::message_router<WindEstimator, GpsReading> {
+class WindEstimator : public MessageSink<WindEstimator, GpsReading> {
  public:
-  void subscribe(etl::imessage_bus* bus) { bus->subscribe(*this); }
-
-  // etl::message_router<WindEstimator, GpsReading>
+  // MessageSink<WindEstimator, GpsReading>
   void on_receive(const GpsReading& msg);
   void on_receive_unknown(const etl::imessage& msg) {}
 


### PR DESCRIPTION
Currently, there are many places we subscribe a message router to a message bus but do not check the return value.  Therefore, the subscription could fail (perhaps due to too many receivers) and we would never know.  This PR hopefully fixes that by creating a MessageSink intermediary class that all of our message routers except FanetRadio are changed to (MessageSink inherits etl::message_router).  MessageSink presents a unified `subscribeTo` method which checks the success of subscription to the message bus and raises a fatalError if it fails.  If/when that happens, the backtrace should clearly show which consumer subscription failed.