### PR TITLE
[FANET] Address Allocator

### DIFF
--- a/fanet_addresses.csv
+++ b/fanet_addresses.csv
@@ -1,0 +1,3 @@
+mac_address,fanet_address
+f0:f5:bd:53:5f:20,0C0001
+00:00:00:00:00:00,0C0010

--- a/src/scripts/README_allocate_fanet_id.md
+++ b/src/scripts/README_allocate_fanet_id.md
@@ -1,0 +1,66 @@
+# FANET ID Allocator for ESP32
+
+> **Warning:** This tool will clear any user-saved settings on your device. Use with caution.
+
+## Overview
+
+The FANET ID Allocator is a Python-based utility for assigning and writing FANET IDs to ESP32 devices. It automatically generates an NVS (Non-Volatile Storage) binary containing the assigned FANET ID and flashes it to the target ESP32. The tool also checks if a MAC address already has a FANET ID and writes a CSV file for record-keeping.
+
+This tool is primarily intended for developers working with ESP32 devices and the FANET protocol, providing a simple way to initialize and manage device IDs.
+
+## How It Works
+
+1. The script checks the MAC address of your ESP32 to see if it already has an assigned FANET ID.
+2. If the device does not yet have a FANET ID, a new one is generated.
+3. An NVS binary is created with multipage blob support enabled.
+4. The binary is flashed to the ESP32 via `esptool.py`.
+5. A temporary CSV is written to record the mapping between MAC addresses and FANET IDs.
+
+The flashing process handles detection of the ESP32 chip type, connection via USB, and verification of the flashed data.
+
+## Using
+
+1. Source your ESP-IDF environment (Linux example):
+
+```bash
+. ~/Documents/esp-idf/export.sh
+```
+
+2. Run the script:
+```bash
+python src/scripts/allocate_fanet_id.py --esp-idf ~/Documents/esp-idf
+```
+
+Example Output:
+```
+scott@Bethanys-MacBook-Air leaf % python src/scripts/allocate_fanet_id.py --esp-idf ~/Documents/esp-idf
+MAC f0:f5:bd:53:5f:20 already has FANET 0C0001
+NVM CSV written to /var/folders/g1/sv5fp2j91l76qqg86z5f78wh0000gp/T/nvm.csv
+
+Creating NVS binary with version: V2 - Multipage Blob Support Enabled
+
+Created NVS binary: ===> /var/folders/g1/sv5fp2j91l76qqg86z5f78wh0000gp/T/flash.bin
+Created NVS binary: /var/folders/g1/sv5fp2j91l76qqg86z5f78wh0000gp/T/flash.bin
+esptool.py v4.9.0
+Found 2 serial ports
+Serial port /dev/cu.usbmodem11121301
+Connecting...
+Detecting chip type... ESP32-S3
+Chip is ESP32-S3 (QFN56) (revision v0.2)
+Features: WiFi, BLE, Embedded Flash 8MB (GD)
+Crystal is 40MHz
+USB mode: USB-Serial/JTAG
+MAC: f0:f5:bd:53:5f:20
+Uploading stub...
+Running stub...
+Stub running...
+Configuring flash size...
+Flash will be erased from 0x00009000 to 0x0000dfff...
+Compressed 20480 bytes to 177...
+Wrote 20480 bytes (177 compressed) at 0x00009000 in 0.2 seconds (effective 769.6 kbit/s)...
+Hash of data verified.
+
+Leaving...
+Hard resetting via RTS pin...
+Flashed /var/folders/g1/sv5fp2j91l76qqg86z5f78wh0000gp/T/flash.bin to device at offset 0x9000
+```

--- a/src/scripts/allocate_fanet_id.py
+++ b/src/scripts/allocate_fanet_id.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+import subprocess
+import csv
+import re
+import sys
+import argparse
+from pathlib import Path
+import tempfile
+
+CSV_FILE = "fanet_addresses.csv"
+PREFIX = "0C"  # fixed prefix
+
+MAC_RE = re.compile(r"MAC:\s*([0-9a-f]{2}(?::[0-9a-f]{2}){5})", re.I)
+ADDR_RE = re.compile(r"^0C([0-9A-F]{4})$")
+
+def run_esptool_read_mac(port=None):
+    cmd = ["esptool.py"]
+    if port:
+        cmd += ["--port", port]
+    cmd += ["read_mac"]
+    res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    match = MAC_RE.search(res.stdout)
+    if not match:
+        raise RuntimeError("Failed to parse MAC from esptool.py output:\n" + res.stdout)
+    return match.group(1).lower()
+
+def normalize_mac(mac: str) -> str:
+    hexchars = re.sub(r'[^0-9A-Fa-f]', '', mac)
+    return ':'.join(hexchars[i:i+2].lower() for i in range(0, 12, 2))
+
+def load_csv(path: Path):
+    if not path.exists():
+        return []
+    with open(path, newline='', encoding='utf-8') as f:
+        return list(csv.DictReader(f))
+
+def find_existing(mac, rows):
+    for row in rows:
+        if row.get("mac_address", "").lower() == mac.lower():
+            return row.get("fanet_address")
+    return None
+
+def next_fanet(rows):
+    max_id = 0
+    for row in rows:
+        fa = row.get("fanet_address", "").upper()
+        m = ADDR_RE.match(fa)
+        if m:
+            val = int(m.group(1), 16)
+            max_id = max(max_id, val)
+    next_id = max_id + 1
+    if next_id > 0xFFFF:
+        raise RuntimeError("FANET ID overflow (exceeded 0xFFFF)")
+    return f"{PREFIX}{next_id:04X}"
+
+def append_csv(path: Path, mac, fanet):
+    write_header = not path.exists()
+    with open(path, "a", newline='', encoding="utf-8") as f:
+        writer = csv.writer(f)
+        if write_header:
+            writer.writerow(["mac_address", "fanet_address"])
+        writer.writerow([mac, fanet])
+
+def write_nvm_csv(fanet_address: str) -> Path:
+    tmpfile = Path(tempfile.gettempdir()) / "nvm.csv"
+    with open(tmpfile, "w", newline='', encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["key", "type", "encoding", "value"])
+        writer.writerow(["fanet", "namespace", "", ""])
+        writer.writerow(["address", "data", "string", fanet_address])
+    return tmpfile
+
+def generate_nvs_bin(esp_idf_dir: Path, nvm_csv: Path) -> Path:
+    bin_file = Path(tempfile.gettempdir()) / "flash.bin"
+    nvs_gen = esp_idf_dir / "components" / "nvs_flash" / "nvs_partition_generator" / "nvs_partition_gen.py"
+    if not nvs_gen.exists():
+        raise RuntimeError(f"Cannot find nvs_partition_gen.py at {nvs_gen}")
+    cmd = [
+        sys.executable,
+        str(nvs_gen),
+        "generate",
+        str(nvm_csv),
+        str(bin_file),
+        "0x5000"  # partition start offset for generation
+    ]
+    subprocess.run(cmd, check=True)
+    print(f"Created NVS binary: {bin_file}")
+    return bin_file
+
+def flash_bin(bin_file: Path, port=None):
+    cmd = ["esptool.py"]
+    if port:
+        cmd += ["--port", port]
+    cmd += ["write_flash", "0x9000", str(bin_file)]
+    subprocess.run(cmd, check=True)
+    print(f"Flashed {bin_file} to device at offset 0x9000")
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", default=CSV_FILE, help="CSV file path")
+    p.add_argument("--port", default=None, help="ESP serial port")
+    p.add_argument("--esp-idf", required=True, type=Path, help="ESP-IDF root directory")
+    args = p.parse_args()
+
+    mac = normalize_mac(run_esptool_read_mac(args.port))
+    rows = load_csv(Path(args.csv))
+
+    existing = find_existing(mac, rows)
+    if existing:
+        print(f"MAC {mac} already has FANET {existing}")
+        fanet = existing
+    else:
+        fanet = next_fanet(rows)
+        append_csv(Path(args.csv), mac, fanet)
+        print(f"Assigned {fanet} to MAC {mac}")
+
+    nvm_csv = write_nvm_csv(fanet)
+    print(f"NVM CSV written to {nvm_csv}")
+
+    bin_file = generate_nvs_bin(args.esp_idf, nvm_csv)
+    flash_bin(bin_file, args.port)
+
+if __name__ == "__main__":
+    main()

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -133,6 +133,10 @@ void Settings::loadDefaults() {
 void Settings::retrieve() {
   leafPrefs.begin("varioPrefs", RO_MODE);
 
+  // Load up the FANET address
+  Preferences fanetPrefs;
+  fanetPrefs.begin("fanet", RO_MODE);
+
   // Vario Settings
   vario_sinkAlarm = leafPrefs.getFloat("SINK_ALARM_VAL", DEF_SINK_ALARM);
   vario_sinkAlarm_units = leafPrefs.getBool("SINK_ALARM_UNIT", DEF_SINK_ALARM_UNITS);
@@ -190,7 +194,7 @@ void Settings::retrieve() {
 
   // Fanet settings
   fanet_region = (FanetRadioRegion)leafPrefs.getUInt("FANET_REGION");
-  fanet_address = leafPrefs.getString("FANET_ADDRESS");
+  fanet_address = fanetPrefs.getString("address");
 
   // Unit Values
   units_climb = leafPrefs.getBool("UNITS_climb");


### PR DESCRIPTION
We have been given the 0x0C FANET vendor ID for Leaf.  To avoid collisions, we should start using them.

This adds a script to generate the NMV partition with an auto incremented  FANET address and store it in a csv file in the repo.

This should only be done before shipping them out by one person at the moment.

This is to address #111

### Test Plan
```
scott@Bethanys-MacBook-Air leaf % python src/scripts/allocate_fanet_id.py --esp-idf ~/Documents/esp-idf
MAC f0:f5:bd:53:5f:20 already has FANET 0C0001
NVM CSV written to /var/folders/g1/sv5fp2j91l76qqg86z5f78wh0000gp/T/nvm.csv

Creating NVS binary with version: V2 - Multipage Blob Support Enabled

Created NVS binary: ===> /var/folders/g1/sv5fp2j91l76qqg86z5f78wh0000gp/T/flash.bin
Created NVS binary: /var/folders/g1/sv5fp2j91l76qqg86z5f78wh0000gp/T/flash.bin
esptool.py v4.9.0
Found 2 serial ports
Serial port /dev/cu.usbmodem11121301
Connecting...
Detecting chip type... ESP32-S3
Chip is ESP32-S3 (QFN56) (revision v0.2)
Features: WiFi, BLE, Embedded Flash 8MB (GD)
Crystal is 40MHz
USB mode: USB-Serial/JTAG
MAC: f0:f5:bd:53:5f:20
Uploading stub...
Running stub...
Stub running...
Configuring flash size...
Flash will be erased from 0x00009000 to 0x0000dfff...
Compressed 20480 bytes to 177...
Wrote 20480 bytes (177 compressed) at 0x00009000 in 0.2 seconds (effective 769.6 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
Flashed /var/folders/g1/sv5fp2j91l76qqg86z5f78wh0000gp/T/flash.bin to device at offset 0x9000
```

Before and after running the allocate script:
<img width="267" height="500" alt="Screenshot 2025-09-30 at 6 18 04 PM" src="https://github.com/user-attachments/assets/328d97e4-767f-43d7-90d8-8e223ad61f22" />
<img width="254" height="494" alt="Screenshot 2025-09-30 at 6 15 57 PM" src="https://github.com/user-attachments/assets/3173dd96-0d05-42a0-84f8-77d41d9db9d1" />

