### PR TITLE
Fix occasional GPS-caused fatal errors

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -111,3 +111,10 @@ framework = arduino
 build_flags = 
 	-D ARDUINO_USB_MODE=1
 	-D ARDUINO_USB_CDC_ON_BOOT=1  # Required for USB Serial on boot (for debugging)  
+
+
+[env:embedded_tests]
+extends = env:leaf_3_2_7_release
+build_flags =
+    ${env:leaf_3_2_7_release.build_flags}
+    -DRUN_EMBEDDED_TESTS

--- a/src/vario/instruments/gps.cpp
+++ b/src/vario/instruments/gps.cpp
@@ -157,17 +157,18 @@ void LeafGPS::on_receive(const GpsMessage& msg) {
     GpsLockGuard mutex;  // Ensure we have a lock on write
     for (size_t i = 0; i < msg.nmea.length(); i++) {
       char a = msg.nmea[i];
-      bool newSentence = gps.encode(a);
+      newSentence = gps.encode(a);
       if (newSentence) {
-        fatalErrorInfo("sentence length: %d", (int)msg.nmea.length());
-        fatalErrorInfo("sentence: %s", msg.nmea.c_str());
-        fatalErrorInfo("index: %d", (int)i);
-        fatalErrorInfo("char: %d", (int)a);
-        fatalError("newSentence encountered in the middle of the line of text '%s'",
-                   msg.nmea.c_str());
+        // TinyGPSPlus is more forgiving than the NMEA standard by detecting a new sentence even
+        // when not followed by a new line.  Encountering this block means there is a sentence
+        // available, just not without the required trailing new line.  In this case, we will
+        // discard the rest of the line but keep the sentence found at the beginning of the line.
+        break;
       }
     }
-    newSentence = gps.encode('\r');
+    if (!newSentence) {
+      newSentence = gps.encode('\r');
+    }
   }
   if (newSentence) {
     updateSatList(msg.nmea);

--- a/src/vario/main.cpp
+++ b/src/vario/main.cpp
@@ -27,6 +27,10 @@
 #include "comms/udp_message_server.h"
 #endif
 
+#ifdef RUN_EMBEDDED_TESTS
+#include "tests/tests.h"
+#endif
+
 // MAIN Module
 // initializes the system.  Responsible for setting up resources with
 // as much dynamic memory as possible at the system bootup.  Sets up
@@ -111,4 +115,10 @@ void setup() {
   Serial.println("Leaf Initialized");
 }
 
-void loop() { taskman.update(); }
+void loop() {
+#ifdef RUN_EMBEDDED_TESTS
+  run_tests(&bus);
+#else
+  taskman.update();
+#endif
+}

--- a/src/vario/tests/gps_tests.cpp
+++ b/src/vario/tests/gps_tests.cpp
@@ -1,0 +1,13 @@
+#include "tests/gps_tests.h"
+
+#include <Arduino.h>
+#include "etl/message_bus.h"
+
+#include "dispatch/message_types.h"
+
+void test_gps_parsing(etl::imessage_bus* bus) {
+  GpsMessage msg = GpsMessage(
+      NMEAString("$GPGSV,2,1,07,11,79,032,27,12,70,321,36,06,35,041,31,21,34,143,23,1*6F*38"));
+  bus->receive(msg);
+  Serial.println("GPS parsing test successful.");
+}

--- a/src/vario/tests/gps_tests.h
+++ b/src/vario/tests/gps_tests.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "etl/message_bus.h"
+
+void test_gps_parsing(etl::imessage_bus* bus);

--- a/src/vario/tests/tests.cpp
+++ b/src/vario/tests/tests.cpp
@@ -1,0 +1,12 @@
+#include "tests/gps_tests.h"
+
+#include <Arduino.h>
+#include "etl/message_bus.h"
+
+void run_tests(etl::imessage_bus* bus) {
+  test_gps_parsing(bus);
+  while (true) {
+    Serial.println("All tests were successful.");
+    delay(5000);
+  }
+}

--- a/src/vario/tests/tests.h
+++ b/src/vario/tests/tests.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "etl/message_bus.h"
+
+void run_tests(etl::imessage_bus* bus);


### PR DESCRIPTION
Previously, detection of a new sentence in the middle of a line of text was considered a fatal error because that condition was an undefined state since NMEA requires valid sentences to be terminated with a new line.  This very occasionally caused a fatal error when the new line was lost in communication between the GPS and ESP32.

This PR first establishes a failing test by:

* Creating a new embedded_tests build environment derived from the latest release build environment
* Running tests from a new tests/ folder in the main loop instead of calling the task manager

This test was verified to produce the expected fatal error.

This PR then resolves the issue by accepting the sentence at the beginning of the line of text and discarding the rest of the line of text.