### PR TITLE
Attempt diagnostic network connection once while off + charging

### DIFF
--- a/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
+++ b/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
@@ -19,12 +19,19 @@ DiagnosticNetwork diagnostic_network;
 void DiagnosticNetwork::reset(const char* reason) {
   Serial.printf("DiagnosticNetwork: reset (%s)\n", reason ? reason : "unknown");
   printed_end_state_ = false;
+  off_usb_scan_attempted_ = false;
   error_msg_ = "No error";
   state_ = State::Ready;
   next_scan_attempt_ms_ = millis() + SCAN_RETRY_DELAY_MS;
   WiFi.scanDelete();
   WiFi.disconnect(true, true);
 }
+
+bool DiagnosticNetwork::shouldResetWhenSwitchingOn() const {
+  return state_ == State::Ready || state_ == State::NoNetworkFound || state_ == State::Error;
+}
+
+bool DiagnosticNetwork::canSleepWhileCharging() const { return shouldResetWhenSwitchingOn(); }
 
 void DiagnosticNetwork::update() {
   if (state_ == State::Ready) {
@@ -74,14 +81,25 @@ void DiagnosticNetwork::update() {
 void DiagnosticNetwork::maybeLookForNetwork() {
   const Power::Info& info = power.info();
 
-  // Only look for network if the device is on and USB-powered
-  if (info.onState != PowerState::On || !info.USBinput) {
+  const bool onAndUsbPowered = info.onState == PowerState::On && info.USBinput;
+  const bool offAndCharging = info.onState == PowerState::OffUSB && info.charging;
+
+  // Look continuously while on and USB-powered, or exactly once when USB wakes the device into
+  // charge-only mode.
+  if (!onAndUsbPowered && !offAndCharging) {
     return;
   }
 
   uint32_t now = millis();
   if (now < next_scan_attempt_ms_) {
     return;
+  }
+
+  if (info.onState == PowerState::OffUSB) {
+    if (off_usb_scan_attempted_) {
+      return;
+    }
+    off_usb_scan_attempted_ = true;
   }
 
   Serial.printf("DiagnosticNetwork: starting scan (USBinput=%d onState=%s)\n", info.USBinput,

--- a/src/vario/diagnostics/diagnostic_network/diagnostic_network.h
+++ b/src/vario/diagnostics/diagnostic_network/diagnostic_network.h
@@ -23,6 +23,8 @@ class DiagnosticNetwork : private StateAssertMixin<DiagnosticNetwork> {
 
   void update();
   void reset(const char* reason);
+  bool canSleepWhileCharging() const;
+  bool shouldResetWhenSwitchingOn() const;
 
   const char* error_msg() const { return error_msg_; }
 
@@ -36,6 +38,7 @@ class DiagnosticNetwork : private StateAssertMixin<DiagnosticNetwork> {
   uint32_t next_scan_attempt_ms_ = 0;
 
   bool printed_end_state_ = false;
+  bool off_usb_scan_attempted_ = false;
 
   void maybeLookForNetwork();
   void checkForDiagnosticNetwork();

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -198,7 +198,9 @@ void Power::switchToOnState() {
   Serial.println("switch_to_on_state");
   info_.onState = PowerState::On;
   wakePeripherals();
-  diagnostic_network.reset("switch_to_on_state");
+  if (diagnostic_network.shouldResetWhenSwitchingOn()) {
+    diagnostic_network.reset("switch_to_on_state");
+  }
   maybeStartBusLog();
 }
 

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -160,12 +160,19 @@ void TaskManager::updateWhileCharging() {
     // update battery level and charge state
     power.readBatteryState();
 
+    // Try to connect to the diagnostic network once while in charge-only mode. If it connects,
+    // the connection will be preserved when the device switches to the on state.
+    diagnostic_network.update();
+
     // Check Buttons
     buttons.update();  // check Button for any presses (user can turn ON from charging state)
 
     // Prep to end this cycle and sleep
-    if (buttons.inspectPins() == Button::NONE)
+    if (buttons.inspectPins() == Button::NONE && diagnostic_network.canSleepWhileCharging()) {
       goToSleep = true;  // get ready to sleep if no button is being pushed
+    } else {
+      goToSleep = false;
+    }
   } else {
     if (goToSleep && settings.system_ecoMode) {  // don't allow sleep if ECO_MODE is off
 


### PR DESCRIPTION
Currently, leaf only attempts to connect to the diagnostic network when powered on (and charging via USB).  To support factory commissioning, this PR also has leaf attempt to connect to the diagnostic network once when off and charging via USB.