### PR TITLE
Protect Fanet calls to baro.climbRate() before full Kalman initialization

### DIFF
--- a/src/vario/comms/fanet_radio.cpp
+++ b/src/vario/comms/fanet_radio.cpp
@@ -490,8 +490,12 @@ void FanetRadio::on_receive(const GpsReading& msg) {
 
   // Update the FANet radio module of our current location
   TinyGPSPlus gps = msg.gps;  // Needed as lat() calls are not const :'(
+  float climbRate = 0;
+  if (baro.climbRateFilteredValid()) {
+    climbRate = baro.climbRateFiltered() / 100.0f;
+  }
   setCurrentLocation(gps.location.lat(), gps.location.lng(), gps.altitude.meters(),
-                     gps.course.deg(), baro.climbRate() / 100.0f, gps.speed.kmph());
+                     gps.course.deg(), climbRate, gps.speed.kmph());
 }
 
 String FanetRadio::getAddress() {

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -234,13 +234,6 @@ void Barometer::setPressureAlt(int32_t newPressure) {
   }
 }
 
-float Barometer::climbRate() {
-  if (!validClimbRateRaw_) {
-    fatalError("Barometer::climbRate accessed before valid");
-  }
-  return climbRateRaw_;
-}
-
 int32_t Barometer::climbRateFiltered() {
   assertState("Barometer::climbRateFiltered", State::Ready);
   if (!validClimbRateFiltered_) {

--- a/src/vario/instruments/baro.h
+++ b/src/vario/instruments/baro.h
@@ -56,9 +56,6 @@ class Barometer : public MessageSink<Barometer, PressureUpdate>,
   // pressure altitude in cm corrected by the altimeter setting
   int32_t altAdjusted();
 
-  // instantaneous climbrate calculated with every pressure altitude measurement (m/s)
-  float climbRate();
-
   // filtered climb value to reduce noise (cm/s)
   int32_t climbRateFiltered();
 

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
@@ -101,8 +101,14 @@ void PageFanetGround::draw_extra() {
     // This really, really shouldn't be done in a Display object
     // but whatever, we'll refactor later.
     // TODO:  Delete me
+
+    float climbRate = 0;
+    if (baro.climbRateFilteredValid()) {
+      climbRate = baro.climbRateFiltered() / 100.0f;
+    }
+
     fanetRadio.setCurrentLocation(gps.location.lat(), gps.location.lng(), gps.altitude.meters(),
-                                  gps.course.deg(), baro.climbRate() / 100.0f, gps.speed.kmph());
+                                  gps.course.deg(), climbRate, gps.speed.kmph());
   }
 }
 


### PR DESCRIPTION
Fanet calls to baro.climbRate() were occurring immediately after log start (as expected).  However, log start could occur before baro/kalman was fully initialized.  Other log calls to baro were protected, but not the calls from fanet functions.

Also removed unused baro.ClimbRate() since all requests for a climb rate should be baro.climbRateFiltered().

 