### PR TITLE
[Debug Webserver] Add memory report

### DIFF
--- a/src/vario/comms/debug_webserver.cpp
+++ b/src/vario/comms/debug_webserver.cpp
@@ -2,6 +2,7 @@
 #include <WiFi.h>
 #include "WebServer.h"
 #include "comms/fanet_radio.h"
+#include "diagnostics/memory_report.h"
 #include "etl/string_stream.h"
 #include "storage/sd_card.h"
 #include "ui/display/display.h"
@@ -34,6 +35,7 @@ void webserver_setup() {
             <li><a href="/screenshot" target="_blank">Download Screenshot</a></li>
             <li><a href="/mass_storage" target="_blank">Start Mass Storage</a></li>
             <li><a href="/fanet" target="_blank">FANet Message Stats</a></li>
+            <li><a href="/memory" target="_blank">Memory Usage Stats</a></li>
           </ul>
         </body>
       </html>
@@ -165,6 +167,8 @@ void webserver_setup() {
     sdcard.setupMassStorage();
     server.send(200, "text/html", "OK!");
   });
+
+  server.on("/memory", HTTP_GET, []() { server.send(200, "text/plain", getMemoryUsage()); });
 
   // Give it a chance to connect so this debug message means something.
   delay(250);

--- a/src/vario/diagnostics/memory_report.h
+++ b/src/vario/diagnostics/memory_report.h
@@ -39,3 +39,34 @@ void printMemoryUsage() {
 #endif
   Serial.println("====================\n");
 }
+
+String getMemoryUsage() {
+  String out;
+
+  uint32_t freeHeap = esp_get_free_heap_size();
+  uint32_t minFreeHeap = esp_get_minimum_free_heap_size();
+  uint32_t usedHeap = heap_caps_get_total_size(MALLOC_CAP_INTERNAL) - freeHeap;
+  uint32_t totalHeap = freeHeap + usedHeap;
+
+  out += "=== Memory Stats ===\n";
+  out += "Total Heap: " + String(totalHeap / 1024) + " KB\n";
+  out += "Free Heap: " + String(freeHeap / 1024) + " KB\n";
+  out += "Used Heap: " + String(usedHeap / 1024) + " KB\n";
+  out += "Largest Free Block: " + String(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT) / 1024) +
+         " KB\n";
+  out += "Minimum Free Heap Ever: " + String(minFreeHeap / 1024) + " KB\n";
+  out += "Main Task Stack High Water Mark: " + String(uxTaskGetStackHighWaterMark(NULL) / 1024) +
+         " KB\n";
+
+#if CONFIG_SPIRAM_USE_MALLOC
+  out += "Free PSRAM: " + String(heap_caps_get_free_size(MALLOC_CAP_SPIRAM)) + " bytes\n";
+  out +=
+      "Largest Free PSRAM Block: " + String(heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM)) +
+      " bytes\n";
+#else
+  out += "PSRAM not available.\n";
+#endif
+
+  out += "====================\n";
+  return out;
+}


### PR DESCRIPTION
## Description

Adds a memory report to the debug webserver to make it easier to test for regressions with code changes.

## Test Plan

<img width="1301" height="587" alt="Screenshot 2025-09-30 at 1 54 03 PM" src="https://github.com/user-attachments/assets/44ef314d-2b58-4c78-94ac-095c3cdc7e74" />
<img width="1305" height="529" alt="Screenshot 2025-09-30 at 1 52 27 PM" src="https://github.com/user-attachments/assets/3b76081e-faa4-4e81-94fd-12b82ad74f7b" />
