### PR TITLE
[FANET] Fix crash on FANET Rx with no location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ vario.ino.cpp
 
 # Python
 *.pyc
+
+# ESP-IDF
+esp-idf/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,19 @@
   - `uv run python -c "from factory_interface.app import app; print(app.title)"`
 - The app requires the operator cookie for API calls. Browser sessions may already have it, but direct API smoke tests need `factory_interface_operator_name=<name>`.
 - Port `8000` may already be in use locally. Starting uvicorn on another port, such as `8001`, works for smoke testing.
+
+## Core Dump Analysis
+
+For ESP32 core dump retrieval and analysis:
+
+**Reference**: [Leaf Core Dump Guide](https://leafvario.com/dev-references/core-dumps/)
+
+**Firmware location**: `.pio/build/leaf_3_2_6_dev/firmware.elf`
+
+**Device path (macOS)**: `/dev/tty.usbmodem*`
+
+**Quick steps**:
+```bash
+cd esp-idf && . ./export.sh
+espcoredump.py -p /dev/tty.usbmodem* info_corefile .pio/build/leaf_3_2_6_dev/firmware.elf
+```

--- a/platformio.ini
+++ b/platformio.ini
@@ -118,3 +118,4 @@ extends = env:leaf_3_2_7_release
 build_flags =
     ${env:leaf_3_2_7_release.build_flags}
     -DRUN_EMBEDDED_TESTS
+    -DUNIT_TESTING

--- a/src/vario/comms/fanet_neighbors.h
+++ b/src/vario/comms/fanet_neighbors.h
@@ -39,6 +39,13 @@ struct FanetNeighbors : public etl::message_router<FanetNeighbors, FanetPacket>,
  public:
   const NeighborMap& get() const { return neighbors_; }
 
+#ifdef UNIT_TESTING
+  // Test accessor methods
+  void addNeighborForTesting(const Neighbor& neighbor) {
+    neighbors_[neighbor.address.asUint()] = neighbor;
+  }
+#endif
+
   void updateFromTable(const FANET::NeighbourTable<FANET::Protocol::FANET_MAX_NEIGHBORS>& table) {
     etl::set<uint32_t, FANET::Protocol::FANET_MAX_NEIGHBORS> seen;
 
@@ -69,59 +76,76 @@ struct FanetNeighbors : public etl::message_router<FanetNeighbors, FanetPacket>,
 
   // Message bus operations.  Receives FanetPacket messages to update location
   void on_receive(const FanetPacket& msg) {
-    // Only process FANET packets that are in our local neighbor table
-    if (!neighbors_.contains(msg.packet.source().asUint())) {
-      return;
-    }
+    try {
+      // Only process FANET packets that are in our local neighbor table
+      if (!neighbors_.contains(msg.packet.source().asUint())) {
+        return;
+      }
 
-    auto& neighbor = neighbors_[msg.packet.source().asUint()];
+      auto& neighbor = neighbors_[msg.packet.source().asUint()];
 
-    // Update the RSSI and SNR values for this packet
-    neighbor.rssi = msg.rssi;
-    neighbor.snr = msg.snr;
+      // Update the RSSI and SNR values for this packet
+      neighbor.rssi = msg.rssi;
+      neighbor.snr = msg.snr;
 
-    float lat;
-    float lon;
+      float lat = 0.0;
+      float lon = 0.0;
+      bool hasLocationData = false;
 
-    // Update location for Tracking and GroundTracking modes
-    if (msg.packet.header().type() == FANET::Header::MessageType::TRACKING) {
-      const auto& trackingPayload = etl::get<FANET::TrackingPayload>(msg.packet.payload().value());
+      // Update location for Tracking and GroundTracking modes
+      if (msg.packet.header().type() == FANET::Header::MessageType::TRACKING) {
+        if (!msg.packet.payload().has_value()) {
+          return;
+        }
 
-      const auto& longitude = trackingPayload.longitude();
-      const auto& latitude = trackingPayload.latitude();
+        const auto& trackingPayload =
+            etl::get<FANET::TrackingPayload>(msg.packet.payload().value());
 
-      lat = latitude;
-      lon = longitude;
+        const auto& longitude = trackingPayload.longitude();
+        const auto& latitude = trackingPayload.latitude();
 
-      neighbor.distanceKm =
-          gps.distanceBetween(gps.location.lat(), gps.location.lng(), latitude, longitude) / 1000;
-      neighbor.groundTrackingMode = etl::nullopt;
+        lat = latitude;
+        lon = longitude;
+        hasLocationData = true;
 
-    } else if (msg.packet.header().type() == FANET::Header::MessageType::GROUND_TRACKING) {
-      const auto& trackingPayload =
-          etl::get<FANET::GroundTrackingPayload>(msg.packet.payload().value());
+        neighbor.distanceKm =
+            gps.distanceBetween(gps.location.lat(), gps.location.lng(), latitude, longitude) / 1000;
+        neighbor.groundTrackingMode = etl::nullopt;
 
-      const auto& longitude = trackingPayload.longitude();
-      const auto& latitude = trackingPayload.latitude();
+      } else if (msg.packet.header().type() == FANET::Header::MessageType::GROUND_TRACKING) {
+        if (!msg.packet.payload().has_value()) {
+          return;
+        }
 
-      lat = latitude;
-      lon = longitude;
+        const auto& trackingPayload =
+            etl::get<FANET::GroundTrackingPayload>(msg.packet.payload().value());
 
-      neighbor.distanceKm =
-          gps.distanceBetween(gps.location.lat(), gps.location.lng(), latitude, longitude) / 1000;
-      neighbor.groundTrackingMode = trackingPayload.groundType();
-    }
+        const auto& longitude = trackingPayload.longitude();
+        const auto& latitude = trackingPayload.latitude();
 
-    // Log to message bus
-    // Format: fanet_rx,<FanetID>,<distance in km>,<RSSI>,<SNR>,<Packet Lat>,<Packet
-    // Lon>,<MyLat>,<MyLon>
-    if (LOG::FANET_RX && bus_) {
-      String fanetRxName = "fanet_rx,";
-      String fanetEntry = fanetRxName + String(neighbor.address.asUint(), HEX) + "," +
-                          (neighbor.distanceKm.value()) + "," + String(neighbor.rssi) + "," +
-                          String(neighbor.snr) + "," + String(lat, 8) + "," + String(lon, 8) + "," +
-                          String(gps.location.lat(), 8) + "," + String(gps.location.lng(), 8);
-      bus_->receive(CommentMessage(fanetEntry));
+        lat = latitude;
+        lon = longitude;
+        hasLocationData = true;
+
+        neighbor.distanceKm =
+            gps.distanceBetween(gps.location.lat(), gps.location.lng(), latitude, longitude) / 1000;
+        neighbor.groundTrackingMode = trackingPayload.groundType();
+      }
+
+      // Log to message bus - only log when we have valid location data
+      // Format: fanet_rx,<FanetID>,<distance in km>,<RSSI>,<SNR>,<Packet Lat>,<Packet
+      // Lon>,<MyLat>,<MyLon>
+      if (LOG::FANET_RX && bus_ && hasLocationData && neighbor.distanceKm.has_value()) {
+        String fanetRxName = "fanet_rx,";
+        String fanetEntry = fanetRxName + String(neighbor.address.asUint(), HEX) + "," +
+                            String(neighbor.distanceKm.value()) + "," + String(neighbor.rssi) +
+                            "," + String(neighbor.snr) + "," + String(lat, 8) + "," +
+                            String(lon, 8) + "," + String(gps.location.lat(), 8) + "," +
+                            String(gps.location.lng(), 8);
+        bus_->receive(CommentMessage(fanetEntry));
+      }
+    } catch (...) {
+      // Silently ignore exceptions to prevent crashes from malformed FANET packets
     }
   }
 

--- a/src/vario/tests/fanet_tests.cpp
+++ b/src/vario/tests/fanet_tests.cpp
@@ -1,0 +1,50 @@
+#include "tests/fanet_tests.h"
+
+#include <Arduino.h>
+#include "comms/fanet_neighbors.h"
+#include "dispatch/message_types.h"
+#include "etl/message_bus.h"
+#include "fanet/address.hpp"
+#include "fanet/header.hpp"
+#include "fanet/packet.hpp"
+
+/**
+ * @brief Test that verifies we don't crash on non-location FANET packets (Issue #306)
+ *
+ * Previously, receiving ACK/NAME/MESSAGE packets would crash when trying to log
+ * with an empty distanceKm optional. This test verifies the fix works.
+ */
+void test_fanet_neighbors_empty_distance(etl::imessage_bus* bus) {
+  Serial.println("\n=== Testing FANET Non-Location Packet Handling (Issue #306) ===");
+
+  FanetNeighbors fanetNeighbors;
+  fanetNeighbors.publishTo(bus);
+
+  // Create test neighbor
+  FANET::Address testAddress(0x12, 0x3456);
+  FanetNeighbors::Neighbor testNeighbor;
+  testNeighbor.address = testAddress;
+  testNeighbor.lastSeen = millis();
+  testNeighbor.rssi = -50.0f;
+  testNeighbor.snr = 10.0f;
+  testNeighbor.distanceKm = etl::nullopt;  // No distance set
+  testNeighbor.groundTrackingMode = etl::nullopt;
+
+#ifdef UNIT_TESTING
+  fanetNeighbors.addNeighborForTesting(testNeighbor);
+
+  // Create ACK packet (non-location type that doesn't set distanceKm)
+  FANET::Header ackHeader(false, false, FANET::Header::MessageType::ACK);
+  FANET::Packet<FANET_MAX_FRAME_SIZE> ackPacket(ackHeader, testAddress, etl::nullopt, etl::nullopt,
+                                                etl::nullopt, etl::nullopt);
+
+  FanetPacket msg(ackPacket, -55.0f, 8.5f);
+
+  Serial.println("Sending ACK packet (should not crash)...");
+  fanetNeighbors.on_receive(msg);
+
+  Serial.println("[PASS] No crash on non-location packet!");
+#else
+  Serial.println("[SKIP] UNIT_TESTING not defined");
+#endif
+}

--- a/src/vario/tests/fanet_tests.h
+++ b/src/vario/tests/fanet_tests.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "etl/message_bus.h"
+
+void test_fanet_neighbors_empty_distance(etl::imessage_bus* bus);

--- a/src/vario/tests/tests.cpp
+++ b/src/vario/tests/tests.cpp
@@ -1,3 +1,4 @@
+#include "tests/fanet_tests.h"
 #include "tests/gps_tests.h"
 
 #include <Arduino.h>
@@ -5,6 +6,7 @@
 
 void run_tests(etl::imessage_bus* bus) {
   test_gps_parsing(bus);
+  test_fanet_neighbors_empty_distance(bus);
   while (true) {
     Serial.println("All tests were successful.");
     delay(5000);


### PR DESCRIPTION
## Summary

This fixes #306.
- Adds exception handling around FANET Rx.  An unhandled exception should just fail to parse the FANET packet, never prevent the vario from enjoying a flight ;)
- Fixed the bug.

## Test plan
Added a test case to the existing test suite.

```
Reconnecting to /dev/cu.usbmodemF0F5BD535F202 ..         Connected!
DMP enabled!
 - Finished IMU
sleep_peripherals: OffUSB
 - Sleeping GPS
LC86G::sleep now: 1834
ready: 708
delay: 0
************ !!!!!!!!!!! GPS SLEEPING COMMAND SENT !!!!!!!!!!! ************
 - Sleeping baro
 - Sleeping speaker
Shut down speaker
 - DONE
 - DONE
Finished Setup
Initializing Bluetooth Module
Leaf Initialized
GPS parsing test successful.

=== Testing FANET Non-Location Packet Handling (Issue #306) ===
Sending ACK packet (should not crash)...
[PASS] No crash on non-location packet!
All tests were successful.
All tests were successful.
```