### PR TITLE
Initiate self-test from factory_interface

### DIFF
--- a/factory_interface/src/factory_interface/app.py
+++ b/factory_interface/src/factory_interface/app.py
@@ -8,6 +8,10 @@ from fastapi.templating import Jinja2Templates
 
 from factory_interface.commissioning_tasks import get_flash_task, start_flash_firmware
 from factory_interface.network_discovery import get_find_device_task, start_find_device
+from factory_interface.self_test_task import (
+    get_self_test_task,
+    start_interactive_self_test,
+)
 from factory_interface.settings import (
     FactoryInterfaceSettings,
     find_firmware_paths,
@@ -94,6 +98,18 @@ async def start_network_discovery_task(serial_number: str) -> JSONResponse:
 @app.get("/api/setup/{serial_number}/network-discovery", response_class=JSONResponse)
 async def get_network_discovery_task(serial_number: str) -> JSONResponse:
     task = get_find_device_task(serial_number)
+    return JSONResponse(task.snapshot())
+
+
+@app.post("/api/setup/{serial_number}/interactive-self-test", response_class=JSONResponse)
+async def start_interactive_self_test_task(serial_number: str) -> JSONResponse:
+    task = start_interactive_self_test(serial_number)
+    return JSONResponse(task.snapshot())
+
+
+@app.get("/api/setup/{serial_number}/interactive-self-test", response_class=JSONResponse)
+async def get_interactive_self_test_task(serial_number: str) -> JSONResponse:
+    task = get_self_test_task(serial_number)
     return JSONResponse(task.snapshot())
 
 

--- a/factory_interface/src/factory_interface/self_test_task.py
+++ b/factory_interface/src/factory_interface/self_test_task.py
@@ -1,0 +1,106 @@
+import asyncio
+import json
+from dataclasses import dataclass, field
+from urllib.request import Request, urlopen
+
+from factory_interface.network_discovery import get_find_device_task
+
+
+SELF_TEST_POLL_SECONDS = 1.0
+HTTP_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass
+class SelfTestTask:
+    status: str = "idle"
+    details: str = ""
+    result: dict | None = None
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    def snapshot(self) -> dict:
+        return {
+            "status": self.status,
+            "details": self.details,
+            "result": self.result,
+        }
+
+
+self_test_tasks: dict[str, SelfTestTask] = {}
+
+
+def get_self_test_task(serial_number: str) -> SelfTestTask:
+    if serial_number not in self_test_tasks:
+        self_test_tasks[serial_number] = SelfTestTask()
+    return self_test_tasks[serial_number]
+
+
+def device_self_test_url(serial_number: str) -> str:
+    discovery_task = get_find_device_task(serial_number)
+    if discovery_task.status != "success" or discovery_task.device is None:
+        raise RuntimeError("Device has not been discovered on the network.")
+
+    device = discovery_task.device
+    return f"http://{device.ip_address}:{device.port}/self-test"
+
+
+def fetch_json(url: str, *, method: str = "GET") -> dict:
+    request = Request(url, method=method)
+    with urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def status_result(payload: dict) -> str | None:
+    status = str(payload.get("status", "")).lower()
+    results = payload.get("results") if isinstance(payload.get("results"), dict) else {}
+    all_tests = str(results.get("all_tests", "")).lower()
+
+    if all_tests in {"pass", "success"} or status in {"pass", "success"}:
+        return "success"
+    if all_tests in {"fail", "failure"} or status in {"fail", "failure"}:
+        return "failure"
+    return None
+
+
+async def run_interactive_self_test(serial_number: str) -> None:
+    task = get_self_test_task(serial_number)
+
+    async with task.lock:
+        task.status = "running"
+        task.details = "Starting interactive self test..."
+        task.result = None
+
+        try:
+            base_url = device_self_test_url(serial_number)
+            await asyncio.to_thread(fetch_json, f"{base_url}/interactive", method="POST")
+
+            while True:
+                payload = await asyncio.to_thread(fetch_json, base_url)
+                task.result = payload
+                task.details = json.dumps(payload, indent=2)
+
+                result = status_result(payload)
+                if result is not None:
+                    task.status = result
+                    return
+
+                if not payload.get("running", False):
+                    task.status = "failure"
+                    task.details = "Self test stopped without a pass/fail result.\n\n" + task.details
+                    return
+
+                await asyncio.sleep(SELF_TEST_POLL_SECONDS)
+        except Exception as exc:
+            task.status = "failure"
+            task.details = f"{type(exc).__name__}: {exc}"
+
+
+def start_interactive_self_test(serial_number: str) -> SelfTestTask:
+    task = get_self_test_task(serial_number)
+    if task.status == "running":
+        return task
+
+    task.status = "running"
+    task.details = "Starting interactive self test..."
+    task.result = None
+    asyncio.create_task(run_interactive_self_test(serial_number))
+    return task

--- a/factory_interface/src/factory_interface/static/styles.css
+++ b/factory_interface/src/factory_interface/static/styles.css
@@ -222,6 +222,11 @@ button:focus-visible {
   overflow-wrap: anywhere;
 }
 
+.checklist-details-pre {
+  white-space: pre-wrap;
+  font-family: Consolas, "Courier New", monospace;
+}
+
 .bootloader-check {
   display: grid;
   grid-column: 1 / -1;

--- a/factory_interface/src/factory_interface/templates/setup_checklist.html
+++ b/factory_interface/src/factory_interface/templates/setup_checklist.html
@@ -45,6 +45,18 @@
       <span>Find device on network</span>
       <p class="checklist-details" id="discovery-details" hidden></p>
     </div>
+
+    <div class="checklist-item checklist-item-with-details">
+      <button
+        class="task-icon task-icon-empty"
+        id="self-test-task-icon"
+        type="button"
+        aria-label="Toggle interactive test details"
+        disabled
+      ></button>
+      <span>Interactive test</span>
+      <pre class="checklist-details checklist-details-pre" id="self-test-details" hidden></pre>
+    </div>
   </div>
 </section>
 
@@ -55,9 +67,13 @@
   const flashConsole = document.querySelector("#flash-console");
   const discoveryTaskIcon = document.querySelector("#discovery-task-icon");
   const discoveryDetails = document.querySelector("#discovery-details");
+  const selfTestTaskIcon = document.querySelector("#self-test-task-icon");
+  const selfTestDetails = document.querySelector("#self-test-details");
   let flashPollTimer = null;
   let discoveryPollTimer = null;
+  let selfTestPollTimer = null;
   let discoveryStartRequested = false;
+  let selfTestStartRequested = false;
 
   function setTaskIcon(icon, status) {
     icon.className = "task-icon";
@@ -80,6 +96,10 @@
 
   function setDiscoveryIcon(status) {
     setTaskIcon(discoveryTaskIcon, status);
+  }
+
+  function setSelfTestIcon(status) {
+    setTaskIcon(selfTestTaskIcon, status);
   }
 
   function applyFlashTaskState(state) {
@@ -126,6 +146,7 @@
       discoveryDetails.hidden = false;
       clearInterval(discoveryPollTimer);
       discoveryPollTimer = null;
+      startSelfTestTask();
     } else if (state.status === "running") {
       discoveryDetails.textContent = "Searching for the newly flashed device...";
       discoveryDetails.hidden = false;
@@ -145,6 +166,31 @@
     }
   }
 
+  function applySelfTestTaskState(state) {
+    setSelfTestIcon(state.status);
+
+    if (state.status === "success") {
+      selfTestDetails.textContent = state.details || "Interactive self test passed.";
+      clearInterval(selfTestPollTimer);
+      selfTestPollTimer = null;
+    } else if (state.status === "running") {
+      selfTestDetails.textContent = state.details || "Interactive self test is running...";
+      if (!selfTestPollTimer) {
+        selfTestPollTimer = setInterval(refreshSelfTestTaskState, 1000);
+      }
+    } else if (state.status === "failure") {
+      selfTestDetails.textContent = state.details || "Interactive self test failed.";
+      selfTestDetails.hidden = false;
+      clearInterval(selfTestPollTimer);
+      selfTestPollTimer = null;
+    } else {
+      selfTestDetails.textContent = "";
+      selfTestDetails.hidden = true;
+      clearInterval(selfTestPollTimer);
+      selfTestPollTimer = null;
+    }
+  }
+
   async function refreshFlashTaskState() {
     const response = await fetch(`/api/setup/${encodeURIComponent(serialNumber)}/flash`);
     applyFlashTaskState(await response.json());
@@ -155,6 +201,13 @@
       `/api/setup/${encodeURIComponent(serialNumber)}/network-discovery`
     );
     applyDiscoveryTaskState(await response.json());
+  }
+
+  async function refreshSelfTestTaskState() {
+    const response = await fetch(
+      `/api/setup/${encodeURIComponent(serialNumber)}/interactive-self-test`
+    );
+    applySelfTestTaskState(await response.json());
   }
 
   async function startFlashTask() {
@@ -185,6 +238,25 @@
     applyDiscoveryTaskState(await response.json());
   }
 
+  async function startSelfTestTask() {
+    if (selfTestStartRequested) return;
+    selfTestStartRequested = true;
+    const currentResponse = await fetch(
+      `/api/setup/${encodeURIComponent(serialNumber)}/interactive-self-test`
+    );
+    const currentState = await currentResponse.json();
+    if (currentState.status === "running" || currentState.status === "success") {
+      applySelfTestTaskState(currentState);
+      return;
+    }
+
+    const response = await fetch(
+      `/api/setup/${encodeURIComponent(serialNumber)}/interactive-self-test`,
+      { method: "POST" }
+    );
+    applySelfTestTaskState(await response.json());
+  }
+
   bootloaderCheckbox.addEventListener("change", () => {
     if (bootloaderCheckbox.checked) {
       startFlashTask();
@@ -199,7 +271,12 @@
     discoveryDetails.hidden = !discoveryDetails.hidden;
   });
 
+  selfTestTaskIcon.addEventListener("click", () => {
+    selfTestDetails.hidden = !selfTestDetails.hidden;
+  });
+
   refreshFlashTaskState();
   refreshDiscoveryTaskState();
+  refreshSelfTestTaskState();
 </script>
 {% endblock %}

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -5,6 +5,7 @@
 #include "diagnostics/memory_report.h"
 #include "diagnostics/self_test/selfTest.h"
 #include "etl/string_stream.h"
+#include "power.h"
 #include "storage/sd_card.h"
 #include "ui/display/display.h"
 #include "utils/lock_guard.h"
@@ -16,7 +17,11 @@ namespace {
 
   enum class SelfTestMode { None, Interactive };
 
+  static constexpr uint32_t SELF_TEST_POWER_ON_DELAY_MS = 10000;
+
   SelfTestMode last_self_test_mode = SelfTestMode::None;
+  bool interactive_self_test_pending = false;
+  uint32_t interactive_self_test_start_ms = 0;
 
   const char* selfTestModeName(SelfTestMode mode) {
     switch (mode) {
@@ -58,11 +63,15 @@ namespace {
     const bool running = selfTest.updateNeeded();
     String json = "{";
     json += "\"running\":";
-    json += running ? "true" : "false";
+    json += (running || interactive_self_test_pending) ? "true" : "false";
+    json += ",\"pending\":";
+    json += interactive_self_test_pending ? "true" : "false";
     json += ",\"mode\":\"";
     json += selfTestModeName(last_self_test_mode);
     json += "\",\"status\":\"";
-    json += running ? "running" : selfTestStatusName(selfTest.results.allTests);
+    json += interactive_self_test_pending ? "pending"
+                                          : running ? "running"
+                                                    : selfTestStatusName(selfTest.results.allTests);
     json += "\",\"results\":{";
     appendSelfTestResult(json, "sd_card", selfTest.results.sdCard);
     appendSelfTestResult(json, "baro", selfTest.results.baro);
@@ -77,6 +86,43 @@ namespace {
     appendSelfTestResult(json, "all_tests", selfTest.results.allTests, false);
     json += "}}";
     return json;
+  }
+
+  void beginInteractiveSelfTest() {
+    interactive_self_test_pending = false;
+    last_self_test_mode = SelfTestMode::Interactive;
+    selfTest.begin(false);
+  }
+
+  void requestInteractiveSelfTest() {
+    last_self_test_mode = SelfTestMode::Interactive;
+
+    if (interactive_self_test_pending) return;
+
+    if (power.info().onState == PowerState::OffUSB) {
+      display.clear();
+      display.showOnSplash();
+      display.setPage(MainPage::Thermal);
+      power.switchToOnState();
+      if (selfTest.updateNeeded()) return;
+
+      interactive_self_test_pending = true;
+      interactive_self_test_start_ms = millis();
+      return;
+    }
+
+    if (selfTest.updateNeeded()) return;
+
+    beginInteractiveSelfTest();
+  }
+
+  void updatePendingInteractiveSelfTest() {
+    if (!interactive_self_test_pending) return;
+
+    const uint32_t elapsed_ms = millis() - interactive_self_test_start_ms;
+    if (elapsed_ms >= SELF_TEST_POWER_ON_DELAY_MS) {
+      beginInteractiveSelfTest();
+    }
   }
 }  // namespace
 
@@ -245,8 +291,7 @@ void webserver_setup() {
   server.on("/memory", HTTP_GET, []() { server.send(200, "text/plain", getMemoryUsage()); });
 
   server.on("/self-test/interactive", HTTP_POST, []() {
-    last_self_test_mode = SelfTestMode::Interactive;
-    selfTest.begin(false);
+    requestInteractiveSelfTest();
     server.send(200, "application/json", selfTestSnapshotJson());
   });
 
@@ -264,5 +309,8 @@ void webserver_setup() {
 }
 
 void webserver_loop() {
-  if (WiFi.status() == WL_CONNECTED) server.handleClient();
+  if (WiFi.status() == WL_CONNECTED) {
+    server.handleClient();
+    updatePendingInteractiveSelfTest();
+  }
 }

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -70,8 +70,8 @@ namespace {
     json += selfTestModeName(last_self_test_mode);
     json += "\",\"status\":\"";
     json += interactive_self_test_pending ? "pending"
-                                          : running ? "running"
-                                                    : selfTestStatusName(selfTest.results.allTests);
+            : running                     ? "running"
+                                          : selfTestStatusName(selfTest.results.allTests);
     json += "\",\"results\":{";
     appendSelfTestResult(json, "sd_card", selfTest.results.sdCard);
     appendSelfTestResult(json, "baro", selfTest.results.baro);
@@ -295,9 +295,8 @@ void webserver_setup() {
     server.send(200, "application/json", selfTestSnapshotJson());
   });
 
-  server.on("/self-test", HTTP_GET, []() {
-    server.send(200, "application/json", selfTestSnapshotJson());
-  });
+  server.on("/self-test", HTTP_GET,
+            []() { server.send(200, "application/json", selfTestSnapshotJson()); });
 
   // Give it a chance to settle so the startup message has a valid IP address.
   delay(250);

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -3,6 +3,7 @@
 #include <WiFi.h>
 #include "comms/fanet_radio.h"
 #include "diagnostics/memory_report.h"
+#include "diagnostics/self_test/selfTest.h"
 #include "etl/string_stream.h"
 #include "storage/sd_card.h"
 #include "ui/display/display.h"
@@ -12,6 +13,71 @@ namespace {
   ::WebServer server;
   String send_buffer = "";
   bool webserver_started = false;
+
+  enum class SelfTestMode { None, Interactive };
+
+  SelfTestMode last_self_test_mode = SelfTestMode::None;
+
+  const char* selfTestModeName(SelfTestMode mode) {
+    switch (mode) {
+      case SelfTestMode::Interactive:
+        return "interactive";
+      case SelfTestMode::None:
+      default:
+        return "none";
+    }
+  }
+
+  const char* selfTestStatusName(SelfTest::Status status) {
+    switch (status) {
+      case SelfTest::Status::Pass:
+        return "pass";
+      case SelfTest::Status::Fail:
+        return "fail";
+      case SelfTest::Status::Running:
+        return "running";
+      case SelfTest::Status::Complete:
+        return "complete";
+      case SelfTest::Status::Unknown:
+      default:
+        return "unknown";
+    }
+  }
+
+  void appendSelfTestResult(String& json, const char* name, SelfTest::Status status,
+                            bool trailingComma = true) {
+    json += "\"";
+    json += name;
+    json += "\":\"";
+    json += selfTestStatusName(status);
+    json += "\"";
+    if (trailingComma) json += ",";
+  }
+
+  String selfTestSnapshotJson() {
+    const bool running = selfTest.updateNeeded();
+    String json = "{";
+    json += "\"running\":";
+    json += running ? "true" : "false";
+    json += ",\"mode\":\"";
+    json += selfTestModeName(last_self_test_mode);
+    json += "\",\"status\":\"";
+    json += running ? "running" : selfTestStatusName(selfTest.results.allTests);
+    json += "\",\"results\":{";
+    appendSelfTestResult(json, "sd_card", selfTest.results.sdCard);
+    appendSelfTestResult(json, "baro", selfTest.results.baro);
+    appendSelfTestResult(json, "imu", selfTest.results.imu);
+    appendSelfTestResult(json, "gps", selfTest.results.gps);
+    appendSelfTestResult(json, "ambient", selfTest.results.ambient);
+    appendSelfTestResult(json, "display", selfTest.results.display);
+    appendSelfTestResult(json, "buttons", selfTest.results.buttons);
+    appendSelfTestResult(json, "power", selfTest.results.power);
+    appendSelfTestResult(json, "speaker", selfTest.results.speaker);
+    appendSelfTestResult(json, "vario", selfTest.results.vario);
+    appendSelfTestResult(json, "all_tests", selfTest.results.allTests, false);
+    json += "}}";
+    return json;
+  }
 }  // namespace
 
 constexpr auto endl = "\n";
@@ -41,6 +107,7 @@ void webserver_setup() {
           <ul>
             <li><a href="/screenshot" target="_blank">Download Screenshot</a></li>
             <li><a href="/mass_storage" target="_blank">Start Mass Storage</a></li>
+            <li><a href="#" onclick="fetch('/self-test/interactive', {method: 'POST'}); return false;">Start Interactive Self Test</a></li>
             <li><a href="/fanet" target="_blank">FANet Message Stats</a></li>
             <li><a href="/memory" target="_blank">Memory Usage Stats</a></li>
           </ul>
@@ -176,6 +243,16 @@ void webserver_setup() {
   });
 
   server.on("/memory", HTTP_GET, []() { server.send(200, "text/plain", getMemoryUsage()); });
+
+  server.on("/self-test/interactive", HTTP_POST, []() {
+    last_self_test_mode = SelfTestMode::Interactive;
+    selfTest.begin(false);
+    server.send(200, "application/json", selfTestSnapshotJson());
+  });
+
+  server.on("/self-test", HTTP_GET, []() {
+    server.send(200, "application/json", selfTestSnapshotJson());
+  });
 
   // Give it a chance to settle so the startup message has a valid IP address.
   delay(250);


### PR DESCRIPTION
This PR adds leaf device webserver endpoints to initiate and monitor self tests, and then uses those endpoints in factory_interface to support a new checklist item for the self test ("Interactive test").  When a self-test is requested when the leaf device is on the charging screen, it automatically switches to on and waits 10 seconds to initiate the test.