### PR TITLE
Discover leaf device on network during factory commissioning

### DIFF
--- a/factory_interface/src/factory_interface/app.py
+++ b/factory_interface/src/factory_interface/app.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from factory_interface.commissioning_tasks import get_flash_task, start_flash_firmware
+from factory_interface.network_discovery import get_find_device_task, start_find_device
 from factory_interface.settings import (
     FactoryInterfaceSettings,
     find_firmware_paths,
@@ -81,6 +82,18 @@ async def start_flash_firmware_task(serial_number: str) -> JSONResponse:
 @app.get("/api/setup/{serial_number}/flash", response_class=JSONResponse)
 async def get_flash_firmware_task(serial_number: str) -> JSONResponse:
     task = get_flash_task(serial_number)
+    return JSONResponse(task.snapshot())
+
+
+@app.post("/api/setup/{serial_number}/network-discovery", response_class=JSONResponse)
+async def start_network_discovery_task(serial_number: str) -> JSONResponse:
+    task = start_find_device(serial_number)
+    return JSONResponse(task.snapshot())
+
+
+@app.get("/api/setup/{serial_number}/network-discovery", response_class=JSONResponse)
+async def get_network_discovery_task(serial_number: str) -> JSONResponse:
+    task = get_find_device_task(serial_number)
     return JSONResponse(task.snapshot())
 
 

--- a/factory_interface/src/factory_interface/commissioning_tasks.py
+++ b/factory_interface/src/factory_interface/commissioning_tasks.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from subprocess import list2cmdline
 
+from factory_interface.network_discovery import (
+    start_find_device,
+    start_preflash_monitor,
+    stop_preflash_monitor,
+)
 from factory_interface.settings import load_settings
 
 
@@ -276,6 +281,7 @@ async def run_flash_firmware(serial_number: str) -> None:
         task.return_code = None
 
         try:
+            start_preflash_monitor(serial_number)
             command, firmware_path = build_flash_firmware_command()
             task.output += f"$ {format_command(command)}\n"
             process = await asyncio.create_subprocess_exec(
@@ -295,12 +301,15 @@ async def run_flash_firmware(serial_number: str) -> None:
             task.return_code = await process.wait()
             if task.return_code == 0:
                 task.status = "success"
+                start_find_device(serial_number)
             else:
                 task.status = "failure"
         except Exception as exc:
             task.output += f"\n{type(exc).__name__}: {exc}\n"
             task.return_code = -1
             task.status = "failure"
+        finally:
+            stop_preflash_monitor(serial_number)
 
 
 def start_flash_firmware(serial_number: str) -> FlashFirmwareTask:

--- a/factory_interface/src/factory_interface/network_discovery.py
+++ b/factory_interface/src/factory_interface/network_discovery.py
@@ -1,0 +1,177 @@
+import asyncio
+import json
+import secrets
+import socket
+from dataclasses import dataclass, field
+
+
+DISCOVERY_PORT = 7432
+DISCOVERY_REQUEST_PREFIX = "LEAF_DISCOVERY_REQUEST/1 "
+DISCOVERY_RESPONSE_TYPE = "leaf_discovery_response"
+PROBE_INTERVAL_SECONDS = 1.0
+PROBE_LISTEN_SECONDS = 0.4
+
+
+@dataclass(frozen=True)
+class LeafDiscoveryResponse:
+    ip_address: str
+    port: int
+    device_id: str
+    nonce: str
+
+    def snapshot(self) -> dict:
+        return {
+            "ip_address": self.ip_address,
+            "port": self.port,
+            "device_id": self.device_id,
+        }
+
+
+@dataclass
+class FindDeviceTask:
+    status: str = "idle"
+    device: LeafDiscoveryResponse | None = None
+    error: str | None = None
+    excluded_device_ids: set[str] = field(default_factory=set)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    def snapshot(self) -> dict:
+        return {
+            "status": self.status,
+            "device": self.device.snapshot() if self.device else None,
+            "error": self.error,
+        }
+
+
+class LeafDiscoveryProtocol(asyncio.DatagramProtocol):
+    def __init__(self, nonce: str):
+        self.nonce = nonce
+        self.responses: list[LeafDiscoveryResponse] = []
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        try:
+            payload = json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return
+
+        if payload.get("type") != DISCOVERY_RESPONSE_TYPE:
+            return
+        if payload.get("nonce") != self.nonce:
+            return
+
+        device_id = str(payload.get("device_id", "")).strip()
+        if not device_id:
+            return
+
+        try:
+            port = int(payload.get("http_port", 0))
+        except (TypeError, ValueError):
+            return
+        if port <= 0:
+            return
+
+        self.responses.append(
+            LeafDiscoveryResponse(
+                ip_address=addr[0],
+                port=port,
+                device_id=device_id,
+                nonce=self.nonce,
+            )
+        )
+
+
+find_device_tasks: dict[str, FindDeviceTask] = {}
+preflash_devices: dict[str, set[str]] = {}
+preflash_monitor_tasks: dict[str, asyncio.Task] = {}
+
+
+def get_find_device_task(serial_number: str) -> FindDeviceTask:
+    if serial_number not in find_device_tasks:
+        find_device_tasks[serial_number] = FindDeviceTask()
+    return find_device_tasks[serial_number]
+
+
+async def probe_once() -> list[LeafDiscoveryResponse]:
+    nonce = secrets.token_hex(8)
+    loop = asyncio.get_running_loop()
+    protocol = LeafDiscoveryProtocol(nonce)
+
+    transport, _ = await loop.create_datagram_endpoint(
+        lambda: protocol,
+        local_addr=("0.0.0.0", 0),
+        family=socket.AF_INET,
+        allow_broadcast=True,
+    )
+
+    try:
+        request = f"{DISCOVERY_REQUEST_PREFIX}{nonce}".encode("ascii")
+        transport.sendto(request, ("255.255.255.255", DISCOVERY_PORT))
+        await asyncio.sleep(PROBE_LISTEN_SECONDS)
+        return protocol.responses
+    finally:
+        transport.close()
+
+
+async def collect_existing_devices(serial_number: str) -> None:
+    preflash_devices[serial_number] = set()
+
+    while True:
+        try:
+            for response in await probe_once():
+                preflash_devices[serial_number].add(response.device_id)
+        except OSError:
+            pass
+        await asyncio.sleep(PROBE_INTERVAL_SECONDS)
+
+
+def start_preflash_monitor(serial_number: str) -> None:
+    stop_preflash_monitor(serial_number)
+    preflash_monitor_tasks[serial_number] = asyncio.create_task(
+        collect_existing_devices(serial_number)
+    )
+
+
+def stop_preflash_monitor(serial_number: str) -> None:
+    task = preflash_monitor_tasks.pop(serial_number, None)
+    if task is not None:
+        task.cancel()
+
+
+async def run_find_device(serial_number: str) -> None:
+    task = get_find_device_task(serial_number)
+
+    async with task.lock:
+        task.status = "running"
+        task.device = None
+        task.error = None
+        task.excluded_device_ids = set(preflash_devices.get(serial_number, set()))
+
+        try:
+            while True:
+                for response in await probe_once():
+                    if response.device_id in task.excluded_device_ids:
+                        continue
+
+                    task.device = response
+                    task.status = "success"
+                    return
+
+                await asyncio.sleep(PROBE_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            task.status = "idle"
+            raise
+        except Exception as exc:
+            task.status = "failure"
+            task.error = f"{type(exc).__name__}: {exc}"
+
+
+def start_find_device(serial_number: str) -> FindDeviceTask:
+    task = get_find_device_task(serial_number)
+    if task.status == "running":
+        return task
+
+    task.status = "running"
+    task.device = None
+    task.error = None
+    asyncio.create_task(run_find_device(serial_number))
+    return task

--- a/factory_interface/src/factory_interface/static/styles.css
+++ b/factory_interface/src/factory_interface/static/styles.css
@@ -209,6 +209,19 @@ button:focus-visible {
   border-bottom: 1px solid var(--line);
 }
 
+.checklist-item-with-details {
+  align-items: start;
+}
+
+.checklist-details {
+  grid-column: 2;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
 .bootloader-check {
   display: grid;
   grid-column: 1 / -1;

--- a/factory_interface/src/factory_interface/templates/setup_checklist.html
+++ b/factory_interface/src/factory_interface/templates/setup_checklist.html
@@ -33,6 +33,18 @@
       hidden
       aria-label="Flash firmware console output"
     ></textarea>
+
+    <div class="checklist-item checklist-item-with-details">
+      <button
+        class="task-icon task-icon-empty"
+        id="discovery-task-icon"
+        type="button"
+        aria-label="Toggle network discovery details"
+        disabled
+      ></button>
+      <span>Find device on network</span>
+      <p class="checklist-details" id="discovery-details" hidden></p>
+    </div>
   </div>
 </section>
 
@@ -41,24 +53,40 @@
   const bootloaderCheckbox = document.querySelector("#bootloader-mode");
   const flashTaskIcon = document.querySelector("#flash-task-icon");
   const flashConsole = document.querySelector("#flash-console");
-  let pollTimer = null;
+  const discoveryTaskIcon = document.querySelector("#discovery-task-icon");
+  const discoveryDetails = document.querySelector("#discovery-details");
+  let flashPollTimer = null;
+  let discoveryPollTimer = null;
+  let discoveryStartRequested = false;
 
-  function setFlashIcon(status) {
-    flashTaskIcon.className = "task-icon";
-    flashTaskIcon.disabled = status === "idle";
+  function setTaskIcon(icon, status) {
+    icon.className = "task-icon";
+    icon.disabled = status === "idle";
 
     if (status === "running") {
-      flashTaskIcon.classList.add("task-icon-running");
+      icon.classList.add("task-icon-running");
     } else if (status === "success") {
-      flashTaskIcon.classList.add("task-icon-success");
+      icon.classList.add("task-icon-success");
     } else if (status === "failure") {
-      flashTaskIcon.classList.add("task-icon-failure");
+      icon.classList.add("task-icon-failure");
     } else {
-      flashTaskIcon.classList.add("task-icon-empty");
+      icon.classList.add("task-icon-empty");
     }
   }
 
-  function applyTaskState(state) {
+  function setFlashIcon(status) {
+    setTaskIcon(flashTaskIcon, status);
+  }
+
+  function setDiscoveryIcon(status) {
+    setTaskIcon(discoveryTaskIcon, status);
+  }
+
+  function applyFlashTaskState(state) {
+    const previousStatus = flashTaskIcon.classList.contains("task-icon-success")
+      ? "success"
+      : null;
+
     setFlashIcon(state.status);
     flashConsole.value = state.output || "";
     flashConsole.scrollTop = flashConsole.scrollHeight;
@@ -66,30 +94,67 @@
     if (state.status === "running") {
       bootloaderCheckbox.checked = true;
       bootloaderCheckbox.disabled = true;
-      if (!pollTimer) {
-        pollTimer = setInterval(refreshTaskState, 500);
+      if (!flashPollTimer) {
+        flashPollTimer = setInterval(refreshFlashTaskState, 500);
       }
     } else if (state.status === "success") {
       bootloaderCheckbox.checked = true;
       bootloaderCheckbox.disabled = true;
-      clearInterval(pollTimer);
-      pollTimer = null;
+      clearInterval(flashPollTimer);
+      flashPollTimer = null;
+      if (previousStatus !== "success") {
+        startDiscoveryTask();
+      }
     } else if (state.status === "failure") {
       bootloaderCheckbox.checked = false;
       bootloaderCheckbox.disabled = false;
-      clearInterval(pollTimer);
-      pollTimer = null;
+      clearInterval(flashPollTimer);
+      flashPollTimer = null;
     } else {
       bootloaderCheckbox.checked = false;
       bootloaderCheckbox.disabled = false;
-      clearInterval(pollTimer);
-      pollTimer = null;
+      clearInterval(flashPollTimer);
+      flashPollTimer = null;
     }
   }
 
-  async function refreshTaskState() {
+  function applyDiscoveryTaskState(state) {
+    setDiscoveryIcon(state.status);
+
+    if (state.status === "success" && state.device) {
+      discoveryDetails.textContent = `IP address: ${state.device.ip_address}:${state.device.port}`;
+      discoveryDetails.hidden = false;
+      clearInterval(discoveryPollTimer);
+      discoveryPollTimer = null;
+    } else if (state.status === "running") {
+      discoveryDetails.textContent = "Searching for the newly flashed device...";
+      discoveryDetails.hidden = false;
+      if (!discoveryPollTimer) {
+        discoveryPollTimer = setInterval(refreshDiscoveryTaskState, 1000);
+      }
+    } else if (state.status === "failure") {
+      discoveryDetails.textContent = state.error || "Network discovery failed.";
+      discoveryDetails.hidden = false;
+      clearInterval(discoveryPollTimer);
+      discoveryPollTimer = null;
+    } else {
+      discoveryDetails.textContent = "";
+      discoveryDetails.hidden = true;
+      clearInterval(discoveryPollTimer);
+      discoveryPollTimer = null;
+    }
+  }
+
+  async function refreshFlashTaskState() {
     const response = await fetch(`/api/setup/${encodeURIComponent(serialNumber)}/flash`);
-    applyTaskState(await response.json());
+    applyFlashTaskState(await response.json());
+  }
+
+  async function refreshDiscoveryTaskState() {
+    const response = await fetch(
+      `/api/setup/${encodeURIComponent(serialNumber)}/network-discovery`
+    );
+    applyDiscoveryTaskState(await response.json());
   }
 
   async function startFlashTask() {
@@ -98,7 +163,26 @@
     const response = await fetch(`/api/setup/${encodeURIComponent(serialNumber)}/flash`, {
       method: "POST",
     });
-    applyTaskState(await response.json());
+    applyFlashTaskState(await response.json());
+  }
+
+  async function startDiscoveryTask() {
+    if (discoveryStartRequested) return;
+    discoveryStartRequested = true;
+    const currentResponse = await fetch(
+      `/api/setup/${encodeURIComponent(serialNumber)}/network-discovery`
+    );
+    const currentState = await currentResponse.json();
+    if (currentState.status === "running" || currentState.status === "success") {
+      applyDiscoveryTaskState(currentState);
+      return;
+    }
+
+    const response = await fetch(
+      `/api/setup/${encodeURIComponent(serialNumber)}/network-discovery`,
+      { method: "POST" }
+    );
+    applyDiscoveryTaskState(await response.json());
   }
 
   bootloaderCheckbox.addEventListener("change", () => {
@@ -111,6 +195,11 @@
     flashConsole.hidden = !flashConsole.hidden;
   });
 
-  refreshTaskState();
+  discoveryTaskIcon.addEventListener("click", () => {
+    discoveryDetails.hidden = !discoveryDetails.hidden;
+  });
+
+  refreshFlashTaskState();
+  refreshDiscoveryTaskState();
 </script>
 {% endblock %}

--- a/src/vario/comms/factory_discovery.cpp
+++ b/src/vario/comms/factory_discovery.cpp
@@ -1,0 +1,67 @@
+#include "comms/factory_discovery.h"
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <cstdio>
+#include <cstring>
+
+#include "diagnostics/diagnostic_network/diagnostic_network.h"
+
+namespace {
+  constexpr uint16_t DISCOVERY_PORT = 7432;
+  constexpr uint16_t HTTP_PORT = 81;
+  constexpr const char* REQUEST_PREFIX = "LEAF_DISCOVERY_REQUEST/1 ";
+  constexpr size_t REQUEST_PREFIX_LEN = 25;
+}  // namespace
+
+FactoryDiscovery factoryDiscovery;
+
+void FactoryDiscovery::update() {
+  if (diagnostic_network.connected()) {
+    if (!listening_) start();
+  } else if (listening_) {
+    stop();
+  }
+}
+
+void FactoryDiscovery::start() {
+  if (!udp_.listen(DISCOVERY_PORT)) {
+    Serial.println("FactoryDiscovery: failed to listen");
+    return;
+  }
+
+  udp_.onPacket([this](AsyncUDPPacket& packet) { this->onPacket(packet); });
+  listening_ = true;
+  Serial.printf("FactoryDiscovery: listening on UDP %u\n", DISCOVERY_PORT);
+}
+
+void FactoryDiscovery::stop() {
+  udp_.close();
+  listening_ = false;
+  Serial.println("FactoryDiscovery: stopped");
+}
+
+void FactoryDiscovery::onPacket(AsyncUDPPacket& packet) {
+  if (!diagnostic_network.connected()) return;
+  if (packet.length() <= REQUEST_PREFIX_LEN) return;
+
+  const char* data = reinterpret_cast<const char*>(packet.data());
+  if (std::memcmp(data, REQUEST_PREFIX, REQUEST_PREFIX_LEN) != 0) return;
+
+  const size_t nonce_len = packet.length() - REQUEST_PREFIX_LEN;
+  if (nonce_len > 64) return;
+
+  char nonce[65];
+  std::memcpy(nonce, data + REQUEST_PREFIX_LEN, nonce_len);
+  nonce[nonce_len] = '\0';
+
+  String mac = WiFi.macAddress();
+  char response[192];
+  snprintf(response, sizeof(response),
+           "{\"type\":\"leaf_discovery_response\",\"version\":1,"
+           "\"nonce\":\"%s\",\"device_id\":\"%s\",\"http_port\":%u}",
+           nonce, mac.c_str(), HTTP_PORT);
+
+  packet.print(response);
+  Serial.printf("FactoryDiscovery: responded to %s\n", packet.remoteIP().toString().c_str());
+}

--- a/src/vario/comms/factory_discovery.h
+++ b/src/vario/comms/factory_discovery.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <AsyncUDP.h>
+
+class FactoryDiscovery {
+ public:
+  void update();
+
+ private:
+  void start();
+  void stop();
+  void onPacket(AsyncUDPPacket& packet);
+
+  AsyncUDP udp_;
+  bool listening_ = false;
+};
+
+extern FactoryDiscovery factoryDiscovery;

--- a/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
+++ b/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
@@ -16,6 +16,11 @@ static constexpr uint32_t SCAN_RETRY_DELAY_MS = 2000;
 
 DiagnosticNetwork diagnostic_network;
 
+bool DiagnosticNetwork::connected() const {
+  return state_ == State::ConnectedToNetwork && WiFi.status() == WL_CONNECTED &&
+         WiFi.SSID() == DIAGNOSTIC_NETWORK_SSID;
+}
+
 void DiagnosticNetwork::reset(const char* reason) {
   Serial.printf("DiagnosticNetwork: reset (%s)\n", reason ? reason : "unknown");
   printed_end_state_ = false;

--- a/src/vario/diagnostics/diagnostic_network/diagnostic_network.h
+++ b/src/vario/diagnostics/diagnostic_network/diagnostic_network.h
@@ -20,6 +20,7 @@ class DiagnosticNetwork : private StateAssertMixin<DiagnosticNetwork> {
   };
 
   State state() const { return state_; }
+  bool connected() const;
 
   void update();
   void reset(const char* reason);

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -6,6 +6,7 @@
 #include "task.h"
 
 #include "comms/ble.h"
+#include "comms/factory_discovery.h"
 #include "diagnostics/diagnostic_network/diagnostic_network.h"
 #include "diagnostics/self_test/selfTest.h"
 #include "hardware/Leaf_SPI.h"
@@ -162,6 +163,7 @@ void TaskManager::updateWhileCharging() {
     // Try to connect to the diagnostic network once while in charge-only mode. If it connects,
     // the connection will be preserved when the device switches to the on state.
     diagnostic_network.update();
+    factoryDiscovery.update();
 
     // Check Buttons
     buttons.update();  // check Button for any presses (user can turn ON from charging state)
@@ -380,6 +382,7 @@ void TaskManager::doNecessaryTasks(void) {
 #endif
 
   diagnostic_network.update();
+  factoryDiscovery.update();
 
   if (performedNecessaryTasks && DEBUG_MAIN_LOOP) {
     performedNecessaryTasks = false;


### PR DESCRIPTION
This PR enables factory_interface to find a newly-flashed leaf device on the diagnostic network so that additional commissioning configuration can proceed.  When on the diagnostic network, leaf listens for UDP discovery packets emitted by the factory_interface server and responds with its IP address.  The factory_interface webapp is updated with a checklist item to find the device on the local network and this succeeds in testing with the IP address of the leaf device.