### PR TITLE
Add Auto-Off Alert Dialog

### DIFF
--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -21,9 +21,13 @@
 #include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 #include "ui/display/display_fields.h"
+#include "ui/display/pages/dialogs/page_alert_autoOff.h"
 #include "ui/input/buttons.h"
 #include "ui/settings/settings.h"
 #include "utils/magic_enum.h"
+
+// Alert page to warn if auto-off is about to occur
+PageAlertAutoOff pageAlertAutoOff;
 
 Power power;  // struct for battery-state and on-state variables
 
@@ -292,7 +296,20 @@ void Power::update() {
   }
 }
 
-void Power::resetAutoOffCounter() { autoOffCounter_ = 0; }
+bool showingAlertAutoOff = false;
+
+void Power::resetAutoOffCounter() {
+  autoOffCounter_ = 0;
+  if (showingAlertAutoOff) {
+    buttons.consumeButton();
+    pageAlertAutoOff.closeAlert();  // close the alert if it's open, since we're shutting down now
+    showingAlertAutoOff = false;    // reset alert page flag so it can show again after this reset
+  }
+}
+
+uint16_t Power::getAutoOffSecondsRemaining() {
+  return (settings.system_autoOff * 60 - autoOffCounter_);
+}
 
 bool Power::autoOff() {
   bool autoShutOff = false;  // start with assuming we're not going to turn off
@@ -301,8 +318,19 @@ bool Power::autoOff() {
   if (autoOffCounter_ >= settings.system_autoOff * 60) {  // convert minutes to seconds
     autoShutOff = true;
   } else if (autoOffCounter_ >= settings.system_autoOff * 60 - 10) {
-    speaker.playSound(
-        fx::decrease);  // start playing warning sounds 5 seconds before it auto-turns off
+    // start playing warning sounds 10 seconds before it auto-turns off
+    speaker.playSound(fx::decrease);
+
+    // and pop up the alert if we have 10 seconds left
+    if (autoOffCounter_ == settings.system_autoOff * 60 - 10 && !showingAlertAutoOff) {
+      pageAlertAutoOff.show();  // show alert page with countdown until auto-off
+      showingAlertAutoOff = true;
+    }
+  }
+  if (autoShutOff) {
+    pageAlertAutoOff.closeAlert();  // close the alert if it's open, since we're shutting down now
+    showingAlertAutoOff =
+        false;  // reset alert page flag for next time we turn on and start counting
   }
   return autoShutOff;
 }

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -57,6 +57,7 @@ class Power {
   void update();
 
   void resetAutoOffCounter();
+  uint16_t getAutoOffSecondsRemaining();
 
   void increaseInputCurrent();
   void decreaseInputCurrent();

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -999,16 +999,16 @@ void displayWaypointDropletPointer(uint8_t centerX, uint8_t centerY, uint8_t poi
 // Menu Title Bar
 void display_menuTitle(String title) {
   u8g2.setFont(leaf_6x12);
-  u8g2.setCursor(9, 14);
+  u8g2.setCursor(8, 14);
   u8g2.setDrawColor(1);
   u8g2.print(title);
   uint8_t xPos = u8g2.getCursorX();
 
   // top "folder tab" outline
   u8g2.drawHLine(0, 15, 96);
-  u8g2.drawLine(2, 15, 5, 0);
+  u8g2.drawLine(1, 15, 4, 0);
   u8g2.drawHLine(5, 0, xPos - 2);
-  u8g2.drawLine(xPos + 3, 0, xPos + 6, 15);
+  u8g2.drawLine(xPos + 2, 0, xPos + 5, 15);
 
   // bottom footer outline
   u8g2.drawHLine(0, 174, 96);

--- a/src/vario/ui/display/pages/dialogs/page_alert_autoOff.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_alert_autoOff.cpp
@@ -1,0 +1,38 @@
+#include "ui/display/pages/dialogs/page_alert_autoOff.h"
+
+#include "power.h"
+#include "ui/audio/speaker.h"
+#include "ui/display/display.h"
+#include "ui/display/display_fields.h"
+#include "ui/display/fonts.h"
+
+void PageAlertAutoOff::draw_extra() {
+  // Title
+  display_menuTitle(String(get_title()));
+
+  uint8_t offset = 15;
+  uint8_t yPos = 30;
+  u8g2.setFont(leaf_6x12);
+  u8g2.setCursor(32, yPos);
+  u8g2.print("Alert!");
+  u8g2.setCursor(22, yPos += offset);
+  u8g2.print("leaf will");
+  u8g2.setCursor(10, yPos += offset);
+  u8g2.print("shutdown in:");
+  u8g2.setCursor(20, yPos += offset);
+  u8g2.print(power.getAutoOffSecondsRemaining());
+  u8g2.print(" seconds!");
+}
+
+void PageAlertAutoOff::show() { push_page(this); }
+
+void PageAlertAutoOff::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (cursor_position == CURSOR_BACK && state == ButtonEvent::CLICKED) {
+    pop_page();
+    speaker.playSound(fx::confirm);
+    power.resetAutoOffCounter();  // reset the auto off counter if user acknowledges the alert. This
+                                  // happens on every button push, so we shouldn't strictly need the
+                                  // call here too, but adding for clarity and redundancy
+    return;
+  }
+}

--- a/src/vario/ui/display/pages/dialogs/page_alert_autoOff.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_alert_autoOff.cpp
@@ -11,17 +11,23 @@ void PageAlertAutoOff::draw_extra() {
   display_menuTitle(String(get_title()));
 
   uint8_t offset = 15;
-  uint8_t yPos = 30;
+  uint8_t yPos = 40;
   u8g2.setFont(leaf_6x12);
   u8g2.setCursor(32, yPos);
   u8g2.print("Alert!");
-  u8g2.setCursor(22, yPos += offset);
-  u8g2.print("leaf will");
+  u8g2.setCursor(22, yPos += 2 * offset);
+  u8g2.print("Leaf will");
   u8g2.setCursor(10, yPos += offset);
   u8g2.print("shutdown in:");
   u8g2.setCursor(20, yPos += offset);
   u8g2.print(power.getAutoOffSecondsRemaining());
   u8g2.print(" seconds!");
+  u8g2.setCursor(32, yPos += 2 * offset);
+  u8g2.print("Press");
+  u8g2.setCursor(17, yPos += offset);
+  u8g2.print("any button");
+  u8g2.setCursor(20, yPos += offset);
+  u8g2.print("to cancel");
 }
 
 void PageAlertAutoOff::show() { push_page(this); }

--- a/src/vario/ui/display/pages/dialogs/page_alert_autoOff.h
+++ b/src/vario/ui/display/pages/dialogs/page_alert_autoOff.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "ui/display/menu_page.h"
+
+class PageAlertAutoOff : public SimpleSettingsMenuPage {
+ public:
+  const char* get_title() const override { return "! AUTO OFF !"; }
+  void draw_extra() override;
+  void show();
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
+  void closeAlert() { pop_page(); }
+};


### PR DESCRIPTION
Add a pop up alert that shows the last 10 second count-down before Leaf auto-turns off.  Can dismiss the dialog with any direction button push (which also resets the auto off timer).