### PR TITLE
Power Updates (battery voltage and shutdown procedure) 

### DIFF
--- a/src/vario/logbook/flight.cpp
+++ b/src/vario/logbook/flight.cpp
@@ -46,12 +46,14 @@ bool Flight::startFlight() {
   return true;
 }
 
-void Flight::end(const FlightStats stats) {
+void Flight::end(const FlightStats stats, bool showSummary) {
   file.close();
 
   // Finally, show the flight summary page
-  static PageFlightSummary dialog;
-  dialog.show(stats);
+  if (showSummary) {
+    static PageFlightSummary dialog;
+    dialog.show(stats);
+  }
 }
 
 bool Flight::started() { return (boolean)file; }

--- a/src/vario/logbook/flight.h
+++ b/src/vario/logbook/flight.h
@@ -9,7 +9,7 @@ class Flight {
   // We wish to start recording a flight.
   // Returns:  Flight log created successfully
   virtual bool startFlight();
-  virtual void end(const FlightStats stats);
+  virtual void end(const FlightStats stats, bool showSummary = true);
 
   // Logs a datapoint
   virtual void log(unsigned long durationSec) {}

--- a/src/vario/logbook/igc.cpp
+++ b/src/vario/logbook/igc.cpp
@@ -106,12 +106,12 @@ bool Igc::startFlight() {
   return true;
 }
 
-void Igc::end(const FlightStats stats) {
+void Igc::end(const FlightStats stats, bool showSummary) {
   // If we've not started a flight yet, don't write to disk.
   if (started()) {
     logger.writeGRecord();
   }
-  Flight::end(stats);
+  Flight::end(stats, showSummary);
 }
 
 void Igc::setPilotFromFile() {

--- a/src/vario/logbook/igc.h
+++ b/src/vario/logbook/igc.h
@@ -8,7 +8,7 @@
 class Igc : public Flight {
  public:
   bool startFlight() override;
-  void end(const FlightStats stats) override;
+  void end(const FlightStats stats, bool showSummary = true) override;
 
   const String fileNameSuffix() const override { return "igc"; }
 

--- a/src/vario/logbook/kml.cpp
+++ b/src/vario/logbook/kml.cpp
@@ -52,7 +52,7 @@ void Kml::log(unsigned long durationSec) {
   file.println(whenPointStr);
 }
 
-void Kml::end(const FlightStats stats) {
+void Kml::end(const FlightStats stats, bool showSummary) {
   file.println(KMLtrackFooterA);  // close </gxtrack> and open track <name>
   file.println("Flight Time: " + formatSeconds(stats.duration, false, 0));
   file.println(KMLtrackFooterB);  // close track </name> and open track <description>
@@ -62,5 +62,5 @@ void Kml::end(const FlightStats stats) {
   file.println(KMLtrackFooterD);  // close document </name> and open document <description>
   // skipping KML file description.  Not needed and clogs up the google earth places list
   file.println(KMLtrackFooterE);  // close document </description> and close document and kml tags
-  Flight::end(stats);
+  Flight::end(stats, showSummary);
 }

--- a/src/vario/logbook/kml.h
+++ b/src/vario/logbook/kml.h
@@ -4,7 +4,7 @@
 class Kml : public Flight {
  public:
   bool startFlight() override;
-  void end(const FlightStats stats) override;
+  void end(const FlightStats stats, bool showSummary = true) override;
 
   const String fileNameSuffix() const override { return "kml"; }
   const String desiredFileName() const override;

--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -239,7 +239,7 @@ void flightTimer_start() {
 }
 
 // stop timer
-void flightTimer_stop() {
+void flightTimer_stop(bool showSummary) {
   windEstimator.clearWindEstimate();  // clear the wind estimate when we stop a flight
   power.resetAutoOffCounter();  // reset the auto-off counter when we stop a flight (it could have
                                 // counted up to nearly the limit prior to auto-starting a log)
@@ -252,7 +252,7 @@ void flightTimer_stop() {
   log_captureEndingValues();
 
   // close the flight
-  flight->end(logbook);
+  flight->end(logbook, showSummary);
   // TODO:  A much cooler end flight sound.  Perhaps even an easter egg?
   speaker.playSound(fx::confirm);
   flight = NULL;

--- a/src/vario/logging/log.h
+++ b/src/vario/logging/log.h
@@ -26,7 +26,7 @@ bool flightTimer_autoStop(void);
 
 // Flight Timer functions
 void flightTimer_start(void);
-void flightTimer_stop(void);
+void flightTimer_stop(bool showSummary = true);
 void flightTimer_toggle(void);
 bool flightTimer_isRunning(void);  // If the timer is running
 bool flightTimer_isLogging(void);  // If the flight recorder log is logging

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -212,17 +212,17 @@ void Power::shutdown() { shutdown(false); }
 void Power::shutdown(bool deadBattery) {
   Serial.println("power_shutdown");
 
+  // save logs and system data
+  if (flightTimer_isRunning()) {
+    flightTimer_stop(false);
+  }
+
   // Show user we're shutting down
   display.clearPage();
   if (deadBattery) {
     display_batteryDead_splash();
   } else {
     display_off_splash();
-  }
-
-  // save logs and system data
-  if (flightTimer_isRunning()) {
-    flightTimer_stop();
   }
 
   baro.sleep();  // stop getting climbrate updates so we don't hear vario beeps while shutting down

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -89,6 +89,7 @@ void Power::bootUp() {
   } else {
     // if not center button, then USB power turned us on, go into charge mode
     info_.onState = PowerState::OffUSB;
+    display.setPage(MainPage::Charging);
   }
 
   // init peripherals (even if we're not turning on and just going into
@@ -212,7 +213,7 @@ void Power::shutdown(bool deadBattery) {
   Serial.println("power_shutdown");
 
   // Show user we're shutting down
-  display.clear();
+  display.clearPage();
   if (deadBattery) {
     display_batteryDead_splash();
   } else {
@@ -251,6 +252,7 @@ void Power::shutdown(bool deadBattery) {
   // go to PowerState::OffUSB, in case device was shut down while
   // plugged into USB, then we can show necessary charging updates etc
   info_.onState = PowerState::OffUSB;
+  display.setPage(MainPage::Charging);
 }
 
 void Power::latchOn() { digitalWrite(POWER_LATCH, HIGH); }
@@ -317,15 +319,7 @@ void Power::readBatteryState() {
 #endif
 
   // Test internal calibration of ADC:
-  info_.battMvCal = analogReadMilliVolts(BATT_SENSE) * 69 / 41;
-
-  // Battery Voltage Level & Percent Remaining
-  info_.batteryADC = analogRead(BATT_SENSE);
-  // uint16_t batt_level_mv = adc_level * 5554 / 4095;  //    (3300mV ADC range / .5942 V_divider)
-  // = 5554.  Then divide by 4095 steps of resolution adjusted formula to account for ESP32 ADC
-  // non-linearity; based on calibration measurements.  This is most accurate between 2.4V
-  // and 4.7V
-  info_.batteryMV = info_.batteryADC * 5300 / 4095 + 260;
+  info_.batteryMV = analogReadMilliVolts(BATT_SENSE) * 69 / 41;
 
   if (info_.batteryMV < BATT_EMPTY_MV) {
     info_.batteryPercent = 0;

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -38,8 +38,6 @@ class Power {
   struct Info {
     int8_t batteryPercent;  // battery percentage remaining from 0-100%
     uint16_t batteryMV;     // milivolts battery voltage (typically between 3200 and 4200)
-    uint16_t batteryADC;    // ADC raw output from ESP32 input pin
-    uint16_t battMvCal;     // Calibrated battery voltage (milivolts)
     bool charging = false;  // if system is being charged or not
     bool USBinput = false;  // if system is plugged into USB power or not
     PowerState onState = PowerState::Off;

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -136,6 +136,11 @@ void Display::showOnSplash() { showSplashScreenFrames_ = 6; }
 // Will first display charging screen if charging, or splash screen if in the process of turning on
 // / waking up Then will display any current modal pages before falling back to the current page
 void Display::update() {
+  if (displayPage_ == MainPage::Blank) {
+    clear();
+    return;
+  }
+
   SpiLockGuard spiLock;  // Take out an SPI lock for the rending of the page
 
   if (displayPage_ == MainPage::Charging) {
@@ -186,6 +191,12 @@ void Display::update() {
 void Display::clear() {
   SpiLockGuard spiLock;
   u8g2.clear();
+}
+
+void Display::clearPage() {
+  clear();
+  mainMenuPage.pop_all_pages();
+  displayPage_ = MainPage::Blank;
 }
 
 void GLCD_inst(byte data) {

--- a/src/vario/ui/display/display.h
+++ b/src/vario/ui/display/display.h
@@ -27,7 +27,8 @@ enum class MainPage : uint8_t {
   ThermalAdv = 3,
   Nav = 4,
   Menu = 5,
-  Charging = 6
+  Charging = 6,
+  Blank = 7
 };
 DEFINE_WRAPPING_BOUNDS(MainPage, MainPage::Debug, MainPage::Menu);
 
@@ -35,7 +36,9 @@ class Display {
  public:
   void init();
   void update();
-  void clear();
+  void clear();      // clear all pixels on the display
+  void clearPage();  // reset all display target pages and pop-ups (there will be no target content
+                     // after this call)
   void setContrast(uint8_t contrast);
 
   void turnPage(PageAction action);

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -656,24 +656,6 @@ void display_battIcon(uint8_t x, uint8_t y, bool vertical) {
   else
     u8g2.setFont(leaf_icons);
   u8g2.print(battIcon);
-  /*
-  Serial.print("percent: ");
-  Serial.print(battPercent);
-  Serial.print(" icon: ");
-  Serial.print((char)battIcon);
-  Serial.print(" milivolts: ");
-  Serial.print(battMV);
-  Serial.print(" ADC: ");
-  Serial.println(battADC);
-
-  u8g2.setFont(leaf_6x12);
-  u8g2.setCursor(x, y+=15);
-  u8g2.print(battPercent);
-  u8g2.setCursor(x, y+=15);
-  u8g2.print(battMV);
-  u8g2.setCursor(x, y+=15);
-  u8g2.print(battADC);
-  */
 }
 
 void display_batt_charging_fullscreen(uint8_t x, uint8_t y) {

--- a/src/vario/ui/display/menu_page.cpp
+++ b/src/vario/ui/display/menu_page.cpp
@@ -64,6 +64,13 @@ void MenuPage::pop_page() {
   current_page->closed(true);
 }
 
+void MenuPage::pop_all_pages() {
+  // Pop all pages from the stack, notifying each page it has been closed
+  while (!get_current_page_stack().empty()) {
+    pop_page();
+  }
+}
+
 MenuPage* MenuPage::get_modal_page() {
   if (get_current_page_stack().empty()) return NULL;
   return get_current_page_stack().top();

--- a/src/vario/ui/display/menu_page.h
+++ b/src/vario/ui/display/menu_page.h
@@ -42,6 +42,10 @@ class MenuPage {
   // If there is no modal page, returns NULL.
   MenuPage* get_modal_page();
 
+  // Pops all modal pages off the stack, returning to a blank slate with no
+  // modal pages
+  void pop_all_pages();
+
  protected:
   void cursor_prev();
   void cursor_next();

--- a/src/vario/ui/display/pages/primary/page_charging.cpp
+++ b/src/vario/ui/display/pages/primary/page_charging.cpp
@@ -45,22 +45,24 @@ void chargingPage_draw() {
     u8g2.print("mA ");
 #endif
     u8g2.setCursor(30, yPos + 10);
-    u8g2.print(info.battMvCal);
+    u8g2.print(info.batteryMV);
     u8g2.print("mV");
     u8g2.setDrawColor(1);
 
-    // Show Input Current limit (not actually charge current)
-    u8g2.setFont(leaf_6x12);
-    u8g2.setCursor(10, 157);
-    u8g2.print("Limit: ");
-    if (info.inputCurrent == PowerInputLevel::i100mA)
-      u8g2.print("100mA");
-    else if (info.inputCurrent == PowerInputLevel::i500mA)
-      u8g2.print("500mA");
-    else if (info.inputCurrent == PowerInputLevel::Max)
-      u8g2.print("810mA");
-    else if (info.inputCurrent == PowerInputLevel::Standby)
-      u8g2.print(" OFF");
+    if (settings.dev_menu) {
+      // If Developer Mode enabled, show Input Current max limit
+      u8g2.setFont(leaf_6x12);
+      u8g2.setCursor(10, 157);
+      u8g2.print("Limit: ");
+      if (info.inputCurrent == PowerInputLevel::i100mA)
+        u8g2.print("100mA");
+      else if (info.inputCurrent == PowerInputLevel::i500mA)
+        u8g2.print("500mA");
+      else if (info.inputCurrent == PowerInputLevel::Max)
+        u8g2.print("810mA");
+      else if (info.inputCurrent == PowerInputLevel::Standby)
+        u8g2.print(" OFF");
+    }
 
     // Display the current SW version
     u8g2.setCursor(0, 172);
@@ -99,9 +101,10 @@ void chargingPage_button(Button button, ButtonEvent state, uint8_t count) {
         case ButtonEvent::CLICKED:
           break;
         case ButtonEvent::HELD:
-          power.increaseInputCurrent();
-
-          speaker.playSound(fx::enter);
+          if (settings.dev_menu) {
+            power.increaseInputCurrent();
+            speaker.playSound(fx::enter);
+          }
           break;
       }
       break;
@@ -110,8 +113,10 @@ void chargingPage_button(Button button, ButtonEvent state, uint8_t count) {
         case ButtonEvent::CLICKED:
           break;
         case ButtonEvent::HELD:
-          power.decreaseInputCurrent();
-          speaker.playSound(fx::exit);
+          if (settings.dev_menu) {
+            power.decreaseInputCurrent();
+            speaker.playSound(fx::exit);
+          }
           break;
       }
       break;

--- a/src/vario/ui/display/pages/primary/page_debug.cpp
+++ b/src/vario/ui/display/pages/primary/page_debug.cpp
@@ -64,16 +64,15 @@ void debugPage_draw() {
     u8g2.setFont(leaf_5h);
     u8g2.print((float)info.batteryMV / 1000, 3);
     u8g2.print("v");
-
-    u8g2.setCursor(x, y += 10);
+    u8g2.setCursor(x, y += 8);
     u8g2.print(info.chargeCurrentMA);
     u8g2.print("mA");
 
     // Altimeter Setting
-    u8g2.setCursor(65, 36);
+    u8g2.setCursor(65, 40);
     u8g2.setFont(leaf_5h);
     u8g2.print("AltSet:");
-    u8g2.setCursor(65, 49);
+    u8g2.setCursor(65, 53);
     u8g2.setFont(leaf_6x12);
     u8g2.print(baro.altimeterSetting);
 


### PR DESCRIPTION
Several improvements/fixes to the power functions and behavior:

* Use factory calibrated ADC voltage for battery state instead of the manually derived curve fit.  This improves charging accuracy and %-full errors.
* Fix improper display.update() calls during/after shutdown.  New display.clearPage() function to clear the display page target and clear any modal pop-up pages.  This ensures:
  * As the device switches to "off" state and sleeps peripherals, there can be no lingering display.update() call to operational pages if the shutdown command happened to occur in a 10ms cycle where display.update() was also going to be called.  This was rare, but causing rare crashes if peripherals were put to sleep before the display.update() tried to read them
  * All modal pages are cleared, so that if the device is plugged into USB when turned off, the stack isn't saved, which results in a pop-up showing when you next turn the device on
  * Related, Show Flight Summary now is conditional on a bool argument in flight.end(), allowing us to skip showing the modal pop up summary page if desired (for example when shutting down the unit and users wouldn't see it anyway).
  
* Previously, input current limit setting for battery charger was exposed on the charging page (hold 'up' or 'down' to adjust charging current limits).  This is now removed, unless Developer mode is on.  This removes confusion and accidental adjustments by users unless they know what they're doing.