### PR TITLE
Timer AutoStop Alert Dialog

### DIFF
--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -14,6 +14,7 @@
 #include "storage/sd_card.h"
 #include "ui/audio/sound_effects.h"
 #include "ui/audio/speaker.h"
+#include "ui/display/pages/dialogs/page_alert_timerAutoStop.h"
 #include "ui/display/pages/fanet/page_fanet_stats.h"
 #include "ui/settings/settings.h"
 #include "utils/string_utils.h"
@@ -32,6 +33,9 @@ Igc igcFlight;
 
 // used to keep track of current flight statistics
 FlightStats logbook;
+
+// Alert page to warn if auto-stop is about to occur
+PageAlertTimerAutoStop pageAlertTimerAutoStop;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // UPDATE - Main function to run every second
@@ -157,6 +161,10 @@ bool flightTimer_autoStop() {
 
     // if all three conditions are met, increment the counter
     autoStopCounter++;
+    // alert the user if we've been in this state for a little while and are about to stop
+    if (autoStopCounter >= AUTO_STOP_MIN_SEC / 2) {
+      pageAlertTimerAutoStop.show();
+    }
     // and check if we've been in this state long enough to trigger auto-stop
     if (autoStopCounter >= AUTO_STOP_MIN_SEC) {
       autoStopCounter = 0;  // reset counter for next time
@@ -170,6 +178,15 @@ bool flightTimer_autoStop() {
   }
   return false;
 }
+
+uint8_t flightTimer_getAutoStopCountRemaining() {
+  if (autoStopCounter)
+    return AUTO_STOP_MIN_SEC - autoStopCounter;
+  else
+    return 0;
+}
+
+void flightTimer_resetAutoStop() { autoStopCounter = 0; }
 
 //////////////////////////////////////////////////////////////////////////////////
 // FLight Timer Management Functions

--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -49,10 +49,10 @@ void log_update() {
       // Otherwise, there's nothing to do here.
       return;
     }
-    // Check auto-stop criteria if we ARE flying
+    // Check auto-stop criteria if we have started a flight (and AutoStop is ON)
   } else {
-    if (flightTimer_autoStop()) {
-      if (settings.log_autoStop) flightTimer_stop();  // stop the log if auto-stop is on
+    if (settings.log_autoStop) {
+      if (flightTimer_autoStop()) flightTimer_stop();  // stop the log if auto-stop is on
     }
   }
 
@@ -148,6 +148,8 @@ bool flightTimer_autoStart() {
   return startTheTimer;
 }
 
+bool showingAlert_ = false;
+
 bool flightTimer_autoStop() {
   if (baro.state() != Barometer::State::Ready) {
     return false;  // can't autoStop without the Baro
@@ -162,16 +164,20 @@ bool flightTimer_autoStop() {
     // if all three conditions are met, increment the counter
     autoStopCounter++;
     // alert the user if we've been in this state for a little while and are about to stop
-    if (autoStopCounter >= AUTO_STOP_MIN_SEC / 2) {
+    if (autoStopCounter == AUTO_STOP_MIN_SEC / 2) {
       pageAlertTimerAutoStop.show();
+      showingAlert_ = true;
+      speaker.playSound(fx::cancel);
     }
     // and check if we've been in this state long enough to trigger auto-stop
     if (autoStopCounter >= AUTO_STOP_MIN_SEC) {
       autoStopCounter = 0;  // reset counter for next time
+      if (showingAlert_) pageAlertTimerAutoStop.closeAlert();
       return true;
     }
   } else {
     autoStopCounter = 0;
+    if (showingAlert_) pageAlertTimerAutoStop.closeAlert();
 
     // reset the comparison altitude to present altitude, since it's still changing
     autoStopAltitude = baro.alt();
@@ -186,7 +192,10 @@ uint8_t flightTimer_getAutoStopCountRemaining() {
     return 0;
 }
 
-void flightTimer_resetAutoStop() { autoStopCounter = 0; }
+void flightTimer_resetAutoStop() {
+  autoStopCounter = 0;
+  showingAlert_ = false;
+}
 
 //////////////////////////////////////////////////////////////////////////////////
 // FLight Timer Management Functions

--- a/src/vario/logging/log.h
+++ b/src/vario/logging/log.h
@@ -46,6 +46,8 @@ void log_checkMinMaxValues(void);
 
 // Returns if we should start recording a flight based on movemnt
 bool flightTimer_autoStop(void);
+uint8_t flightTimer_getAutoStopCountRemaining(void);
+void flightTimer_resetAutoStop(void);
 
 // Returns if we should stop recording a flight based on idle-ness
 bool flightTimer_autoStart(void);

--- a/src/vario/ui/display/menu_page.cpp
+++ b/src/vario/ui/display/menu_page.cpp
@@ -2,6 +2,7 @@
 
 #include "etl/array.h"
 #include "ui/display/display.h"
+#include "ui/display/display_fields.h"
 #include "ui/display/fonts.h"
 #include "ui/input/buttons.h"
 
@@ -84,11 +85,7 @@ void SimpleSettingsMenuPage::draw() {
   u8g2.firstPage();
   do {
     // Title
-    u8g2.setFont(leaf_6x12);
-    u8g2.setCursor(2, 12);
-    u8g2.setDrawColor(1);
-    u8g2.print(get_title());
-    u8g2.drawHLine(0, 15, 95);
+    display_menuTitle(String(get_title()));
 
     // Draw the cursor selection box
     const auto BOX_X = 74 - 10;

--- a/src/vario/ui/display/pages/dialogs/page_alert_timerAutoStop.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_alert_timerAutoStop.cpp
@@ -1,0 +1,36 @@
+#include "ui/display/pages/dialogs/page_alert_timerAutoStop.h"
+
+#include "logging/log.h"
+#include "ui/audio/speaker.h"
+#include "ui/display/display.h"
+#include "ui/display/display_fields.h"
+#include "ui/display/fonts.h"
+
+void PageAlertTimerAutoStop::draw_extra() {
+  // Title
+  display_menuTitle(String(get_title()));
+
+  uint8_t offset = 15;
+  uint8_t yPos = 30;
+  u8g2.setFont(leaf_6x12);
+  u8g2.setCursor(32, yPos);
+  u8g2.print("Alert!");
+  u8g2.setCursor(22, yPos += offset);
+  u8g2.print("Timer will");
+  u8g2.setCursor(10, yPos += offset);
+  u8g2.print("Auto-Stop in:");
+  u8g2.setCursor(20, yPos += offset);
+  u8g2.print(flightTimer_getAutoStopCountRemaining());
+  u8g2.print(" seconds!");
+}
+
+void PageAlertTimerAutoStop::show() { push_page(this); }
+
+void PageAlertTimerAutoStop::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (cursor_position == CURSOR_BACK && state == ButtonEvent::CLICKED) {
+    pop_page();
+    speaker.playSound(fx::confirm);
+    flightTimer_resetAutoStop();
+    return;
+  }
+}

--- a/src/vario/ui/display/pages/dialogs/page_alert_timerAutoStop.h
+++ b/src/vario/ui/display/pages/dialogs/page_alert_timerAutoStop.h
@@ -8,4 +8,5 @@ class PageAlertTimerAutoStop : public SimpleSettingsMenuPage {
   void draw_extra() override;
   void show();
   void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
+  void closeAlert() { pop_page(); }
 };

--- a/src/vario/ui/display/pages/dialogs/page_alert_timerAutoStop.h
+++ b/src/vario/ui/display/pages/dialogs/page_alert_timerAutoStop.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "ui/display/menu_page.h"
+
+class PageAlertTimerAutoStop : public SimpleSettingsMenuPage {
+ public:
+  const char* get_title() const override { return "! TIMER !"; }
+  void draw_extra() override;
+  void show();
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
+};


### PR DESCRIPTION
Improved logic for AutoStop Timer function, as well as pop up dialog to alert user that Timer will soon stop.

Dialog can be dismissed with button push (resets AutoStop timer count), or if AutoStop conditions fail (altitude change, IMU value, or GPS speed > thresholds) while dialog is showing, it will be auto-dismissed (and AutoStop timer count reset too).