### PR TITLE
Vario bug

### DIFF
--- a/src/vario/hardware/icm_20948.cpp
+++ b/src/vario/hardware/icm_20948.cpp
@@ -14,6 +14,24 @@
 #define SERIAL_PORT Serial
 #define AD0_VAL 0  // I2C address bit
 
+namespace {
+  // The DMP runs at 225Hz. The task manager polls the IMU at 20Hz, so keep the FIFO
+  // production rate close to the consumer rate and drain bursts when the main loop is delayed.
+  constexpr int DMP_ODR_INTERVAL_20HZ = 10;  // 225 / (10 + 1) = 20.45Hz
+  constexpr uint8_t MAX_DMP_PACKETS_PER_UPDATE = 8;
+
+  bool invalid(double value, double min, double max) {
+    return isnan(value) || isinf(value) || value < min || value > max;
+  }
+
+  void publishComment(etl::imessage_bus* bus, const char* msg) {
+    Serial.println(msg);
+    if (bus) {
+      bus->receive(CommentMessage(msg));
+    }
+  }
+}  // namespace
+
 void ICM20948::init() {
   WIRE_PORT.begin();
   WIRE_PORT.setClock(400000);
@@ -45,9 +63,11 @@ void ICM20948::init() {
   success &= (IMU_.enableDMPSensor(INV_ICM20948_SENSOR_ORIENTATION) == ICM_20948_Stat_Ok);
   success &= (IMU_.enableDMPSensor(INV_ICM20948_SENSOR_ACCELEROMETER) == ICM_20948_Stat_Ok);
 
-  // Configuring DMP to output data at multiple ODRs:
-  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Quat9, 2) == ICM_20948_Stat_Ok);  // Set to the maximum
-  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Accel, 2) == ICM_20948_Stat_Ok);  // Set to the maximum
+  // Configuring DMP to output data at multiple ODRs.
+  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Quat9, DMP_ODR_INTERVAL_20HZ) ==
+              ICM_20948_Stat_Ok);
+  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Accel, DMP_ODR_INTERVAL_20HZ) ==
+              ICM_20948_Stat_Ok);
 
   // Enable the FIFO
   success &= (IMU_.enableFIFO() == ICM_20948_Stat_Ok);
@@ -70,12 +90,34 @@ void ICM20948::init() {
 }
 
 void ICM20948::update() {
-  icm_20948_DMP_data_t data;
-  IMU_.readDMPdataFromFIFO(&data);  // TODO: consider rate-limiting this operation
+  etl::imessage_bus* bus = bus_;
+  MotionUpdate latest(millis());
+  bool moreData = false;
 
-  if ((IMU_.status == ICM_20948_Stat_Ok) ||
-      (IMU_.status == ICM_20948_Stat_FIFOMoreDataAvail))  // Was valid data available?
-  {
+  for (uint8_t packet = 0; packet < MAX_DMP_PACKETS_PER_UPDATE; ++packet) {
+    icm_20948_DMP_data_t data;
+    IMU_.readDMPdataFromFIFO(&data);
+
+    if (IMU_.status == ICM_20948_Stat_FIFONoDataAvail) {
+      moreData = false;
+      break;
+    }
+
+    if (IMU_.status == ICM_20948_Stat_FIFOIncompleteData) {
+      publishComment(bus, "ICM20948 FIFO incomplete packet; resetting FIFO");
+      IMU_.resetFIFO();
+      return;
+    }
+
+    if ((IMU_.status != ICM_20948_Stat_Ok) &&
+        (IMU_.status != ICM_20948_Stat_FIFOMoreDataAvail)) {
+      char msg[100];
+      snprintf(msg, sizeof(msg), "ICM20948 DMP FIFO read failed: %s", IMU_.statusString());
+      publishComment(bus, msg);
+      return;
+    }
+
+    moreData = (IMU_.status == ICM_20948_Stat_FIFOMoreDataAvail);
     MotionUpdate update(millis());
     if ((data.header & DMP_header_bitmap_Quat9) > 0) {
       // Scale to +/- 1
@@ -91,44 +133,63 @@ void ICM20948::update() {
       update.az = ((double)data.Raw_Accel.Data.Z) / 8192.0;
       update.hasAcceleration = true;
     }
-    etl::imessage_bus* bus = bus_;
-    if ((update.hasOrientation || update.hasAcceleration) && bus) {
+    if (update.hasOrientation || update.hasAcceleration) {
       // Invalidate insane orientation data
       if (update.hasOrientation) {
-        if (isnan(update.qx) || isinf(update.qx) || update.qx < -1.1 || update.qx > 1.1 ||
-            isnan(update.qy) || isinf(update.qy) || update.qy < -1.1 || update.qy > 1.1 ||
-            isnan(update.qz) || isinf(update.qz) || update.qz < -1.1 || update.qz > 1.1) {
+        if (invalid(update.qx, -1.1, 1.1) || invalid(update.qy, -1.1, 1.1) ||
+            invalid(update.qz, -1.1, 1.1)) {
           char msg[100];
           snprintf(msg, sizeof(msg),
                    "ICM20948 invalid orientation Q1=%X; Q2=%X; Q3=%X (%.2f, %.2f, %.2f)",
                    data.Quat9.Data.Q1, data.Quat9.Data.Q2, data.Quat9.Data.Q3, update.qx, update.qy,
                    update.qz);
-          Serial.println(msg);
-          bus->receive(CommentMessage(msg));
+          publishComment(bus, msg);
           update.hasOrientation = false;
         }
       }
 
       // Invalidate insane acceleration data
       if (update.hasAcceleration) {
-        if (isnan(update.ax) || isinf(update.ax) || update.ax < -1000 || update.ax > 1000 ||
-            isnan(update.ay) || isinf(update.ay) || update.ay < -1000 || update.ay > 1000 ||
-            isnan(update.az) || isinf(update.az) || update.az < -1000 || update.az > 1000) {
+        if (invalid(update.ax, -8, 8) || invalid(update.ay, -8, 8) ||
+            invalid(update.az, -8, 8)) {
           char msg[100];
           snprintf(msg, sizeof(msg),
                    "ICM20948 invalid acceleration X=%X; Y=%X; Z=%X (%.2f, %.2f, %.2f)",
                    data.Raw_Accel.Data.X, data.Raw_Accel.Data.Y, data.Raw_Accel.Data.Z, update.ax,
                    update.ay, update.az);
-          Serial.println(msg);
-          bus->receive(CommentMessage(msg));
+          publishComment(bus, msg);
           update.hasAcceleration = false;
         }
       }
 
-      // Only dispatch to bus if sanity checks pass
-      if (update.hasOrientation || update.hasAcceleration) {
-        bus->receive(update);
+      // Keep only the newest valid values from the FIFO burst.
+      if (update.hasOrientation) {
+        latest.qx = update.qx;
+        latest.qy = update.qy;
+        latest.qz = update.qz;
+        latest.hasOrientation = true;
+        latest.t = update.t;
+      }
+      if (update.hasAcceleration) {
+        latest.ax = update.ax;
+        latest.ay = update.ay;
+        latest.az = update.az;
+        latest.hasAcceleration = true;
+        latest.t = update.t;
       }
     }
+
+    if (!moreData) {
+      break;
+    }
+  }
+
+  if (moreData) {
+    publishComment(bus, "ICM20948 FIFO backlog exceeded drain limit; resetting FIFO");
+    IMU_.resetFIFO();
+  }
+
+  if (latest.hasOrientation && latest.hasAcceleration && bus) {
+    bus->receive(latest);
   }
 }

--- a/src/vario/hardware/icm_20948.cpp
+++ b/src/vario/hardware/icm_20948.cpp
@@ -64,10 +64,8 @@ void ICM20948::init() {
   success &= (IMU_.enableDMPSensor(INV_ICM20948_SENSOR_ACCELEROMETER) == ICM_20948_Stat_Ok);
 
   // Configuring DMP to output data at multiple ODRs.
-  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Quat9, DMP_ODR_INTERVAL_20HZ) ==
-              ICM_20948_Stat_Ok);
-  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Accel, DMP_ODR_INTERVAL_20HZ) ==
-              ICM_20948_Stat_Ok);
+  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Quat9, DMP_ODR_INTERVAL_20HZ) == ICM_20948_Stat_Ok);
+  success &= (IMU_.setDMPODRrate(DMP_ODR_Reg_Accel, DMP_ODR_INTERVAL_20HZ) == ICM_20948_Stat_Ok);
 
   // Enable the FIFO
   success &= (IMU_.enableFIFO() == ICM_20948_Stat_Ok);
@@ -109,8 +107,7 @@ void ICM20948::update() {
       return;
     }
 
-    if ((IMU_.status != ICM_20948_Stat_Ok) &&
-        (IMU_.status != ICM_20948_Stat_FIFOMoreDataAvail)) {
+    if ((IMU_.status != ICM_20948_Stat_Ok) && (IMU_.status != ICM_20948_Stat_FIFOMoreDataAvail)) {
       char msg[100];
       snprintf(msg, sizeof(msg), "ICM20948 DMP FIFO read failed: %s", IMU_.statusString());
       publishComment(bus, msg);
@@ -150,8 +147,7 @@ void ICM20948::update() {
 
       // Invalidate insane acceleration data
       if (update.hasAcceleration) {
-        if (invalid(update.ax, -8, 8) || invalid(update.ay, -8, 8) ||
-            invalid(update.az, -8, 8)) {
+        if (invalid(update.ax, -8, 8) || invalid(update.ay, -8, 8) || invalid(update.az, -8, 8)) {
           char msg[100];
           snprintf(msg, sizeof(msg),
                    "ICM20948 invalid acceleration X=%X; Y=%X; Z=%X (%.2f, %.2f, %.2f)",

--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -26,10 +26,45 @@ namespace {
   constexpr double AFTER_SECONDS = 5.0;           // ...after this number of seconds
   constexpr double K_UPDATE = constexpr_log(1 - NEW_MEASUREMENT_WEIGHT) / AFTER_SECONDS;
 
-  constexpr uint8_t IMU_SAMPLE_RATE = 40;  // Hz
+  constexpr uint8_t IMU_SAMPLE_RATE = 20;  // Hz
   constexpr double GRAVITY_INIT_S = 3.0;   // Time to take to estimate the initial gravity magnitude
   // samples to bypass at startup while gravity is estimated
   constexpr uint32_t GRAVITY_INIT_SAMPLES = IMU_SAMPLE_RATE * GRAVITY_INIT_S;
+
+  constexpr double MIN_GRAVITY_G = 0.5;
+  constexpr double MAX_GRAVITY_G = 1.5;
+  constexpr double GRAVITY_UPDATE_ACCEL_TOLERANCE_G = 0.12;
+  constexpr double GRAVITY_UPDATE_VERTICAL_TOLERANCE_G = 0.25;
+
+  bool normalizeQuaternion(double* qw, double* qx, double* qy, double* qz) {
+    double qVecMagnitude2 = (*qx * *qx) + (*qy * *qy) + (*qz * *qz);
+    if (isnan(qVecMagnitude2) || isinf(qVecMagnitude2) || qVecMagnitude2 > 1.05) {
+      return false;
+    }
+
+    if (qVecMagnitude2 > 1.0) {
+      qVecMagnitude2 = 1.0;
+    }
+
+    *qw = sqrt(1.0 - qVecMagnitude2);
+
+    double qMagnitude = sqrt((*qw * *qw) + (*qx * *qx) + (*qy * *qy) + (*qz * *qz));
+    if (isnan(qMagnitude) || isinf(qMagnitude) || qMagnitude < 0.5) {
+      return false;
+    }
+
+    *qw /= qMagnitude;
+    *qx /= qMagnitude;
+    *qy /= qMagnitude;
+    *qz /= qMagnitude;
+    return true;
+  }
+
+  bool plausibleGravity(double gravity) {
+    double magnitude = fabs(gravity);
+    return !isnan(gravity) && !isinf(gravity) && magnitude >= MIN_GRAVITY_G &&
+           magnitude <= MAX_GRAVITY_G;
+  }
 }  // namespace
 
 void quaternionMult(double qw, double qx, double qy, double qz, double rw, double rx, double ry,
@@ -65,10 +100,14 @@ IMU::IMU()
       gravityInitCount_(GRAVITY_INIT_SAMPLES) {}
 
 void IMU::processMotion(const MotionUpdate& m) {
-  // Scale to +/- 1
-  double magnitude = ((m.qx * m.qx) + (m.qy * m.qy) + (m.qz * m.qz));
-  if (magnitude >= 1.0) magnitude = 1.0;
-  double qw = sqrt(1.0 - magnitude);
+  double qw = 0;
+  double qx = m.qx;
+  double qy = m.qy;
+  double qz = m.qz;
+  if (!normalizeQuaternion(&qw, &qx, &qy, &qz)) {
+    validAccelVert_ = false;
+    return;
+  }
 
   bool needComma = false;
   bool needNewline = false;
@@ -77,11 +116,11 @@ void IMU::processMotion(const MotionUpdate& m) {
   Serial.print(F("Qw:"));
   printFloat(qw);
   Serial.print(F(",Qx:"));
-  printFloat(m.qx);
+  printFloat(qx);
   Serial.print(F(",Qy:"));
-  printFloat(m.qy);
+  printFloat(qy);
   Serial.print(F(",Qz:"));
-  printFloat(m.qz);
+  printFloat(qz);
   needComma = true;
   needNewline = true;
 #endif
@@ -104,11 +143,11 @@ void IMU::processMotion(const MotionUpdate& m) {
 #endif
 
   double awx, awy, awz;
-  rotateByQuaternion(m.ax, m.ay, m.az, qw, m.qx, m.qy, m.qz, &awx, &awy, &awz);
+  rotateByQuaternion(m.ax, m.ay, m.az, qw, qx, qy, qz, &awx, &awy, &awz);
   if (isinf(awz) || isnan(awz)) {
     fatalErrorInfo(
         "m.ax=%g, m.ay=%g, m.az=%g, qw=%g, m.qx=%g, m.qy=%g, m.qz=%g, awx=%g, awy=%g, awz=%g", m.ax,
-        m.ay, m.az, qw, m.qx, m.qy, m.qz, awx, awy, awz);
+        m.ay, m.az, qw, qx, qy, qz, awx, awy, awz);
     fatalError("IMU awz was invalid");
   }
 
@@ -142,6 +181,11 @@ void IMU::processMotion(const MotionUpdate& m) {
     gravity_ += awz;
     if (--gravityInitCount_ == 0) {
       gravity_ /= GRAVITY_INIT_SAMPLES;
+      if (!plausibleGravity(gravity_)) {
+        gravity_ = 0;
+        gravityInitCount_ = GRAVITY_INIT_SAMPLES;
+        validAccelVert_ = false;
+      }
     }
   }
   if (gravityInitCount_ == 0) {
@@ -151,10 +195,18 @@ void IMU::processMotion(const MotionUpdate& m) {
     validAccelVert_ = true;
 
     // Slowly update estimate of gravity
-    double dt = ((double)m.t - tLastGravityUpdate_) * 0.001;
-    double f = exp(K_UPDATE * dt);
-
-    gravity_ = gravity_ * f + awz * (1 - f);
+    double accelMagnitudeDelta = fabs(accelTot_ - fabs(gravity_));
+    if (accelMagnitudeDelta <= GRAVITY_UPDATE_ACCEL_TOLERANCE_G &&
+        fabs(accelVert_) <= GRAVITY_UPDATE_VERTICAL_TOLERANCE_G) {
+      double dt = ((double)m.t - tLastGravityUpdate_) * 0.001;
+      if (dt > 0.0 && dt < 1.0) {
+        double f = exp(K_UPDATE * dt);
+        double nextGravity = gravity_ * f + awz * (1 - f);
+        if (plausibleGravity(nextGravity)) {
+          gravity_ = nextGravity;
+        }
+      }
+    }
   }
 
 #ifdef SHOW_VERTICAL_ACCEL

--- a/src/vario/math/kalman.cpp
+++ b/src/vario/math/kalman.cpp
@@ -46,6 +46,14 @@ void KalmanFilterPA::update(double measuredTime, double measuredPosition,
   }
 
   double dt = measuredTime - t_;
+  if (dt <= 0.0) {
+    return;
+  }
+  if (dt > 1.0) {
+    init(measuredTime, measuredPosition, measuredAcceleration);
+    return;
+  }
+
   double dt2 = dt * dt;
   double dt3 = dt2 * dt;
   double dt4 = dt3 * dt;


### PR DESCRIPTION
From Codex:
Implemented the IMU/baro/Kalman hardening pass.
The biggest concrete issue was in icm_20948.cpp (line 20): the DMP was producing ~75 Hz while the task loop consumed one packet at 20 Hz. I changed the DMP ODR to ~20 Hz, drain FIFO bursts to the newest valid sample, and reset/log if the FIFO still has backlog or incomplete packets.
I also hardened imu.cpp (line 39) by normalizing the reconstructed quaternion before world-Z rotation, rejecting implausible quaternion/gravity states, aligning gravity init to the actual 20 Hz cadence, and only adapting the gravity baseline when total acceleration and vertical acceleration look steady. kalman.cpp (line 49) now ignores duplicate/non-increasing timestamps and reinitializes after >1s timing gaps instead of integrating a huge step.