### PR TITLE
Add memory reset to factory_interface

### DIFF
--- a/factory_interface/src/factory_interface/app.py
+++ b/factory_interface/src/factory_interface/app.py
@@ -21,6 +21,11 @@ from factory_interface.network_discovery import (
     reset_find_device_task,
     start_find_device,
 )
+from factory_interface.nonvolatile_memory_task import (
+    get_reset_nonvolatile_memory_task,
+    reset_reset_nonvolatile_memory_task,
+    start_reset_nonvolatile_memory,
+)
 from factory_interface.self_test_task import (
     get_self_test_task,
     reset_self_test_task,
@@ -50,6 +55,7 @@ def reset_setup_tasks_if_complete() -> None:
     tasks = [
         get_flash_task(),
         get_find_device_task(),
+        get_reset_nonvolatile_memory_task(),
         get_mac_address_task(),
         get_self_test_task(),
     ]
@@ -60,6 +66,7 @@ def reset_setup_tasks_if_complete() -> None:
 
     reset_flash_task()
     reset_find_device_task()
+    reset_reset_nonvolatile_memory_task()
     reset_mac_address_task()
     reset_self_test_task()
 
@@ -122,6 +129,18 @@ async def start_network_discovery_task() -> JSONResponse:
 @app.get("/api/setup/network-discovery", response_class=JSONResponse)
 async def get_network_discovery_task() -> JSONResponse:
     task = get_find_device_task()
+    return JSONResponse(task.snapshot())
+
+
+@app.post("/api/setup/reset-nonvolatile-memory", response_class=JSONResponse)
+async def start_reset_nonvolatile_memory_task() -> JSONResponse:
+    task = start_reset_nonvolatile_memory()
+    return JSONResponse(task.snapshot())
+
+
+@app.get("/api/setup/reset-nonvolatile-memory", response_class=JSONResponse)
+async def get_reset_nonvolatile_memory_task_status() -> JSONResponse:
+    task = get_reset_nonvolatile_memory_task()
     return JSONResponse(task.snapshot())
 
 

--- a/factory_interface/src/factory_interface/nonvolatile_memory_task.py
+++ b/factory_interface/src/factory_interface/nonvolatile_memory_task.py
@@ -1,0 +1,123 @@
+import asyncio
+import json
+import time
+from dataclasses import dataclass, field
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from factory_interface.network_discovery import get_find_device_task, probe_once
+
+
+HTTP_TIMEOUT_SECONDS = 5.0
+RESET_REBOOT_GRACE_SECONDS = 2.0
+RESET_RECONNECT_TIMEOUT_SECONDS = 45.0
+RESET_RECONNECT_POLL_SECONDS = 1.0
+
+
+@dataclass
+class ResetNonvolatileMemoryTask:
+    status: str = "idle"
+    details: str = ""
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    def snapshot(self) -> dict:
+        return {
+            "status": self.status,
+            "details": self.details,
+        }
+
+
+reset_nonvolatile_memory_task = ResetNonvolatileMemoryTask()
+
+
+def get_reset_nonvolatile_memory_task() -> ResetNonvolatileMemoryTask:
+    return reset_nonvolatile_memory_task
+
+
+def reset_reset_nonvolatile_memory_task() -> None:
+    reset_nonvolatile_memory_task.status = "idle"
+    reset_nonvolatile_memory_task.details = ""
+
+
+def device_base_url() -> tuple[str, str]:
+    discovery_task = get_find_device_task()
+    if discovery_task.status != "success" or discovery_task.device is None:
+        raise RuntimeError("Device has not been discovered on the network.")
+
+    device = discovery_task.device
+    return f"http://{device.ip_address}:{device.port}", device.device_id
+
+
+def fetch_json(url: str, *, method: str = "GET") -> dict:
+    request = Request(url, method=method)
+    with urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+async def wait_for_device(base_url: str, device_id: str) -> None:
+    deadline = time.monotonic() + RESET_RECONNECT_TIMEOUT_SECONDS
+    last_error: Exception | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            await asyncio.to_thread(fetch_json, f"{base_url}/mac-address")
+            return
+        except (OSError, URLError, TimeoutError) as exc:
+            last_error = exc
+
+        try:
+            for response in await probe_once():
+                if response.device_id == device_id:
+                    get_find_device_task().device = response
+                    await asyncio.to_thread(
+                        fetch_json,
+                        f"http://{response.ip_address}:{response.port}/mac-address",
+                    )
+                    return
+        except (OSError, URLError, TimeoutError) as exc:
+            last_error = exc
+
+        await asyncio.sleep(RESET_RECONNECT_POLL_SECONDS)
+
+    if last_error is not None:
+        raise RuntimeError(f"Device did not reconnect after reset: {last_error}")
+    raise RuntimeError("Device did not reconnect after reset.")
+
+
+async def run_reset_nonvolatile_memory() -> None:
+    task = get_reset_nonvolatile_memory_task()
+
+    async with task.lock:
+        task.status = "running"
+        task.details = "Resetting nonvolatile memory..."
+
+        try:
+            base_url, device_id = device_base_url()
+            payload = await asyncio.to_thread(
+                fetch_json,
+                f"{base_url}/settings/factory-reset",
+                method="POST",
+            )
+            if not payload.get("reset_requested", False):
+                raise RuntimeError("Device did not acknowledge the reset request.")
+
+            task.details = "Waiting for device to reboot after settings reset..."
+            await asyncio.sleep(RESET_REBOOT_GRACE_SECONDS)
+            await wait_for_device(base_url, device_id)
+
+            task.status = "success"
+            task.details = "Nonvolatile memory reset."
+        except Exception as exc:
+            task.status = "failure"
+            task.details = f"{type(exc).__name__}: {exc}"
+
+
+def start_reset_nonvolatile_memory() -> ResetNonvolatileMemoryTask:
+    task = get_reset_nonvolatile_memory_task()
+    if task.status == "running":
+        return task
+
+    task.status = "running"
+    task.details = "Resetting nonvolatile memory..."
+    asyncio.create_task(run_reset_nonvolatile_memory())
+    return task

--- a/factory_interface/src/factory_interface/nonvolatile_memory_task.py
+++ b/factory_interface/src/factory_interface/nonvolatile_memory_task.py
@@ -18,12 +18,20 @@ RESET_RECONNECT_POLL_SECONDS = 1.0
 class ResetNonvolatileMemoryTask:
     status: str = "idle"
     details: str = ""
+    reset_status: str = "idle"
+    reset_details: str = ""
+    reconnect_status: str = "idle"
+    reconnect_details: str = ""
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     def snapshot(self) -> dict:
         return {
             "status": self.status,
             "details": self.details,
+            "reset_status": self.reset_status,
+            "reset_details": self.reset_details,
+            "reconnect_status": self.reconnect_status,
+            "reconnect_details": self.reconnect_details,
         }
 
 
@@ -37,6 +45,10 @@ def get_reset_nonvolatile_memory_task() -> ResetNonvolatileMemoryTask:
 def reset_reset_nonvolatile_memory_task() -> None:
     reset_nonvolatile_memory_task.status = "idle"
     reset_nonvolatile_memory_task.details = ""
+    reset_nonvolatile_memory_task.reset_status = "idle"
+    reset_nonvolatile_memory_task.reset_details = ""
+    reset_nonvolatile_memory_task.reconnect_status = "idle"
+    reset_nonvolatile_memory_task.reconnect_details = ""
 
 
 def device_base_url() -> tuple[str, str]:
@@ -90,6 +102,10 @@ async def run_reset_nonvolatile_memory() -> None:
     async with task.lock:
         task.status = "running"
         task.details = "Resetting nonvolatile memory..."
+        task.reset_status = "running"
+        task.reset_details = "Resetting nonvolatile memory..."
+        task.reconnect_status = "idle"
+        task.reconnect_details = ""
 
         try:
             base_url, device_id = device_base_url()
@@ -101,15 +117,27 @@ async def run_reset_nonvolatile_memory() -> None:
             if not payload.get("reset_requested", False):
                 raise RuntimeError("Device did not acknowledge the reset request.")
 
+            task.reset_status = "success"
+            task.reset_details = "Nonvolatile memory reset command accepted."
+            task.reconnect_status = "running"
+            task.reconnect_details = "Waiting for device to reconnect..."
             task.details = "Waiting for device to reboot after settings reset..."
             await asyncio.sleep(RESET_REBOOT_GRACE_SECONDS)
             await wait_for_device(base_url, device_id)
 
             task.status = "success"
             task.details = "Nonvolatile memory reset."
+            task.reconnect_status = "success"
+            task.reconnect_details = "Device reconnected."
         except Exception as exc:
             task.status = "failure"
             task.details = f"{type(exc).__name__}: {exc}"
+            if task.reset_status == "running":
+                task.reset_status = "failure"
+                task.reset_details = task.details
+            else:
+                task.reconnect_status = "failure"
+                task.reconnect_details = task.details
 
 
 def start_reset_nonvolatile_memory() -> ResetNonvolatileMemoryTask:
@@ -119,5 +147,9 @@ def start_reset_nonvolatile_memory() -> ResetNonvolatileMemoryTask:
 
     task.status = "running"
     task.details = "Resetting nonvolatile memory..."
+    task.reset_status = "running"
+    task.reset_details = "Resetting nonvolatile memory..."
+    task.reconnect_status = "idle"
+    task.reconnect_details = ""
     asyncio.create_task(run_reset_nonvolatile_memory())
     return task

--- a/factory_interface/src/factory_interface/templates/setup_checklist.html
+++ b/factory_interface/src/factory_interface/templates/setup_checklist.html
@@ -60,6 +60,18 @@
     <div class="checklist-item checklist-item-with-details">
       <button
         class="task-icon task-icon-empty"
+        id="reconnect-task-icon"
+        type="button"
+        aria-label="Toggle device reconnect details"
+        disabled
+      ></button>
+      <span>Wait for device to reconnect</span>
+      <p class="checklist-details" id="reconnect-details" hidden></p>
+    </div>
+
+    <div class="checklist-item checklist-item-with-details">
+      <button
+        class="task-icon task-icon-empty"
         id="mac-address-task-icon"
         type="button"
         aria-label="Toggle MAC address details"
@@ -91,6 +103,8 @@
   const discoveryDetails = document.querySelector("#discovery-details");
   const resetNonvolatileTaskIcon = document.querySelector("#reset-nonvolatile-task-icon");
   const resetNonvolatileDetails = document.querySelector("#reset-nonvolatile-details");
+  const reconnectTaskIcon = document.querySelector("#reconnect-task-icon");
+  const reconnectDetails = document.querySelector("#reconnect-details");
   const macAddressTaskIcon = document.querySelector("#mac-address-task-icon");
   const macAddressDetails = document.querySelector("#mac-address-details");
   const selfTestTaskIcon = document.querySelector("#self-test-task-icon");
@@ -134,6 +148,10 @@
 
   function setResetNonvolatileIcon(status) {
     setTaskIcon(resetNonvolatileTaskIcon, status);
+  }
+
+  function setReconnectIcon(status) {
+    setTaskIcon(reconnectTaskIcon, status);
   }
 
   function setMacAddressIcon(status) {
@@ -205,27 +223,40 @@
   }
 
   function applyResetNonvolatileTaskState(state) {
-    setResetNonvolatileIcon(state.status);
+    const resetStatus = state.reset_status || state.status;
+    const reconnectStatus = state.reconnect_status || "idle";
+    setResetNonvolatileIcon(resetStatus);
+    setReconnectIcon(reconnectStatus);
 
     if (state.status === "success") {
-      resetNonvolatileDetails.textContent = state.details || "Nonvolatile memory reset.";
+      resetNonvolatileDetails.textContent =
+        state.reset_details || "Nonvolatile memory reset command accepted.";
+      reconnectDetails.textContent = state.reconnect_details || "Device reconnected.";
       clearInterval(resetNonvolatilePollTimer);
       resetNonvolatilePollTimer = null;
       startMacAddressTask();
     } else if (state.status === "running") {
-      resetNonvolatileDetails.textContent = state.details || "Resetting nonvolatile memory...";
-      resetNonvolatileDetails.hidden = false;
+      resetNonvolatileDetails.textContent =
+        state.reset_details || "Resetting nonvolatile memory...";
+      reconnectDetails.textContent = state.reconnect_details || "Waiting for device to reconnect...";
+      resetNonvolatileDetails.hidden = resetStatus === "idle";
+      reconnectDetails.hidden = reconnectStatus === "idle";
       if (!resetNonvolatilePollTimer) {
         resetNonvolatilePollTimer = setInterval(refreshResetNonvolatileTaskState, 1000);
       }
     } else if (state.status === "failure") {
-      resetNonvolatileDetails.textContent = state.details || "Nonvolatile memory reset failed.";
-      resetNonvolatileDetails.hidden = false;
+      resetNonvolatileDetails.textContent =
+        state.reset_details || "Nonvolatile memory reset failed.";
+      reconnectDetails.textContent = state.reconnect_details || "Device did not reconnect.";
+      resetNonvolatileDetails.hidden = resetStatus === "idle";
+      reconnectDetails.hidden = reconnectStatus === "idle";
       clearInterval(resetNonvolatilePollTimer);
       resetNonvolatilePollTimer = null;
     } else {
       resetNonvolatileDetails.textContent = "";
       resetNonvolatileDetails.hidden = true;
+      reconnectDetails.textContent = "";
+      reconnectDetails.hidden = true;
       clearInterval(resetNonvolatilePollTimer);
       resetNonvolatilePollTimer = null;
     }
@@ -388,6 +419,10 @@
 
   resetNonvolatileTaskIcon.addEventListener("click", () => {
     resetNonvolatileDetails.hidden = !resetNonvolatileDetails.hidden;
+  });
+
+  reconnectTaskIcon.addEventListener("click", () => {
+    reconnectDetails.hidden = !reconnectDetails.hidden;
   });
 
   macAddressTaskIcon.addEventListener("click", () => {

--- a/factory_interface/src/factory_interface/templates/setup_checklist.html
+++ b/factory_interface/src/factory_interface/templates/setup_checklist.html
@@ -48,6 +48,18 @@
     <div class="checklist-item checklist-item-with-details">
       <button
         class="task-icon task-icon-empty"
+        id="reset-nonvolatile-task-icon"
+        type="button"
+        aria-label="Toggle nonvolatile memory reset details"
+        disabled
+      ></button>
+      <span>Reset nonvolatile memory</span>
+      <p class="checklist-details" id="reset-nonvolatile-details" hidden></p>
+    </div>
+
+    <div class="checklist-item checklist-item-with-details">
+      <button
+        class="task-icon task-icon-empty"
         id="mac-address-task-icon"
         type="button"
         aria-label="Toggle MAC address details"
@@ -77,15 +89,19 @@
   const flashConsole = document.querySelector("#flash-console");
   const discoveryTaskIcon = document.querySelector("#discovery-task-icon");
   const discoveryDetails = document.querySelector("#discovery-details");
+  const resetNonvolatileTaskIcon = document.querySelector("#reset-nonvolatile-task-icon");
+  const resetNonvolatileDetails = document.querySelector("#reset-nonvolatile-details");
   const macAddressTaskIcon = document.querySelector("#mac-address-task-icon");
   const macAddressDetails = document.querySelector("#mac-address-details");
   const selfTestTaskIcon = document.querySelector("#self-test-task-icon");
   const selfTestDetails = document.querySelector("#self-test-details");
   let flashPollTimer = null;
   let discoveryPollTimer = null;
+  let resetNonvolatilePollTimer = null;
   let macAddressPollTimer = null;
   let selfTestPollTimer = null;
   let discoveryStartRequested = false;
+  let resetNonvolatileStartRequested = false;
   let macAddressStartRequested = false;
   let selfTestStartRequested = false;
 
@@ -114,6 +130,10 @@
 
   function setSelfTestIcon(status) {
     setTaskIcon(selfTestTaskIcon, status);
+  }
+
+  function setResetNonvolatileIcon(status) {
+    setTaskIcon(resetNonvolatileTaskIcon, status);
   }
 
   function setMacAddressIcon(status) {
@@ -164,7 +184,7 @@
       discoveryDetails.hidden = false;
       clearInterval(discoveryPollTimer);
       discoveryPollTimer = null;
-      startMacAddressTask();
+      startResetNonvolatileTask();
     } else if (state.status === "running") {
       discoveryDetails.textContent = "Searching for the newly flashed device...";
       discoveryDetails.hidden = false;
@@ -181,6 +201,33 @@
       discoveryDetails.hidden = true;
       clearInterval(discoveryPollTimer);
       discoveryPollTimer = null;
+    }
+  }
+
+  function applyResetNonvolatileTaskState(state) {
+    setResetNonvolatileIcon(state.status);
+
+    if (state.status === "success") {
+      resetNonvolatileDetails.textContent = state.details || "Nonvolatile memory reset.";
+      clearInterval(resetNonvolatilePollTimer);
+      resetNonvolatilePollTimer = null;
+      startMacAddressTask();
+    } else if (state.status === "running") {
+      resetNonvolatileDetails.textContent = state.details || "Resetting nonvolatile memory...";
+      resetNonvolatileDetails.hidden = false;
+      if (!resetNonvolatilePollTimer) {
+        resetNonvolatilePollTimer = setInterval(refreshResetNonvolatileTaskState, 1000);
+      }
+    } else if (state.status === "failure") {
+      resetNonvolatileDetails.textContent = state.details || "Nonvolatile memory reset failed.";
+      resetNonvolatileDetails.hidden = false;
+      clearInterval(resetNonvolatilePollTimer);
+      resetNonvolatilePollTimer = null;
+    } else {
+      resetNonvolatileDetails.textContent = "";
+      resetNonvolatileDetails.hidden = true;
+      clearInterval(resetNonvolatilePollTimer);
+      resetNonvolatilePollTimer = null;
     }
   }
 
@@ -250,6 +297,11 @@
     applyMacAddressTaskState(await response.json());
   }
 
+  async function refreshResetNonvolatileTaskState() {
+    const response = await fetch("/api/setup/reset-nonvolatile-memory");
+    applyResetNonvolatileTaskState(await response.json());
+  }
+
   async function refreshSelfTestTaskState() {
     const response = await fetch("/api/setup/interactive-self-test");
     applySelfTestTaskState(await response.json());
@@ -276,6 +328,20 @@
 
     const response = await fetch("/api/setup/network-discovery", { method: "POST" });
     applyDiscoveryTaskState(await response.json());
+  }
+
+  async function startResetNonvolatileTask() {
+    if (resetNonvolatileStartRequested) return;
+    resetNonvolatileStartRequested = true;
+    const currentResponse = await fetch("/api/setup/reset-nonvolatile-memory");
+    const currentState = await currentResponse.json();
+    if (currentState.status === "running" || currentState.status === "success") {
+      applyResetNonvolatileTaskState(currentState);
+      return;
+    }
+
+    const response = await fetch("/api/setup/reset-nonvolatile-memory", { method: "POST" });
+    applyResetNonvolatileTaskState(await response.json());
   }
 
   async function startMacAddressTask() {
@@ -320,6 +386,10 @@
     discoveryDetails.hidden = !discoveryDetails.hidden;
   });
 
+  resetNonvolatileTaskIcon.addEventListener("click", () => {
+    resetNonvolatileDetails.hidden = !resetNonvolatileDetails.hidden;
+  });
+
   macAddressTaskIcon.addEventListener("click", () => {
     macAddressDetails.hidden = !macAddressDetails.hidden;
   });
@@ -330,6 +400,7 @@
 
   refreshFlashTaskState();
   refreshDiscoveryTaskState();
+  refreshResetNonvolatileTaskState();
   refreshMacAddressTaskState();
   refreshSelfTestTaskState();
 </script>

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -155,6 +155,7 @@ void webserver_setup() {
             <li><a href="/screenshot" target="_blank">Download Screenshot</a></li>
             <li><a href="/mass_storage" target="_blank">Start Mass Storage</a></li>
             <li><a href="#" onclick="fetch('/self-test/interactive', {method: 'POST'}); return false;">Start Interactive Self Test</a></li>
+            <li><a href="#" onclick="fetch('/settings/factory-reset', {method: 'POST'}); return false;">Factory Reset Settings</a></li>
             <li><a href="/mac-address" target="_blank">MAC Address</a></li>
             <li><a href="/fanet" target="_blank">FANet Message Stats</a></li>
             <li><a href="/memory" target="_blank">Memory Usage Stats</a></li>
@@ -297,6 +298,13 @@ void webserver_setup() {
     json += settings.getMacAddress();
     json += "\"}";
     server.send(200, "application/json", json);
+  });
+
+  server.on("/settings/factory-reset", HTTP_POST, []() {
+    settings.factoryResetVario();
+    server.send(200, "application/json", "{\"reset_requested\":true}");
+    delay(250);
+    ESP.restart();
   });
 
   server.on("/self-test/interactive", HTTP_POST, []() {

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -77,8 +77,10 @@ String Settings::getMacAddress() {
 }
 
 void Settings::factoryResetVario() {
+  leafPrefs.begin("varioPrefs", RW_MODE);
   leafPrefs.remove(
       "nvsInitVario");  // remove this key so that we force a factory settings reload on next reboot
+  leafPrefs.end();
 }
 
 void Settings::loadDefaults() {


### PR DESCRIPTION
This PR adds a checklist item to factory_interface to reset nonvolatile memory, wiping settings and other nonvolatile state, rebooting the device, and reconnecting.  This happens before the other commissioning steps after initially flashing firmware.