### PR TITLE
Don't allow log auto-start if Flight Summary is showing

### DIFF
--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -16,6 +16,7 @@
 #include "ui/audio/sound_effects.h"
 #include "ui/audio/speaker.h"
 #include "ui/display/pages/dialogs/page_alert_timerAutoStop.h"
+#include "ui/display/pages/dialogs/page_flight_summary.h"
 #include "ui/display/pages/fanet/page_fanet_stats.h"
 #include "ui/settings/settings.h"
 #include "utils/string_utils.h"
@@ -124,6 +125,11 @@ int32_t autoStopAltitude = 0;
 
 bool flightTimer_autoStart() {
   bool startTheTimer = false;  // default to not auto-start
+
+  if (PageFlightSummary::isShowing()) {
+    autoStartCounter = 0;
+    return false;
+  }
 
   // keep track of how many times (seconds) we've been continuously over the min speed threshold
   if (gps.speed.mph() > AUTO_START_MIN_SPEED) {

--- a/src/vario/ui/display/pages/dialogs/page_flight_summary.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_flight_summary.cpp
@@ -7,6 +7,8 @@
 #include "ui/settings/settings.h"
 #include "utils/string_utils.h"
 
+bool PageFlightSummary::showing_ = false;
+
 void PageFlightSummary::draw_extra() {
   u8g2.setFont(leaf_6x12);
 

--- a/src/vario/ui/display/pages/dialogs/page_flight_summary.h
+++ b/src/vario/ui/display/pages/dialogs/page_flight_summary.h
@@ -6,11 +6,17 @@ class PageFlightSummary : public SimpleSettingsMenuPage {
  public:
   const char* get_title() const override { return "Flight Summary"; }
   virtual void draw_extra() override;
+  void closed(bool removed_from_Stack) override {
+    if (removed_from_Stack) showing_ = false;
+  }
   void show(const FlightStats stats) {
     this->stats = stats;
+    showing_ = true;
     push_page(this);
   }
+  static bool isShowing() { return showing_; }
 
  private:
   FlightStats stats;
+  static bool showing_;
 };


### PR DESCRIPTION
if the user is still looking at the flight summary, then don't allow another log to auto-start in the background.  This also helps if the user forgets to turn off their vario, since a new log can't start (once a log auto-starts, the vario won't turn itself off).