### PR TITLE
Fix: critical assignment bug in UDP message type check

### DIFF
--- a/src/vario/comms/udp_message_server.cpp
+++ b/src/vario/comms/udp_message_server.cpp
@@ -51,7 +51,7 @@ void UDPMessageServer::onPacket(AsyncUDPPacket& packet) {
     onGPSMessage(line, n);
   } else if (msgType == 'M') {
     onMotionUpdate(line, n);
-  } else if (msgType = 'P') {
+  } else if (msgType == 'P') {
     onPressureUpdate(line, n);
   } else {
     Serial.printf("Unrecognized UDP message type: '%s'\n", msgType);


### PR DESCRIPTION
Changed msgType = 'P' (assignment) to msgType == 'P' (comparison). This bug caused all unrecognized message types to incorrectly execute the pressure update handler instead of being rejected.