### PR TITLE
Fix: Prevent crashing when calling ClimbRate during boot races

### DIFF
--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -236,15 +236,32 @@ void Barometer::setPressureAlt(int32_t newPressure) {
 
 float Barometer::climbRate() {
   if (!validClimbRateRaw_) {
-    fatalError("Barometer::climbRate accessed before valid");
+    static bool warned = false;
+    if (!warned) {
+      fatalErrorInfo("Barometer::climbRate accessed before valid");
+      warned = true;
+    }
+    return 0.0f;
   }
   return climbRateRaw_;
 }
 
 int32_t Barometer::climbRateFiltered() {
-  assertState("Barometer::climbRateFiltered", State::Ready);
+  if (state_ != State::Ready) {
+    static bool warnedNotReady = false;
+    if (!warnedNotReady) {
+      fatalErrorInfo("Barometer::climbRateFiltered accessed before ready");
+      warnedNotReady = true;
+    }
+    return 0;
+  }
   if (!validClimbRateFiltered_) {
-    fatalError("Barometer::climbRateFiltered accessed before valid");
+    static bool warnedNotValid = false;
+    if (!warnedNotValid) {
+      fatalErrorInfo("Barometer::climbRateFiltered accessed before valid");
+      warnedNotValid = true;
+    }
+    return 0;
   }
   return climbRateFiltered_;
 }

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -236,32 +236,15 @@ void Barometer::setPressureAlt(int32_t newPressure) {
 
 float Barometer::climbRate() {
   if (!validClimbRateRaw_) {
-    static bool warned = false;
-    if (!warned) {
-      fatalErrorInfo("Barometer::climbRate accessed before valid");
-      warned = true;
-    }
-    return 0.0f;
+    fatalError("Barometer::climbRate accessed before valid");
   }
   return climbRateRaw_;
 }
 
 int32_t Barometer::climbRateFiltered() {
-  if (state_ != State::Ready) {
-    static bool warnedNotReady = false;
-    if (!warnedNotReady) {
-      fatalErrorInfo("Barometer::climbRateFiltered accessed before ready");
-      warnedNotReady = true;
-    }
-    return 0;
-  }
+  assertState("Barometer::climbRateFiltered", State::Ready);
   if (!validClimbRateFiltered_) {
-    static bool warnedNotValid = false;
-    if (!warnedNotValid) {
-      fatalErrorInfo("Barometer::climbRateFiltered accessed before valid");
-      warnedNotValid = true;
-    }
-    return 0;
+    fatalError("Barometer::climbRateFiltered accessed before valid");
   }
   return climbRateFiltered_;
 }

--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -180,12 +180,18 @@ bool flightTimer_autoStop() {
     // and check if we've been in this state long enough to trigger auto-stop
     if (autoStopCounter >= AUTO_STOP_MIN_SEC) {
       autoStopCounter = 0;  // reset counter for next time
-      if (showingAlert_) pageAlertTimerAutoStop.closeAlert();
+      if (showingAlert_) {
+        pageAlertTimerAutoStop.closeAlert();
+        showingAlert_ = false;
+      }
       return true;
     }
   } else {
     autoStopCounter = 0;
-    if (showingAlert_) pageAlertTimerAutoStop.closeAlert();
+    if (showingAlert_) {
+      pageAlertTimerAutoStop.closeAlert();
+      showingAlert_ = false;
+    }
 
     // reset the comparison altitude to present altitude, since it's still changing
     autoStopAltitude = baro.alt();

--- a/src/vario/ui/display/menu_page.cpp
+++ b/src/vario/ui/display/menu_page.cpp
@@ -58,6 +58,7 @@ void MenuPage::push_page(MenuPage* page) {
 }
 
 void MenuPage::pop_page() {
+  if (get_current_page_stack().empty()) return;
   // Remove the current page from the stack, notifying the page it has been closed
   auto current_page = get_current_page_stack().top();
   get_current_page_stack().pop();


### PR DESCRIPTION
## Summary

There are multiple race conditions that exist between components attempting to get a climb rate, and it crashing as it's not yet ready.  Instead of a few ms where a 0 climb rate was used, this is now a hard crash.  A regression in #209.

This changes the behavior to not crash, but, just print an error and carry on, like the previous tried and tested behavior.

Call sites here are in FANET, BLE, and Claude also found:

> baro.climbRate() checks validClimbRateRaw_, which is only set to true inside filterAltitude() — and filterAltitude()       
  requires imu.velocityValid(). The IMU takes GRAVITY_INIT_S = 3.0 seconds to estimate gravity before velocityValid() returns true. That's  
  the same 3-second window as AUTO_START_MIN_SEC = 3. So it's a near-exact race: auto-start fires right as (or before) the IMU finishes     
  initialization, leaving validClimbRateRaw_ = false and crashing.

 >  The actual bug to fix is in fanet_radio.cpp:494 — baro.climbRate() needs a validity guard (either check baro.climbRateFilteredValid()     
  before the call, or add a climbRateValid() method to baro that exposes validClimbRateRaw_).

This will do for now to not crash, and, later I'll look at changing the call-sites to reduce the occurrence of these warning type of bugs.

## Test Plan
Test in next flight!