### PR TITLE
Remove weAreFlying, Improve AutoStop Detection

### DIFF
--- a/src/vario/logging/log.h
+++ b/src/vario/logging/log.h
@@ -12,10 +12,10 @@
 #define AUTO_START_MIN_SEC 3    // seconds above the min speed to auto-start
 #define AUTO_START_MIN_ALT 500  // cm altitude change for timer auto-start
 
-#define AUTO_STOP_MAX_SPEED 3   // mph max -- must be below this speed for timer to auto-stop
-#define AUTO_STOP_MAX_ACCEL 10  // Max accelerometer signal
-#define AUTO_STOP_MAX_ALT 200   // cm altitude change for timer auto-stop
-#define AUTO_STOP_MIN_SEC 10    // seconds of low speed / low accel for timer to auto-stop
+#define AUTO_STOP_MAX_SPEED 3     // mph max -- must be below this speed for timer to auto-stop
+#define AUTO_STOP_MAX_ACCEL 0.2f  // Max accelerometer signal (m/s^2) to consider "not moving"
+#define AUTO_STOP_MAX_ALT 100     // cm altitude change for timer auto-stop
+#define AUTO_STOP_MIN_SEC 20      // seconds of low speed / low accel for timer to auto-stop
 
 // Main Log functions
 void log_update(void);  // Update function to run every second
@@ -49,8 +49,5 @@ bool flightTimer_autoStop(void);
 
 // Returns if we should stop recording a flight based on idle-ness
 bool flightTimer_autoStart(void);
-
-// check if we're flying (used for functions that should only work in-flight, like wind estimates)
-bool getAreWeFlying(void);
 
 extern FlightStats logbook;

--- a/src/vario/ui/audio/speaker.cpp
+++ b/src/vario/ui/audio/speaker.cpp
@@ -280,7 +280,7 @@ void Speaker::updateVario() {
 
     if (++varioPlaySampleCount_ >= varioPlaySamples_) {
       varioPlaySampleCount_ = 0;
-      if (varioRestSamples_) betweenVarioBeeps_ = true;  // next time through we want to play sound
+      if (varioRestSamples_) betweenVarioBeeps_ = true;  // next time through we want to rest
     }
   }
 }

--- a/src/vario/wind_estimate/wind_estimate.cpp
+++ b/src/vario/wind_estimate/wind_estimate.cpp
@@ -36,7 +36,7 @@ void WindEstimator::on_receive(const GpsReading& msg) {
     GroundVelocity v = {.trackAngle = (float)(DEG_TO_RAD * gps.course.deg()),
                         .speed = (float)gps.speed.mps()};
 
-    if (getAreWeFlying()) submitVelocityForWindEstimate(v);
+    if (flightTimer_isRunning()) submitVelocityForWindEstimate(v);
   }
 }
 


### PR DESCRIPTION
remove parallel 'we are flying' state variable and instead just use the timer_running state

improve auto-stop detection and further condition it on a calm IMU accel value

This should fix the issue of unexpected speaker and wind_estimate behavior based on the weAreFlying state variable. Also should limit the number of false positives of AutoStop