### PR TITLE
Reduce firmware differences in different build environments

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     strategy:
       matrix:
         hardware-variant:
@@ -31,8 +31,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-tags: true  # Ensures tags are available
-          fetch-depth: 0    # Ensures full history is fetched
+          fetch-tags: true # Ensures tags are available
+          fetch-depth: 0 # Ensures full history is fetched
 
       - uses: actions/cache@v4
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install PlatformIO Core
         run: pip install platformio==6.1.19
@@ -61,7 +61,7 @@ jobs:
             .pio/build/${{ matrix.hardware-variant }}_${{ matrix.behavior-variant }}/firmware-*.bin
 
       - name: Upload latest_firmware.json artifact
-        if: matrix.behavior-variant == 'release' && matrix.hardware-variant == 'leaf_3_2_5'  # Arbitrary single job from the matrix (any job will work)
+        if: matrix.behavior-variant == 'release' && matrix.hardware-variant == 'leaf_3_2_5' # Arbitrary single job from the matrix (any job will work)
         uses: actions/upload-artifact@v4
         with:
           name: versions

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,7 @@ extra_configs =
 
 # See documentation in scripts for expected configuration variables
 extra_scripts =
+	pre:src/scripts/reproducible_build.py
 	pre:src/scripts/capture_build_info.py
 	pre:src/scripts/versioning.py
 	post:src/scripts/rename_firmware.py

--- a/src/scripts/reproducible_build.py
+++ b/src/scripts/reproducible_build.py
@@ -1,0 +1,67 @@
+# Attempt to make firmware binaries more reproducible by equalizing
+# machine-specific strings and setting timestamps according to the commit.
+#
+# Does not equalize precompiled library strings in toolchain packages that may
+# differ between host OS (Linux/Windows).
+
+Import("env")
+
+import os
+import pathlib
+import subprocess
+
+
+def _run_git(args: list[str]) -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", *args],
+            cwd=env["PROJECT_DIR"],
+            stderr=subprocess.STDOUT,
+        ).decode(errors="replace").strip()
+    except Exception:
+        return None
+
+
+def _path_forms(path: pathlib.Path) -> list[str]:
+    resolved = path.resolve()
+    forms = [str(resolved), resolved.as_posix()]
+    # GCC diagnostics and __FILE__ strings on Windows commonly use forward
+    # slashes even when Python/SCons starts with backslash paths.
+    forms.append(str(resolved).replace("\\", "/"))
+    return sorted(set(forms), key=len, reverse=True)
+
+
+def _append_prefix_maps(source: pathlib.Path, target: str, flags: list[str]) -> None:
+    for source_form in _path_forms(source):
+        flags.append(f"-ffile-prefix-map={source_form}={target}")
+        flags.append(f"-fmacro-prefix-map={source_form}={target}")
+
+
+def _configure_source_date_epoch() -> None:
+    # GCC uses SOURCE_DATE_EPOCH to make __DATE__ and __TIME__ deterministic.
+    # Use the commit time so release builds still carry meaningful provenance.
+    if os.environ.get("SOURCE_DATE_EPOCH"):
+        return
+
+    commit_time = _run_git(["log", "-1", "--format=%ct"])
+    os.environ["SOURCE_DATE_EPOCH"] = commit_time if commit_time else "0"
+
+
+def _configure_prefix_maps() -> None:
+    flags: list[str] = []
+    project_dir = pathlib.Path(env["PROJECT_DIR"])
+    _append_prefix_maps(project_dir, "/leaf", flags)
+
+    platformio_home = pathlib.Path.home() / ".platformio"
+    if platformio_home.exists():
+        _append_prefix_maps(platformio_home, "/platformio", flags)
+
+    env.Append(CCFLAGS=flags)
+    env.Append(CXXFLAGS=flags)
+
+    print("[reproducible_build.py] SOURCE_DATE_EPOCH=" + os.environ["SOURCE_DATE_EPOCH"])
+    print("[reproducible_build.py] Added path prefix maps for project and PlatformIO roots")
+
+
+_configure_source_date_epoch()
+_configure_prefix_maps()


### PR DESCRIPTION
Currently, the firmware produced when building locally does not match the firmware produced by GitHub build actions.  Pinning a few unpinned dependencies probably alleviated the key problem leading to #271, but it should be possible to produce exactly the same binary, byte-for-byte, in whichever build environment the user happens to be using.  This PR works toward achieving that objective based on a conversation with Codex and its implementation of reproducible_build.py.  It also changes the GitHub build OS to Windows as apparently there are toolchain constants that get built into the actual firmware (!) so a build on Linux will never produce exactly the same firmware as a build on Windows.

Tested via the standard test procedure.

The firmware build in presubmit checks matches size exactly with locally-built firmware but isn't exactly identical.  The two differences in content are the version tag and the build time.  The version tag is different because GitHub creates a synthetic merge commit to test branches, so I expect this difference will disappear when local and server are building exactly the same commit.  Likewise, the build time is set according to the commit timestamp, so I expect the build time difference to disappear when building exactly the same commit.  Unfortunately, it will be difficult to verify this prior to merging this PR to main.  After it is merged, we should be able to definitively verify identical firmware build contents.  If contents still differ, I still think this PR will have been a positive contribution toward identical firmware builds.