### PR TITLE
Adjustable AutoOff Timeout and UI Improvements

### DIFF
--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -11,6 +11,7 @@
 #include "logbook/flight.h"
 #include "logbook/igc.h"
 #include "logbook/kml.h"
+#include "power.h"
 #include "storage/sd_card.h"
 #include "ui/audio/sound_effects.h"
 #include "ui/audio/speaker.h"
@@ -240,6 +241,8 @@ void flightTimer_start() {
 // stop timer
 void flightTimer_stop() {
   windEstimator.clearWindEstimate();  // clear the wind estimate when we stop a flight
+  power.resetAutoOffCounter();  // reset the auto-off counter when we stop a flight (it could have
+                                // counted up to nearly the limit prior to auto-starting a log)
   // Short Circuit, no need to do anything if there's no flight recording.
   if (flight == NULL) {
     return;

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -300,7 +300,7 @@ bool Power::autoOff() {
     autoShutOff = true;
   } else if (autoOffCounter_ >= settings.system_autoOff * 60 - 10) {
     speaker.playSound(
-    fx::decrease);  // start playing warning sounds 5 seconds before it auto-turns off
+        fx::decrease);  // start playing warning sounds 5 seconds before it auto-turns off
   }
   return autoShutOff;
 }

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -40,12 +40,9 @@ Power power;  // struct for battery-state and on-state variables
 // plus we want to shutdown while we have power to save logs etc
 
 // Auto-Power-Off Threshold values
-#define AUTO_OFF_MAX_SPEED 3      // mph max -- must be below this speed for timer to auto-stop
-#define AUTO_OFF_MAX_ACCEL 10     // Max accelerometer signal
-#define AUTO_OFF_MAX_ALT 400      // cm altitude change for timer auto-stop
-#define AUTO_OFF_TIME 300         // seconds of inactivity for timer to auto-stop
-#define AUTO_OFF_TIME_NO_FIX 600  // if no GPS fix, search longer before shutting down
-uint16_t timeout_limit = AUTO_OFF_TIME_NO_FIX;  // start assuming no fix
+#define AUTO_OFF_MAX_SPEED 3   // mph max -- must be below this speed for timer to auto-stop
+#define AUTO_OFF_MAX_ACCEL 10  // Max accelerometer signal
+#define AUTO_OFF_MAX_ALT 400   // cm altitude change for timer auto-stop
 
 const char* nameOf(PowerInputLevel level) {
   switch (level) {
@@ -298,50 +295,13 @@ void Power::resetAutoOffCounter() { autoOffCounter_ = 0; }
 bool Power::autoOff() {
   bool autoShutOff = false;  // start with assuming we're not going to turn off
 
-  // we will auto-stop only if BOTH the GPS speed AND the Altitude change trigger the stopping
-  // thresholds.
-
-  // First check if baro is available (it's not available immediately after boot-up)
-  if (baro.state() != Barometer::State::Ready) {
-    return false;
+  autoOffCounter_++;
+  if (autoOffCounter_ >= settings.system_autoOff * 60) {  // convert minutes to seconds
+    autoShutOff = true;
+  } else if (autoOffCounter_ >= settings.system_autoOff * 60 - 10) {
+    speaker.playSound(
+    fx::decrease);  // start playing warning sounds 5 seconds before it auto-turns off
   }
-
-  // Then determine if we're timing out with or without a GPS fix, since we want a longer timeout
-  // with no fix to allow GPS to search for awhile
-
-  // if we get a fix AND haven't yet updated the timeout...
-  if (gps.fixInfo.fix > 0 && timeout_limit == AUTO_OFF_TIME_NO_FIX) {
-    timeout_limit = AUTO_OFF_TIME;  // ...reduce the timout
-    if (autoOffCounter_ > timeout_limit - 6) {
-      // if we get a fix, but we're already past the warning timout, move us back to the
-      // beginning of the warning, so we still get the full 5 seconds of audible warnings
-      autoOffCounter_ = timeout_limit - 6;
-    }
-  }
-
-  // Then check if altitude is stable
-  int32_t altNow = baro.alt();
-  int32_t altDifference = abs(altNow - autoOffAltitude_);
-  if (altDifference < AUTO_OFF_MAX_ALT) {
-    // then check if GPS speed is slow enough
-    if (gps.speed.mph() < AUTO_OFF_MAX_SPEED) {
-      autoOffCounter_++;
-      if (autoOffCounter_ >= timeout_limit) {
-        autoShutOff = true;
-      } else if (autoOffCounter_ >= timeout_limit - 5) {
-        speaker.playSound(
-            fx::decrease);  // start playing warning sounds 5 seconds before it auto-turns off
-      }
-    } else {
-      autoOffCounter_ = 0;
-    }
-
-  } else {
-    autoOffAltitude_ = altNow;  // reset the comparison altitude to present altitude,
-                                // since it's still changing
-    autoOffCounter_ = 0;
-  }
-
   return autoShutOff;
 }
 

--- a/src/vario/ui/display/pages/dialogs/page_warning.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_warning.cpp
@@ -24,10 +24,10 @@ void warningPage_draw() {
     u8g2.setCursor(2, 12);
     u8g2.print((char)34);
     u8g2.setCursor(84, 12);
-    u8g2.print('"');
+    u8g2.print((char)34);
 
     u8g2.setFont(leaf_6x12);
-    u8g2.setCursor(18, 12);
+    u8g2.setCursor(20, 12);
     u8g2.setDrawColor(1);
     u8g2.print("WARNING");
 

--- a/src/vario/ui/display/pages/menu/page_menu_system.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_system.cpp
@@ -120,11 +120,14 @@ void SystemMenuPage::drawSystemMenu() {
           break;
 
         case cursor_system_poweroff:
-          u8g2.setCursor(setting_choice_x + 8, menu_items_y[i]);
-          if (settings.system_autoOff)
-            u8g2.print((char)125);
-          else
-            u8g2.print((char)123);
+          u8g2.setCursor(setting_choice_x + 4, menu_items_y[i]);
+          if (settings.system_autoOff) {
+            if (settings.system_autoOff < 10) u8g2.print(" ");
+            u8g2.print(settings.system_autoOff);
+            u8g2.print("m");
+          } else {
+            u8g2.print("OFF");
+          }
           break;
 
         case cursor_system_showWarning:
@@ -183,7 +186,7 @@ void SystemMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count
       if (state == ButtonEvent::CLICKED) settings.adjustVolumeSystem(dir);
       break;
     case cursor_system_poweroff:
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.system_autoOff);
+      if (state == ButtonEvent::CLICKED) settings.adjustAutoOff(dir);
       break;
     case cursor_system_showWarning:
       if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.system_showWarning);

--- a/src/vario/ui/display/pages/menu/page_menu_system.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_system.cpp
@@ -80,12 +80,16 @@ void SystemMenuPage::drawSystemMenu() {
     uint8_t setting_name_x = 2;
     uint8_t setting_choice_x = 64;
     uint8_t menu_items_y[] = {190, 45, 60, 75, 90, 105, 120, 150, 165};
-    char twoZeros[] = "00";
 
     // first draw cursor selection box
-    u8g2.drawRBox(setting_choice_x - 2, menu_items_y[cursor_position] - 14, 34, 16, 2);
+    if (cursor_position == cursor_system_showWarning) {
+      u8g2.drawRBox(setting_choice_x + 4, menu_items_y[cursor_position] - 14, 34, 16, 2);
+    } else {
+      u8g2.drawRBox(setting_choice_x - 2, menu_items_y[cursor_position] - 14, 34, 16, 2);
+    }
 
     // then draw all the menu items
+    u8g2.setFont(leaf_6x12);
     for (int i = 0; i <= cursor_max; i++) {
       u8g2.setCursor(setting_name_x, menu_items_y[i]);
       u8g2.print(labels[i]);
@@ -107,7 +111,7 @@ void SystemMenuPage::drawSystemMenu() {
           u8g2.print(displayTimeZone / 60);
           u8g2.print(':');
           if (displayTimeZone % 60 == 0)
-            u8g2.print(twoZeros);
+            u8g2.print("00");
           else
             u8g2.print(displayTimeZone % 60);
           break;
@@ -131,7 +135,13 @@ void SystemMenuPage::drawSystemMenu() {
           break;
 
         case cursor_system_showWarning:
-          u8g2.setCursor(setting_choice_x + 8, menu_items_y[i]);
+          u8g2.setCursor(setting_choice_x + 6, menu_items_y[i]);
+
+          u8g2.setFont(leaf_icons);
+          u8g2.print((char)34);
+          u8g2.setFont(leaf_6x12);
+          u8g2.setCursor(u8g2.getCursorX() + 1, u8g2.getCursorY());
+
           if (settings.system_showWarning)
             u8g2.print((char)125);
           else

--- a/src/vario/ui/display/pages/menu/page_menu_system.h
+++ b/src/vario/ui/display/pages/menu/page_menu_system.h
@@ -23,8 +23,8 @@ class SystemMenuPage : public SettingsMenuPage {
 
  private:
   void drawSystemMenu();
-  static constexpr char* labels[9] = {"Back", "TimeZone", "Volume", "Auto-Off", "ShowWarning",
-                                      "Wifi", "BT",       "About",  "Reset"};
+  static constexpr char* labels[9] = {"Back", "TimeZone",  "Volume", "Auto-Off", "ShowSafety",
+                                      "Wifi", "Bluetooth", "About",  "Reset"};
 };
 
 #endif

--- a/src/vario/ui/display/pages/menu/page_menu_vario.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.cpp
@@ -138,11 +138,12 @@ void VarioMenuPage::draw() {
           }
           // Print units for climb/sink thresholds
           u8g2.setFont(leaf_labels);
+          u8g2.setDrawColor(1);
           if (settings.units_climb) {
-            u8g2.setCursor(u8g2.getCursorX() - 20, u8g2.getCursorY() + 10);
+            u8g2.setCursor(u8g2.getCursorX() - 20, u8g2.getCursorY() + 12);
             u8g2.print("fpm");
           } else {
-            u8g2.setCursor(u8g2.getCursorX() - 18, u8g2.getCursorY() + 11);
+            u8g2.setCursor(u8g2.getCursorX() - 18, u8g2.getCursorY() + 12);
             u8g2.print("m/s");
           }
           u8g2.setFont(leaf_6x12);

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -179,25 +179,27 @@ void PageMenuSystemWifiSetup::draw_extra() {
   u8g2.print((char)wifiIcon);
 
   u8g2.setFont(leaf_6x12);
-  auto y = 20;
+  auto y = 15;
   auto x = 0;
-  const auto OFFSET = 9;  // default new paragraph spacing
+  const auto OFFSET = 4;  // default new paragraph spacing
   u8g2.setCursor(0, y);
 
   // Instruction Page
-  const char* lines[] = {">Join Leaf WiFi",     "On Phone or Laptop", " ", ">Click Sign In",
-                         "  Or Visit:",         "http://192.168.4.1", " ", ">Configure WiFi",
-                         "Select your network", "and enter password", " ", ">Press Save"};
+  const char* lines[] = {"Follow these steps", "on Phone or Laptop:",  "1.Join Leaf WiFi",   " ",
+                         "2.Click Sign In",    "  Or Visit:",          "http://192.168.4.1", " ",
+                         "3.Configure WiFi",   "Select your network",  "and enter password", " ",
+                         "4.Press Save",       "This page will close", "when connected..."};
 
   uint8_t lineNum = 0;
 
   for (auto line : lines) {
     u8g2.setCursor(0, y);
-    if (lineNum == 0 || lineNum == 3 || lineNum == 7 || lineNum == 11) {
+    if (lineNum == 2 || lineNum == 4 || lineNum == 8 || lineNum == 12) {
       y += 14;
       x = 0;
       u8g2.setFont(leaf_6x12);
-    } else if (lineNum == 1 || lineNum == 4 || lineNum == 5 || lineNum == 8 || lineNum == 9) {
+    } else if (lineNum == 0 || lineNum == 1 || lineNum == 5 || lineNum == 6 || lineNum == 9 ||
+               lineNum == 10 || lineNum == 13 || lineNum == 14) {
       y += 11;
       x = 5;
       u8g2.setFont(leaf_5x8);

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -162,7 +162,7 @@ void Settings::retrieve() {
   system_volume = leafPrefs.getChar("VOLUME_SYSTEM");
   speaker.setVolume(Speaker::SoundChannel::FX, (SpeakerVolume)system_volume);
   system_ecoMode = leafPrefs.getBool("ECO_MODE");
-  system_autoOff = leafPrefs.getBool("AUTO_OFF");
+  system_autoOff = leafPrefs.getChar("AUTO_OFF");
   system_wifiOn = leafPrefs.getBool("WIFI_ON");
   system_bluetoothOn = leafPrefs.getBool("BLUETOOTH_ON");
   system_showWarning = leafPrefs.getBool("SHOW_WARNING");
@@ -239,7 +239,7 @@ void Settings::save() {
   leafPrefs.putShort("TIME_ZONE", system_timeZone);
   leafPrefs.putChar("VOLUME_SYSTEM", system_volume);
   leafPrefs.putBool("ECO_MODE", system_ecoMode);
-  leafPrefs.putBool("AUTO_OFF", system_autoOff);
+  leafPrefs.putChar("AUTO_OFF", system_autoOff);
   leafPrefs.putBool("WIFI_ON", system_wifiOn);
   leafPrefs.putBool("BLUETOOTH_ON", system_bluetoothOn);
   leafPrefs.putBool("SHOW_WARNING", system_showWarning);
@@ -607,4 +607,41 @@ void Settings::toggleBoolOnOff(bool* switchSetting) {
     speaker.playSound(fx::enter);  // if we turned it on
   else
     speaker.playSound(fx::cancel);  // if we turned it off
+}
+
+void Settings::adjustAutoOff(Button dir) {
+  uint8_t autoOffOptions[8] = {0, 1, 5, 10, 15, 30, 45, 60};  // in minutes, where 0 = DISABLE
+  for (uint8_t i = 0; i < sizeof(autoOffOptions) / sizeof(autoOffOptions[0]); i++) {
+    if (system_autoOff <= autoOffOptions[i]) {
+      // found the current setting in the options list, now adjust based on button press
+      if (dir == Button::RIGHT || dir == Button::CENTER) {
+        if (i >= sizeof(autoOffOptions) / sizeof(autoOffOptions[0]) - 1) {
+          speaker.playSound(fx::doubleClick);
+          system_autoOff = autoOffOptions[sizeof(autoOffOptions) / sizeof(autoOffOptions[0]) - 1];
+        } else {
+          system_autoOff = autoOffOptions[i + 1];
+          speaker.playSound(fx::neutral);
+        }
+      } else if (dir == Button::LEFT) {
+        if (i > 0) {
+          system_autoOff = autoOffOptions[i - 1];
+          if (system_autoOff != 0) {
+            speaker.playSound(fx::neutral);
+          } else {
+            speaker.playSound(fx::cancel);
+          }
+        } else {
+          speaker.playSound(fx::cancel);
+          system_autoOff = autoOffOptions[0];
+        }
+      }
+      break;
+    }
+    if (i == sizeof(autoOffOptions) / sizeof(autoOffOptions[0]) - 1) {
+      // if we don't find the current setting in the options list, then set it to default
+      system_autoOff = autoOffOptions[0];
+      speaker.playSound(fx::cancel);
+      break;
+    }
+  }
 }

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -65,7 +65,8 @@ typedef uint8_t SettingLogFormat;
 // This allows us to cover all time zones, including the :30 minute and :15 minute ones
 #define DEF_TIME_ZONE -420   // -420 min = UTC -7 hrs (PDT)
 #define DEF_VOLUME_SYSTEM 1  // 0=off, 1=low, 2=med, 3=high
-#define DEF_AUTO_OFF 0       // 1 = ENABLE, 0 = DISABLE
+#define DEF_AUTO_OFF 0       // 0 = DISABLE
+#define AUTO_OFF_MAX 60      // max auto-off time in minutes (1 hour)
 #define DEF_WIFI_ON 0        // default wifi off
 #define DEF_BLUETOOTH_ON 0   // default bluetooth off
 #define DEF_SHOW_WARNING 1   // default show warning on startup
@@ -142,7 +143,7 @@ setting | samples | time avg
   int16_t system_timeZone;
   int8_t system_volume;
   bool system_ecoMode;
-  bool system_autoOff;
+  uint8_t system_autoOff;
   bool system_wifiOn;
   bool system_bluetoothOn;
   bool system_showWarning;
@@ -203,6 +204,7 @@ setting | samples | time avg
   void adjustVolumeVario(Button dir);
   void adjustVolumeSystem(Button dir);
   void adjustTimeZone(Button dir);
+  void adjustAutoOff(Button dir);
 
   void adjustDisplayField_navPage_alt(Button dir);
   void adjustDisplayField_thermalPage_alt(Button dir);


### PR DESCRIPTION
### Add adjustable (OFF <-> 60min) AutoOff time.  
* This change also removes dependencies on altimeter/accel/GPS changes.  Previously, AutoOff was set to a fixed timeout, and pressing a button, or experiencing movement based on the sensors, would reset the timeout.
Now, only a button push will reset the timeout; otherwise after the user-setting-timeout has expired, the device will turn off.  This allows Leaf to be packed away in a car or rucksack and experiencing motion and still Auto-Turn-Off.
* If flight-timer is running, the AutoOff feature is obviously still disabled.
* No changes to flight timer Auto-Stop detection/time.
### UI Improvements
* More clear Wifi Setup Instructions
* Other small tweaks and fixes to menus to make things cleaner and more intuitive   