### PR TITLE
  Fix: double pop_page() crash from AutoStop alert dialog (regression from #241)                                                                             

### DIFF
--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -180,12 +180,18 @@ bool flightTimer_autoStop() {
     // and check if we've been in this state long enough to trigger auto-stop
     if (autoStopCounter >= AUTO_STOP_MIN_SEC) {
       autoStopCounter = 0;  // reset counter for next time
-      if (showingAlert_) pageAlertTimerAutoStop.closeAlert();
+      if (showingAlert_) {
+        pageAlertTimerAutoStop.closeAlert();
+        showingAlert_ = false;
+      }
       return true;
     }
   } else {
     autoStopCounter = 0;
-    if (showingAlert_) pageAlertTimerAutoStop.closeAlert();
+    if (showingAlert_) {
+      pageAlertTimerAutoStop.closeAlert();
+      showingAlert_ = false;
+    }
 
     // reset the comparison altitude to present altitude, since it's still changing
     autoStopAltitude = baro.alt();

--- a/src/vario/ui/display/menu_page.cpp
+++ b/src/vario/ui/display/menu_page.cpp
@@ -58,6 +58,7 @@ void MenuPage::push_page(MenuPage* page) {
 }
 
 void MenuPage::pop_page() {
+  if (get_current_page_stack().empty()) return;
   // Remove the current page from the stack, notifying the page it has been closed
   auto current_page = get_current_page_stack().top();
   get_current_page_stack().pop();


### PR DESCRIPTION
## Summary
                                                                                                                                                             
  PR #241 introduced the AutoStop alert dialog and a showingAlert_ flag to                                                                                   
  track whether it was on the modal stack. However, the two inline closeAlert()                                                                              
  call sites inside flightTimer_autoStop() never reset showingAlert_ to false.                                                                               
  Only flightTimer_resetAutoStop() did so correctly.                                                                                                         
                                                                                                                                                             
  This meant that on the next evaluation tick after the dialog was closed, the                                                                               
  else-branch would call closeAlert() again — invoking pop_page() on a page                                                                                  
  that was no longer on the modal stack. pop_page() called .top() on the empty                                                                             
  stack, returned a garbage MenuPage*, and virtual dispatch through that pointer                                                                             
  jumped to an unmapped address, crashing the device.                                                                                                        
                                                                                                                                                             
  Fix 1: reset showingAlert_ = false immediately after each closeAlert() call                                                                                
  in flightTimer_autoStop(), so no subsequent tick can double-pop the stack.                                                                               
                                                                                                                                                             
  Fix 2: make pop_page() itself defensive — if the page stack is empty, silently                                                                             
  no-op rather than calling .top()/.pop() on an empty container and crashing.                                                                                
  This acts as a last line of defence against any future caller bugs of this class.        