### PR TITLE
GPS self test additions

### DIFF
--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -568,10 +568,10 @@ bool SelfTest::tallyResults() {
   bool allPass = true;
   if (results.sdCard != Status::Pass || results.baro != Status::Pass ||
       results.imu != Status::Pass || results.gps != Status::Pass ||
-      results.gpsFix != Status::Pass ||
-      results.ambient != Status::Pass || results.display != Status::Pass ||
-      results.buttons != Status::Pass || results.power != Status::Pass ||
-      results.speaker != Status::Pass || results.vario != Status::Pass) {
+      results.gpsFix != Status::Pass || results.ambient != Status::Pass ||
+      results.display != Status::Pass || results.buttons != Status::Pass ||
+      results.power != Status::Pass || results.speaker != Status::Pass ||
+      results.vario != Status::Pass) {
     allPass = false;
   }
   return allPass;

--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -23,11 +23,19 @@ VarioInteractiveTest varioTest;
 
 constexpr size_t BUFFER_SIZE = 512;
 constexpr uint32_t GPS_SERIAL_TEST_TIMEOUT_MS = 5000;
+constexpr uint32_t GPS_FIX_TEST_TIMEOUT_MS = 30UL * 60UL * 1000UL;
 File self_test_file;
 
 bool gpsSerialTestInitialized = false;
 uint32_t gpsSerialInitialPassedChecksumCount = 0;
 uint32_t gpsSerialStartMillis = 0;
+
+bool gpsFixTestInitialized = false;
+uint32_t gpsFixInitialSentencesWithFixCount = 0;
+uint32_t gpsFixStartMillis = 0;
+uint32_t gpsFixRemainingSeconds = GPS_FIX_TEST_TIMEOUT_MS / 1000;
+uint32_t gpsFixLastDisplayUpdateMillis = 0;
+SelfTest_PageGPSFix selfTest_pageGPSFix{&gpsFixRemainingSeconds};
 
 bool useSDFile() {
   if (self_test_file) {
@@ -202,6 +210,49 @@ SelfTest::Status SelfTest::testGPSserial() {
     gpsSerialTestInitialized = false;
     selfTestInfo("* SELF TEST * GPS SER * FAIL - No valid NMEA sentence received");
     return Status::Fail;
+  }
+
+  return Status::Running;
+}
+
+/////////////////////////////////////////////
+// GPS FIX TEST
+SelfTest::Status SelfTest::testGPSfix() {
+  const uint32_t millisNow = millis();
+
+  if (!gpsFixTestInitialized) {
+    gpsFixTestInitialized = true;
+    gpsFixInitialSentencesWithFixCount = gps.sentencesWithFix();
+    gpsFixStartMillis = millisNow;
+    gpsFixLastDisplayUpdateMillis = 0;
+    gpsFixRemainingSeconds = GPS_FIX_TEST_TIMEOUT_MS / 1000;
+    selfTestInfo("* SELF TEST * GPS FIX * INFO - Waiting for GPS fix");
+    selfTest_pageGPSFix.show();
+    display.update();
+  }
+
+  if (gps.sentencesWithFix() > gpsFixInitialSentencesWithFixCount) {
+    gpsFixTestInitialized = false;
+    selfTest_pageGPSFix.close();
+    selfTestInfo("* SELF TEST * GPS FIX * PASS - GPS fix acquired with %d satellites",
+                 gps.fixInfo.numberOfSats);
+    return Status::Pass;
+  }
+
+  const uint32_t elapsedMillis = millisNow - gpsFixStartMillis;
+  if (elapsedMillis >= GPS_FIX_TEST_TIMEOUT_MS) {
+    gpsFixTestInitialized = false;
+    gpsFixRemainingSeconds = 0;
+    display.update();
+    selfTest_pageGPSFix.close();
+    selfTestInfo("* SELF TEST * GPS FIX * FAIL - Timeout waiting for GPS fix");
+    return Status::Fail;
+  }
+
+  gpsFixRemainingSeconds = (GPS_FIX_TEST_TIMEOUT_MS - elapsedMillis + 999) / 1000;
+  if (millisNow - gpsFixLastDisplayUpdateMillis >= 1000) {
+    gpsFixLastDisplayUpdateMillis = millisNow;
+    display.update();
   }
 
   return Status::Running;
@@ -509,6 +560,7 @@ bool SelfTest::tallyResults() {
   bool allPass = true;
   if (results.sdCard != Status::Pass || results.baro != Status::Pass ||
       results.imu != Status::Pass || results.gps != Status::Pass ||
+      results.gpsFix != Status::Pass ||
       results.ambient != Status::Pass || results.display != Status::Pass ||
       results.buttons != Status::Pass || results.power != Status::Pass ||
       results.speaker != Status::Pass || results.vario != Status::Pass) {
@@ -566,6 +618,9 @@ SelfTest::Status SelfTest::runAutoTests(bool closeFileWhenDone) {
     selfTest.results.imu = testIMU();
   } else if (selfTest.results.gps == Status::Unknown || selfTest.results.gps == Status::Running) {
     selfTest.results.gps = testGPS();
+  } else if (selfTest.results.gpsFix == Status::Unknown ||
+             selfTest.results.gpsFix == Status::Running) {
+    selfTest.results.gpsFix = testGPSfix();
   } else if (selfTest.results.ambient == Status::Unknown ||
              selfTest.results.ambient == Status::Running) {
     selfTest.results.ambient = testAmbient();
@@ -620,5 +675,6 @@ void SelfTest::clearResults() {
   buttonsTest.status = Status::Unknown;
   varioTest.status = Status::Unknown;
   gpsSerialTestInitialized = false;
+  gpsFixTestInitialized = false;
   // speaker test is called regardless so no need to reset
 }

--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -22,7 +22,12 @@ ButtonsInteractiveTest buttonsTest;
 VarioInteractiveTest varioTest;
 
 constexpr size_t BUFFER_SIZE = 512;
+constexpr uint32_t GPS_SERIAL_TEST_TIMEOUT_MS = 5000;
 File self_test_file;
+
+bool gpsSerialTestInitialized = false;
+uint32_t gpsSerialInitialPassedChecksumCount = 0;
+uint32_t gpsSerialStartMillis = 0;
 
 bool useSDFile() {
   if (self_test_file) {
@@ -167,13 +172,39 @@ SelfTest::Status SelfTest::testAmbient() {
 SelfTest::Status SelfTest::testGPS() {
   Status result = Status::Running;
   if (!gps.fixInfo.numberOfSats) {
-    selfTestInfo("* SELF TEST *   GPS   * FAIL - GPS sees zero satellites");
-    result = Status::Fail;
+    result = testGPSserial();
   } else {
     result = Status::Pass;
     selfTestInfo("* SELF TEST *   GPS   * PASS - GPS sees %d satellites", gps.fixInfo.numberOfSats);
   }
   return result;
+}
+
+/////////////////////////////////////////////
+// GPS SERIAL TEST
+SelfTest::Status SelfTest::testGPSserial() {
+  if (!gpsSerialTestInitialized) {
+    gpsSerialTestInitialized = true;
+    gpsSerialInitialPassedChecksumCount = gps.passedChecksum();
+    gpsSerialStartMillis = millis();
+    selfTestInfo(
+        "* SELF TEST * GPS SER * INFO - GPS sees zero satellites; waiting for valid NMEA "
+        "sentence");
+  }
+
+  if (gps.passedChecksum() > gpsSerialInitialPassedChecksumCount) {
+    gpsSerialTestInitialized = false;
+    selfTestInfo("* SELF TEST * GPS SER * PASS - Valid NMEA sentence received");
+    return Status::Pass;
+  }
+
+  if (millis() - gpsSerialStartMillis >= GPS_SERIAL_TEST_TIMEOUT_MS) {
+    gpsSerialTestInitialized = false;
+    selfTestInfo("* SELF TEST * GPS SER * FAIL - No valid NMEA sentence received");
+    return Status::Fail;
+  }
+
+  return Status::Running;
 }
 
 /////////////////////////////////////////////
@@ -588,5 +619,6 @@ void SelfTest::clearResults() {
   // reset interactive tests
   buttonsTest.status = Status::Unknown;
   varioTest.status = Status::Unknown;
+  gpsSerialTestInitialized = false;
   // speaker test is called regardless so no need to reset
 }

--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -35,7 +35,8 @@ uint32_t gpsFixInitialSentencesWithFixCount = 0;
 uint32_t gpsFixStartMillis = 0;
 uint32_t gpsFixRemainingSeconds = GPS_FIX_TEST_TIMEOUT_MS / 1000;
 uint32_t gpsFixLastDisplayUpdateMillis = 0;
-SelfTest_PageGPSFix selfTest_pageGPSFix{&gpsFixRemainingSeconds};
+bool gpsFixTestCancelled = false;
+SelfTest_PageGPSFix selfTest_pageGPSFix{&gpsFixRemainingSeconds, &gpsFixTestCancelled};
 
 bool useSDFile() {
   if (self_test_file) {
@@ -222,6 +223,7 @@ SelfTest::Status SelfTest::testGPSfix() {
 
   if (!gpsFixTestInitialized) {
     gpsFixTestInitialized = true;
+    gpsFixTestCancelled = false;
     gpsFixInitialSentencesWithFixCount = gps.sentencesWithFix();
     gpsFixStartMillis = millisNow;
     gpsFixLastDisplayUpdateMillis = 0;
@@ -229,6 +231,12 @@ SelfTest::Status SelfTest::testGPSfix() {
     selfTestInfo("* SELF TEST * GPS FIX * INFO - Waiting for GPS fix");
     selfTest_pageGPSFix.show();
     display.update();
+  }
+
+  if (gpsFixTestCancelled) {
+    gpsFixTestInitialized = false;
+    selfTestInfo("* SELF TEST * GPS FIX * FAIL - Cancelled by user");
+    return Status::Fail;
   }
 
   if (gps.sentencesWithFix() > gpsFixInitialSentencesWithFixCount) {
@@ -618,9 +626,6 @@ SelfTest::Status SelfTest::runAutoTests(bool closeFileWhenDone) {
     selfTest.results.imu = testIMU();
   } else if (selfTest.results.gps == Status::Unknown || selfTest.results.gps == Status::Running) {
     selfTest.results.gps = testGPS();
-  } else if (selfTest.results.gpsFix == Status::Unknown ||
-             selfTest.results.gpsFix == Status::Running) {
-    selfTest.results.gpsFix = testGPSfix();
   } else if (selfTest.results.ambient == Status::Unknown ||
              selfTest.results.ambient == Status::Running) {
     selfTest.results.ambient = testAmbient();
@@ -649,12 +654,16 @@ SelfTest::Status SelfTest::runInteractiveTests(bool closeFileWhenDone) {
   } else if (buttonsTest.status == SelfTest::Status::Unknown ||
              buttonsTest.status == SelfTest::Status::Running) {
     selfTest.results.buttons = buttonsTest.update();
+  } else if (selfTest.results.speaker == SelfTest::Status::Unknown ||
+             selfTest.results.speaker == SelfTest::Status::Running) {
+    selfTest.results.speaker =
+        testSpeaker();  // (speaker test is blocking and only requires one call)
+  } else if (selfTest.results.gpsFix == SelfTest::Status::Unknown ||
+             selfTest.results.gpsFix == SelfTest::Status::Running) {
+    selfTest.results.gpsFix = testGPSfix();
   }
   // else if (other tests requiring multiple frames go here)
   else {
-    // any other interactive tests that only require one frame
-    selfTest.results.speaker =
-        testSpeaker();  // (speaker test is blocking and only requires one call)
     selfTestInfo("* SELF TEST * Interactive tests complete");
     statusInteractiveTests = Status::Complete;  // interactive tests complete
     if (closeFileWhenDone && self_test_file) {
@@ -676,5 +685,6 @@ void SelfTest::clearResults() {
   varioTest.status = Status::Unknown;
   gpsSerialTestInitialized = false;
   gpsFixTestInitialized = false;
+  gpsFixTestCancelled = false;
   // speaker test is called regardless so no need to reset
 }

--- a/src/vario/diagnostics/self_test/selfTest.h
+++ b/src/vario/diagnostics/self_test/selfTest.h
@@ -19,6 +19,7 @@ class SelfTest {
     Status baro = Status::Unknown;
     Status imu = Status::Unknown;
     Status gps = Status::Unknown;
+    Status gpsFix = Status::Unknown;
     Status ambient = Status::Unknown;
     Status display = Status::Unknown;
     Status buttons = Status::Unknown;
@@ -48,6 +49,7 @@ class SelfTest {
   static Status testIMU();
   static Status testGPS();
   static Status testGPSserial();
+  static Status testGPSfix();
   static Status testAmbient();
   static Status testDisplay();
   static Status testSDCard();

--- a/src/vario/diagnostics/self_test/selfTest.h
+++ b/src/vario/diagnostics/self_test/selfTest.h
@@ -47,6 +47,7 @@ class SelfTest {
   static Status testBaro();
   static Status testIMU();
   static Status testGPS();
+  static Status testGPSserial();
   static Status testAmbient();
   static Status testDisplay();
   static Status testSDCard();

--- a/src/vario/diagnostics/self_test/selfTest_displayScreens.cpp
+++ b/src/vario/diagnostics/self_test/selfTest_displayScreens.cpp
@@ -120,6 +120,10 @@ void SelfTest_PageSpeaker::draw_extra() {
 // GPS Fix Self-Test Page
 void SelfTest_PageGPSFix::show() { push_page(this); }
 
+void SelfTest_PageGPSFix::closed(bool removed_from_Stack) {
+  if (removed_from_Stack) *cancelled_ = true;
+}
+
 void SelfTest_PageGPSFix::draw_extra() {
   const uint32_t remainingSeconds = *remainingSeconds_;
   const uint16_t remainingMinutes = remainingSeconds / 60;

--- a/src/vario/diagnostics/self_test/selfTest_displayScreens.cpp
+++ b/src/vario/diagnostics/self_test/selfTest_displayScreens.cpp
@@ -129,28 +129,31 @@ void SelfTest_PageGPSFix::draw_extra() {
   const uint16_t remainingMinutes = remainingSeconds / 60;
   const uint8_t remainingSecondsPart = remainingSeconds % 60;
 
-  u8g2.setFont(leaf_6x12);
-  u8g2.setCursor(11, 31);
-  u8g2.print("Acquiring");
-  u8g2.setCursor(21, 45);
-  u8g2.print("GPS fix");
+  u8g2.setFont(leaf_5x8);
+  u8g2.setCursor(7, 31);
+  u8g2.print("Place Leaf outside");
+  u8g2.setCursor(10, 41);
+  u8g2.print("with a clear view");
+  u8g2.setCursor(25, 51);
+  u8g2.print("of the sky");
 
   u8g2.setFont(leaf_5x8);
-  u8g2.setCursor(0, 61);
-  u8g2.print("Timeout: ");
+  u8g2.setCursor(0, 67);
+  u8g2.print("Timeout:");
+  u8g2.setCursor(70, 67);
   u8g2.print(remainingMinutes);
   u8g2.print(":");
   if (remainingSecondsPart < 10) u8g2.print("0");
   u8g2.print(remainingSecondsPart);
 
-  u8g2.setCursor(0, 73);
-  u8g2.print("Sats:");
+  u8g2.setCursor(0, 78);
+  u8g2.print("Sats: ");
   u8g2.print(gps.fixInfo.numberOfSats);
-  u8g2.setCursor(52, 73);
-  u8g2.print("Fix:");
+  u8g2.setCursor(70, 78);
+  u8g2.print("Fix: ");
   u8g2.print(gps.fixInfo.fix);
 
-  gpsMenuPage.drawConstellation(4, 82, 84);
+  gpsMenuPage.drawConstellation(5, 84, 84);
 }
 
 //////////////////////////////////////////////

--- a/src/vario/diagnostics/self_test/selfTest_displayScreens.cpp
+++ b/src/vario/diagnostics/self_test/selfTest_displayScreens.cpp
@@ -1,10 +1,12 @@
 #include "selfTest_displayScreens.h"
 
 #include "diagnostics/self_test/selfTest.h"
+#include "instruments/gps.h"
 #include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 #include "ui/display/display_fields.h"
 #include "ui/display/fonts.h"
+#include "ui/display/pages.h"
 
 //////////////////////////////////////////////
 // Button Self-Test Page
@@ -115,11 +117,44 @@ void SelfTest_PageSpeaker::draw_extra() {
 }
 
 //////////////////////////////////////////////
+// GPS Fix Self-Test Page
+void SelfTest_PageGPSFix::show() { push_page(this); }
+
+void SelfTest_PageGPSFix::draw_extra() {
+  const uint32_t remainingSeconds = *remainingSeconds_;
+  const uint16_t remainingMinutes = remainingSeconds / 60;
+  const uint8_t remainingSecondsPart = remainingSeconds % 60;
+
+  u8g2.setFont(leaf_6x12);
+  u8g2.setCursor(11, 31);
+  u8g2.print("Acquiring");
+  u8g2.setCursor(21, 45);
+  u8g2.print("GPS fix");
+
+  u8g2.setFont(leaf_5x8);
+  u8g2.setCursor(0, 61);
+  u8g2.print("Timeout: ");
+  u8g2.print(remainingMinutes);
+  u8g2.print(":");
+  if (remainingSecondsPart < 10) u8g2.print("0");
+  u8g2.print(remainingSecondsPart);
+
+  u8g2.setCursor(0, 73);
+  u8g2.print("Sats:");
+  u8g2.print(gps.fixInfo.numberOfSats);
+  u8g2.setCursor(52, 73);
+  u8g2.print("Fix:");
+  u8g2.print(gps.fixInfo.fix);
+
+  gpsMenuPage.drawConstellation(4, 82, 84);
+}
+
+//////////////////////////////////////////////
 // Results Self-Test Page
 void SelfTest_PageResults::show() { push_page(this); }
 
 void SelfTest_PageResults::draw_extra() {
-  uint8_t lineSpacing = 14;
+  uint8_t lineSpacing = 13;
   u8g2.setCursor(0, 30);
   u8g2.setFont(leaf_6x12);
   u8g2.print("All Tests: ");
@@ -134,7 +169,7 @@ void SelfTest_PageResults::draw_extra() {
 
   SelfTest::Status testResult = SelfTest::Status::Unknown;
 
-  for (int i = 0; i < 10; i++) {
+  for (int i = 0; i < 11; i++) {
     u8g2.setCursor(0, u8g2.getCursorY() + lineSpacing);
 
     if (i == 0) {
@@ -150,21 +185,24 @@ void SelfTest_PageResults::draw_extra() {
       testResult = selfTest.results.gps;
       u8g2.print("GPS:");
     } else if (i == 4) {
+      testResult = selfTest.results.gpsFix;
+      u8g2.print("GPS Fix:");
+    } else if (i == 5) {
       testResult = selfTest.results.ambient;
       u8g2.print("Ambient:");
-    } else if (i == 5) {
+    } else if (i == 6) {
       testResult = selfTest.results.display;
       u8g2.print("Display:");
-    } else if (i == 6) {
+    } else if (i == 7) {
       testResult = selfTest.results.buttons;
       u8g2.print("Buttons:");
-    } else if (i == 7) {
+    } else if (i == 8) {
       testResult = selfTest.results.power;
       u8g2.print("Power:");
-    } else if (i == 8) {
+    } else if (i == 9) {
       testResult = selfTest.results.speaker;
       u8g2.print("Speaker:");
-    } else if (i == 9) {
+    } else if (i == 10) {
       testResult = selfTest.results.vario;
       u8g2.print("Vario:");
     }

--- a/src/vario/diagnostics/self_test/selfTest_displayScreens.h
+++ b/src/vario/diagnostics/self_test/selfTest_displayScreens.h
@@ -72,19 +72,20 @@ class SelfTest_PageSpeaker : public SimpleSettingsMenuPage {
 // GPS Fix Self-Test Page
 class SelfTest_PageGPSFix : public SimpleSettingsMenuPage {
  public:
-  SelfTest_PageGPSFix(uint32_t* remainingSeconds) : remainingSeconds_(remainingSeconds) {}
+  SelfTest_PageGPSFix(uint32_t* remainingSeconds, bool* cancelled)
+      : remainingSeconds_(remainingSeconds), cancelled_(cancelled) {}
   const char* get_title() const override { return "GPS Fix Test"; }
 
-  bool button_event(Button button, ButtonEvent state, uint8_t count) override {
-    // Ignore button events on this page
-    return false;
-  }
   void show();
   void draw_extra() override;
   void close() { pop_page(); }
 
+ protected:
+  void closed(bool removed_from_Stack) override;
+
  private:
   uint32_t* remainingSeconds_;
+  bool* cancelled_;
 };
 
 // Results Self-Test Page

--- a/src/vario/diagnostics/self_test/selfTest_displayScreens.h
+++ b/src/vario/diagnostics/self_test/selfTest_displayScreens.h
@@ -69,6 +69,24 @@ class SelfTest_PageSpeaker : public SimpleSettingsMenuPage {
   void close() { pop_page(); }
 };
 
+// GPS Fix Self-Test Page
+class SelfTest_PageGPSFix : public SimpleSettingsMenuPage {
+ public:
+  SelfTest_PageGPSFix(uint32_t* remainingSeconds) : remainingSeconds_(remainingSeconds) {}
+  const char* get_title() const override { return "GPS Fix Test"; }
+
+  bool button_event(Button button, ButtonEvent state, uint8_t count) override {
+    // Ignore button events on this page
+    return false;
+  }
+  void show();
+  void draw_extra() override;
+  void close() { pop_page(); }
+
+ private:
+  uint32_t* remainingSeconds_;
+};
+
 // Results Self-Test Page
 class SelfTest_PageResults : public SimpleSettingsMenuPage {
  public:


### PR DESCRIPTION
This PR adds additional GPS testing as part of SelfTest.
1. During the automated checks, testGPS looks for satellites to confirm the GPS module is working.  However, this fails when testing indoors and no satellites are seen.  If 0 sats are seen, then the test will fall back to a serial communication test, and at least ensure the GPS module is speaking valid NMEA sentences on the Serial bus.
2. An additional GPS test (testGPSfix) is added at the end of the interactive tests, where Leaf will wait up to 30 minutes trying to acquire a fix.  If no fix is acquired, the test times out and fails.  The user can also press "back" during the GPSfix test to cancel the test (also interpreted as a 'fail').  