### PR TITLE
Update GPS Sat info from other constellations

### DIFF
--- a/src/vario/instruments/gps.cpp
+++ b/src/vario/instruments/gps.cpp
@@ -24,39 +24,39 @@ LeafGPS gps;
 #define DEBUG_GPS 0
 
 namespace {
-bool isGsvSentence(const NMEAString& nmea) {
-  return nmea.length() >= 7 && nmea[0] == '$' && nmea[3] == 'G' && nmea[4] == 'S' &&
-         nmea[5] == 'V' && nmea[6] == ',';
-}
-
-bool parseNmeaIntField(const NMEAString& nmea, uint8_t targetField, int& value) {
-  uint8_t field = 0;
-  size_t start = nmea[0] == '$' ? 1 : 0;
-
-  for (size_t i = start; i <= nmea.length(); ++i) {
-    char c = i < nmea.length() ? nmea[i] : '\0';
-    if (c == ',' || c == '*' || c == '\0') {
-      if (field == targetField) {
-        if (i == start) return false;
-
-        int parsed = 0;
-        for (size_t j = start; j < i; ++j) {
-          if (nmea[j] < '0' || nmea[j] > '9') return false;
-          parsed = parsed * 10 + (nmea[j] - '0');
-        }
-
-        value = parsed;
-        return true;
-      }
-
-      ++field;
-      start = i + 1;
-      if (c == '*' || c == '\0') return false;
-    }
+  bool isGsvSentence(const NMEAString& nmea) {
+    return nmea.length() >= 7 && nmea[0] == '$' && nmea[3] == 'G' && nmea[4] == 'S' &&
+           nmea[5] == 'V' && nmea[6] == ',';
   }
 
-  return false;
-}
+  bool parseNmeaIntField(const NMEAString& nmea, uint8_t targetField, int& value) {
+    uint8_t field = 0;
+    size_t start = nmea[0] == '$' ? 1 : 0;
+
+    for (size_t i = start; i <= nmea.length(); ++i) {
+      char c = i < nmea.length() ? nmea[i] : '\0';
+      if (c == ',' || c == '*' || c == '\0') {
+        if (field == targetField) {
+          if (i == start) return false;
+
+          int parsed = 0;
+          for (size_t j = start; j < i; ++j) {
+            if (nmea[j] < '0' || nmea[j] > '9') return false;
+            parsed = parsed * 10 + (nmea[j] - '0');
+          }
+
+          value = parsed;
+          return true;
+        }
+
+        ++field;
+        start = i + 1;
+        if (c == '*' || c == '\0') return false;
+      }
+    }
+
+    return false;
+  }
 }  // namespace
 
 const char enableGGA[] PROGMEM = "$PAIR062,0,1";  // enable GGA message every 1 second
@@ -194,8 +194,7 @@ void LeafGPS::updateSatList(const NMEAString& nmea) {
 
   int totalMessages = 0;
   int currentMessage = 0;
-  if (!parseNmeaIntField(nmea, 1, totalMessages) ||
-      !parseNmeaIntField(nmea, 2, currentMessage)) {
+  if (!parseNmeaIntField(nmea, 1, totalMessages) || !parseNmeaIntField(nmea, 2, currentMessage)) {
     return;
   }
 

--- a/src/vario/instruments/gps.cpp
+++ b/src/vario/instruments/gps.cpp
@@ -23,6 +23,42 @@ LeafGPS gps;
 
 #define DEBUG_GPS 0
 
+namespace {
+bool isGsvSentence(const NMEAString& nmea) {
+  return nmea.length() >= 7 && nmea[0] == '$' && nmea[3] == 'G' && nmea[4] == 'S' &&
+         nmea[5] == 'V' && nmea[6] == ',';
+}
+
+bool parseNmeaIntField(const NMEAString& nmea, uint8_t targetField, int& value) {
+  uint8_t field = 0;
+  size_t start = nmea[0] == '$' ? 1 : 0;
+
+  for (size_t i = start; i <= nmea.length(); ++i) {
+    char c = i < nmea.length() ? nmea[i] : '\0';
+    if (c == ',' || c == '*' || c == '\0') {
+      if (field == targetField) {
+        if (i == start) return false;
+
+        int parsed = 0;
+        for (size_t j = start; j < i; ++j) {
+          if (nmea[j] < '0' || nmea[j] > '9') return false;
+          parsed = parsed * 10 + (nmea[j] - '0');
+        }
+
+        value = parsed;
+        return true;
+      }
+
+      ++field;
+      start = i + 1;
+      if (c == '*' || c == '\0') return false;
+    }
+  }
+
+  return false;
+}
+}  // namespace
+
 const char enableGGA[] PROGMEM = "$PAIR062,0,1";  // enable GGA message every 1 second
 const char enableGSV[] PROGMEM = "PAIR062,3,4";   // enable GSV message every 1 second
 const char enableRMC[] PROGMEM = "PAIR062,4,1";   // enable RMC message every 1 second
@@ -99,7 +135,6 @@ void LeafGPS::updateFixInfo() {
 void LeafGPS::update() {
   // update sats if we're tracking sat NMEA sentences
   navigator.update();
-  updateSatList();
   updateFixInfo();
   calculateGlideRatio();
 
@@ -135,6 +170,8 @@ void LeafGPS::on_receive(const GpsMessage& msg) {
     newSentence = gps.encode('\r');
   }
   if (newSentence) {
+    updateSatList(msg.nmea);
+
     NMEASentenceContents contents = {.speed = gps.speed.isUpdated(),
                                      .course = gps.course.isUpdated()};
     // Push the parsed reading onto the bus!
@@ -149,43 +186,60 @@ void LeafGPS::on_receive(const GpsMessage& msg) {
 // copy data from each satellite message into the sats[] array.  Then, if we reach the complete set
 // of sentences, copy the fresh sat data into the satDisplay[] array for showing on LCD screen when
 // needed.
-void LeafGPS::updateSatList() {
-  // copy data if we have a complete single sentence
-  if (totalGPGSVMessages.isUpdated()) {
-    for (int i = 0; i < 4; ++i) {
-      int no = atoi(satNumber[i].value());
-      // Serial.print(F("SatNumber is ")); Serial.println(no);
-      if (no >= 1 && no <= MAX_SATELLITES) {
-        sats[no - 1].elevation = atoi(elevation[i].value());
-        sats[no - 1].azimuth = atoi(azimuth[i].value());
-        sats[no - 1].snr = atoi(snr[i].value());
-        sats[no - 1].active = true;
-      }
+void LeafGPS::updateSatList(const NMEAString& nmea) {
+  if (!isGsvSentence(nmea)) {
+    gsvSentenceGroupActive = false;
+    return;
+  }
+
+  int totalMessages = 0;
+  int currentMessage = 0;
+  if (!parseNmeaIntField(nmea, 1, totalMessages) ||
+      !parseNmeaIntField(nmea, 2, currentMessage)) {
+    return;
+  }
+
+  if (currentMessage == 1 && !gsvSentenceGroupActive) {
+    for (int i = 0; i < MAX_SATELLITES; ++i) {
+      sats[i].active = false;
     }
+  }
+  gsvSentenceGroupActive = true;
 
-    // If we're on the final sentence, then copy data into the display array
-    int totalMessages = atoi(totalGPGSVMessages.value());
-    int currentMessage = atoi(messageNumber.value());
-    if (totalMessages == currentMessage) {
-      uint8_t satelliteCount = 0;
+  for (int i = 0; i < 4; ++i) {
+    int no = 0;
+    int elevationValue = 0;
+    int azimuthValue = 0;
+    int snrValue = 0;
+    const uint8_t field = 4 + 4 * i;
 
-      for (int i = 0; i < MAX_SATELLITES; ++i) {
-        // copy data
-        satsDisplay[i].elevation = sats[i].elevation;
-        satsDisplay[i].azimuth = sats[i].azimuth;
-        satsDisplay[i].snr = sats[i].snr;
-        satsDisplay[i].active = sats[i].active;
+    if (parseNmeaIntField(nmea, field, no) && no >= 1 && no <= MAX_SATELLITES &&
+        parseNmeaIntField(nmea, field + 1, elevationValue) &&
+        parseNmeaIntField(nmea, field + 2, azimuthValue)) {
+      parseNmeaIntField(nmea, field + 3, snrValue);
 
-        // keep track of how many satellites we can see while we're scanning through all the ID's
-        // (i)
-        if (satsDisplay[i].active) satelliteCount++;
-
-        // then negate the source, so it will only be used if it's truly updated again (i.e.,
-        // received again in an NMEA sat message)
-        sats[i].active = false;
-      }
-      fixInfo.numberOfSats = satelliteCount;  // save counted satellites
+      sats[no - 1].elevation = elevationValue;
+      sats[no - 1].azimuth = azimuthValue;
+      sats[no - 1].snr = snrValue;
+      sats[no - 1].active = true;
     }
+  }
+
+  // If we're on the final sentence, then copy data into the display array
+  if (totalMessages == currentMessage) {
+    uint8_t satelliteCount = 0;
+
+    for (int i = 0; i < MAX_SATELLITES; ++i) {
+      satsDisplay[i].elevation = sats[i].elevation;
+      satsDisplay[i].azimuth = sats[i].azimuth;
+      satsDisplay[i].snr = sats[i].snr;
+      satsDisplay[i].active = sats[i].active;
+
+      // keep track of how many satellites we can see while we're scanning through all the ID's
+      // (i)
+      if (satsDisplay[i].active) satelliteCount++;
+    }
+    fixInfo.numberOfSats = satelliteCount;  // save counted satellites
   }
 }
 

--- a/src/vario/instruments/gps.h
+++ b/src/vario/instruments/gps.h
@@ -85,7 +85,7 @@ class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, 
 
  private:
   void updateFixInfo();
-  void updateSatList(void);
+  void updateSatList(const NMEAString& nmea);
 
   void calculateGlideRatio();
 
@@ -123,6 +123,7 @@ class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, 
 
   NMEAString nmeaBuffer = {'\0'};  // buffer for reading NMEA sentences
   int nmeaBufferIndex = 0;         // index into the buffer currently writing to
+  bool gsvSentenceGroupActive = false;
 };
 extern LeafGPS gps;
 

--- a/src/vario/ui/display/pages/menu/page_menu_gps.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_gps.cpp
@@ -25,9 +25,9 @@ void GPSMenuPage::draw() {
     uint8_t linespacing = 10;  // for 5x8 font values like lat/lon/hdop
 
     // GPS constellation and lat/long
-    uint8_t size = 75;
-    uint8_t x = 8;
-    uint8_t y = 22;
+    uint8_t size = 92;
+    uint8_t x = 2;
+    uint8_t y = 30;
 
     drawConstellation(x, y, size);
 
@@ -37,38 +37,46 @@ void GPSMenuPage::draw() {
     u8g2.setFont(leaf_5x8);
 
     // Num of Sats (Upper left Corner)
-    u8g2.setCursor(0, y + 4);
+    u8g2.setCursor(0, y - 4);
     u8g2.print("Sats:");
     u8g2.setCursor(2, u8g2.getCursorY() + linespacing);
     u8g2.print(gps.satellites.value());
 
     // HDOP / accuracy (upper right corner)
-    u8g2.setCursor(70, y + 4);
+    u8g2.setCursor(70, y - 4);
     u8g2.print("HDOP:");
     u8g2.setCursor(76, u8g2.getCursorY() + linespacing);
     u8g2.print(float(gps.hdop.value()) / 100, 2);
 
     // draw lat long
-    u8g2.setCursor(0, size + y + linespacing + 2);
+    u8g2.setCursor(0, size + y + linespacing + 4);
     u8g2.print("Lat:");
-    u8g2.setCursor(25, u8g2.getCursorY());
-    u8g2.print(" ");
-    if (gps.location.lat() >= 0) u8g2.print(" ");
+    u8g2.setCursor(31, u8g2.getCursorY());
+    if (abs(gps.location.lat()) < 10) {
+      // add extra space for single-digit latitudes to align with longitude
+      u8g2.setCursor(u8g2.getCursorX() + 6, u8g2.getCursorY());
+    }
+    if (gps.location.lat() >= 0) u8g2.print("+");
     u8g2.print(gps.location.lat(), 7);
 
     u8g2.setCursor(0, u8g2.getCursorY() + linespacing);
     u8g2.print("Lon:");
     u8g2.setCursor(25, u8g2.getCursorY());
-    if (gps.location.lng() >= 0) u8g2.print(" ");
+    if (abs(gps.location.lng()) < 10) {
+      // add extra space for leading zeros
+      u8g2.setCursor(u8g2.getCursorX() + 6, u8g2.getCursorY());
+      if (abs(gps.location.lng()) < 10) {
+        u8g2.setCursor(u8g2.getCursorX() + 6, u8g2.getCursorY());
+      }
+    }
+    if (gps.location.lng() >= 0) u8g2.print("+");
     u8g2.print(gps.location.lng(), 7);
 
     // Menu Items
     u8g2.setFont(leaf_6x12);
-    uint8_t start_y = 29;
-    uint8_t y_spacing = 16;
     uint8_t setting_name_x = 3;
     uint8_t setting_choice_x = 74;
-    uint8_t menu_items_y[] = {190, 155};
+    uint8_t menu_items_y[] = {190, 165};
 
     // first draw cursor selection box
     u8g2.drawRBox(setting_choice_x - 2, menu_items_y[cursor_position] - 14, 22, 16, 2);


### PR DESCRIPTION
GPS Sat info was previously only captured from "GPGSV" strings.  This would usually result in only about 4~6 satellites shown.

Additional Sat info comes through in GNGSV, GLGSV, GAGSV, GBGSV..etc.. messages based on the constellation.

This PR changes the way Sat info is updated.  Instead of a TinyGPS custom handler for just GPGSV strings, the code now handles all types of GSV strings from LeafGPS::on_receive.

Also made some tweaks to the GPS menu page to show things more clearly

Before/After:
<img width="392" height="346" alt="image" src="https://github.com/user-attachments/assets/7056d4aa-e7aa-4e69-aa01-79d39bd39954" />