### PR TITLE
GPX dynamic routes

### DIFF
--- a/src/vario/navigation/gpx.cpp
+++ b/src/vario/navigation/gpx.cpp
@@ -82,9 +82,7 @@ bool Navigator::addRoutePoint(Route* route, WaypointID waypointIndex) {
   return true;
 }
 
-const Waypoint& Navigator::waypoint(WaypointID pointIndex) const {
-  return waypoints[pointIndex];
-}
+const Waypoint& Navigator::waypoint(WaypointID pointIndex) const { return waypoints[pointIndex]; }
 
 const Waypoint& Navigator::routePoint(RouteID routeIndex, RouteIndex pointIndex) const {
   return waypoint(routeWaypointIndexes[routes[routeIndex].firstRoutePointIndex + pointIndex - 1]);

--- a/src/vario/navigation/gpx.cpp
+++ b/src/vario/navigation/gpx.cpp
@@ -34,38 +34,60 @@ void Navigator::init() {
 }
 
 void Navigator::clear() {
-  totalPoints = 0;
   totalWaypoints = 0;
+  totalRoutePointRefs = 0;
   totalRoutes = 0;
 }
 
 bool Navigator::addWaypoint(const Waypoint& waypoint) {
-  if (totalPoints >= maxNavPoints || totalWaypoints >= maxNavPoints) {
+  if (totalWaypoints >= maxNavPoints) {
     return false;
   }
-  points[++totalPoints] = waypoint;
-  waypointPointIndexes[++totalWaypoints] = totalPoints;
+  waypoints[++totalWaypoints] = waypoint;
   return true;
 }
 
-bool Navigator::addRoutePoint(Route* route, const Waypoint& waypoint) {
-  if (totalPoints >= maxNavPoints) {
+WaypointID Navigator::findWaypointByName(const String& name) const {
+  if (name == "") {
+    return WaypointID::None;
+  }
+  for (uint8_t i = 1; i <= totalWaypoints; i++) {
+    if (waypoints[i].name == name) {
+      return WaypointID(i);
+    }
+  }
+  return WaypointID::None;
+}
+
+WaypointID Navigator::addOrFindWaypoint(const Waypoint& waypoint) {
+  WaypointID existingIndex = findWaypointByName(waypoint.name);
+  if (existingIndex) {
+    return existingIndex;
+  }
+  if (!addWaypoint(waypoint)) {
+    return WaypointID::None;
+  }
+  return WaypointID(totalWaypoints);
+}
+
+bool Navigator::addRoutePoint(Route* route, WaypointID waypointIndex) {
+  if (!waypointIndex || totalRoutePointRefs >= maxRoutePointRefs) {
     return false;
   }
-  points[++totalPoints] = waypoint;
   if (route->totalPoints == 0) {
-    route->firstPointIndex = totalPoints;
+    route->firstRoutePointIndex = totalRoutePointRefs + 1;
   }
+  routeWaypointIndexes[++totalRoutePointRefs] = waypointIndex;
   route->totalPoints++;
   return true;
 }
 
 const Waypoint& Navigator::waypoint(WaypointID pointIndex) const {
-  return points[waypointPointIndexes[pointIndex]];
+  return waypoints[pointIndex];
 }
 
 const Waypoint& Navigator::routePoint(RouteID routeIndex, RouteIndex pointIndex) const {
-  return points[routes[routeIndex].firstPointIndex + pointIndex - 1];
+  return waypoint(routeWaypointIndexes[routes[routeIndex].firstRoutePointIndex + pointIndex - 1]);
 }
 
 // update nav data every second
@@ -282,9 +304,6 @@ bool gpx_readFile(fs::FS& fs, String fileName) {
   if (success) {
     Serial.println("gpx_readFile was successful:");
     Serial.print("  ");
-    Serial.print(parse_result.totalPoints);
-    Serial.println(" total points");
-    Serial.print("  ");
     Serial.print(parse_result.totalWaypoints);
     Serial.println(" waypoints");
     for (uint8_t wp = 1; wp <= parse_result.totalWaypoints; wp++) {
@@ -321,8 +340,6 @@ bool gpx_readFile(fs::FS& fs, String fileName) {
     }
     navigator = parse_result;
     Serial.print("Navigator loaded ");
-    Serial.print(navigator.totalPoints);
-    Serial.print(" total points, ");
     Serial.print(navigator.totalWaypoints);
     Serial.print(" waypoints and ");
     Serial.print(navigator.totalRoutes);
@@ -345,29 +362,29 @@ void Navigator::loadRoutes() {
   totalRoutes = 4;
 
   routes[1].name = "R: TheCircuit";
-  addRoutePoint(&routes[1], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[1], waypoint(WaypointID(7)));
-  addRoutePoint(&routes[1], waypoint(WaypointID(8)));
-  addRoutePoint(&routes[1], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[1], waypoint(WaypointID(2)));
+  addRoutePoint(&routes[1], WaypointID(1));
+  addRoutePoint(&routes[1], WaypointID(7));
+  addRoutePoint(&routes[1], WaypointID(8));
+  addRoutePoint(&routes[1], WaypointID(1));
+  addRoutePoint(&routes[1], WaypointID(2));
 
   routes[2].name = "R: Scenic";
-  addRoutePoint(&routes[2], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[2], waypoint(WaypointID(3)));
-  addRoutePoint(&routes[2], waypoint(WaypointID(4)));
-  addRoutePoint(&routes[2], waypoint(WaypointID(5)));
-  addRoutePoint(&routes[2], waypoint(WaypointID(2)));
+  addRoutePoint(&routes[2], WaypointID(1));
+  addRoutePoint(&routes[2], WaypointID(3));
+  addRoutePoint(&routes[2], WaypointID(4));
+  addRoutePoint(&routes[2], WaypointID(5));
+  addRoutePoint(&routes[2], WaypointID(2));
 
   routes[3].name = "R: Downhill";
-  addRoutePoint(&routes[3], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[3], waypoint(WaypointID(5)));
-  addRoutePoint(&routes[3], waypoint(WaypointID(2)));
+  addRoutePoint(&routes[3], WaypointID(1));
+  addRoutePoint(&routes[3], WaypointID(5));
+  addRoutePoint(&routes[3], WaypointID(2));
 
   routes[4].name = "R: MiniTri";
-  addRoutePoint(&routes[4], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[4], waypoint(WaypointID(4)));
-  addRoutePoint(&routes[4], waypoint(WaypointID(5)));
-  addRoutePoint(&routes[4], waypoint(WaypointID(1)));
+  addRoutePoint(&routes[4], WaypointID(1));
+  addRoutePoint(&routes[4], WaypointID(4));
+  addRoutePoint(&routes[4], WaypointID(5));
+  addRoutePoint(&routes[4], WaypointID(1));
 }
 
 void Navigator::loadWaypoints() {

--- a/src/vario/navigation/gpx.h
+++ b/src/vario/navigation/gpx.h
@@ -9,8 +9,9 @@
 
 // Waypoint definition and memory allocation
 #define waypointRadius 150  // meters radius to count as "reaching/crossing" a waypoint
-#define maxRoutes 5
-#define maxNavPoints 75
+#define maxRoutes 10
+#define maxNavPoints 100
+#define maxRoutePointRefs 75
 
 struct Waypoint {
   String name;
@@ -22,7 +23,7 @@ struct Waypoint {
 // Route definition and memory allocation
 struct Route {
   String name;
-  uint8_t firstPointIndex = 0;
+  uint8_t firstRoutePointIndex = 0;
   uint8_t totalPoints = 0;
 };
 
@@ -41,14 +42,16 @@ class Navigator {
 
   void clear();
   bool addWaypoint(const Waypoint& waypoint);
-  bool addRoutePoint(Route* route, const Waypoint& waypoint);
+  WaypointID addOrFindWaypoint(const Waypoint& waypoint);
+  WaypointID findWaypointByName(const String& name) const;
+  bool addRoutePoint(Route* route, WaypointID waypointIndex);
   const Waypoint& waypoint(WaypointID pointIndex) const;
   const Waypoint& routePoint(RouteID routeIndex, RouteIndex pointIndex) const;
 
-  Waypoint points[maxNavPoints + 1];
-  uint8_t totalPoints = 0;
-  uint8_t waypointPointIndexes[maxNavPoints + 1];
+  Waypoint waypoints[maxNavPoints + 1];
   uint8_t totalWaypoints = 0;
+  WaypointID routeWaypointIndexes[maxRoutePointRefs + 1];
+  uint8_t totalRoutePointRefs = 0;
   Route routes[maxRoutes + 1];
   uint8_t totalRoutes = 0;
 

--- a/src/vario/navigation/gpx_parser.cpp
+++ b/src/vario/navigation/gpx_parser.cpp
@@ -61,7 +61,13 @@ bool GPXParser::parse(Navigator* result) {
         return false;
       }
       Waypoint waypoint;
-      if (readWaypoint(&waypoint, "wpt")) {
+      bool foundCoordinates = false;
+      if (readWaypoint(&waypoint, "wpt", false, &foundCoordinates)) {
+        if (!foundCoordinates) {
+          Serial.print("WARNING: GPX waypoint missing coordinates; skipping wpt: ");
+          Serial.println(waypoint.name);
+          continue;
+        }
         if (!result->addOrFindWaypoint(waypoint)) {
           Serial.println("WARNING: maximum number of GPX points reached; skipping extra wpt");
           continue;
@@ -198,10 +204,13 @@ char GPXParser::skipWhitespace() {
   return c;
 }
 
-bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name) {
+bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name, bool requireCoordinates,
+                             bool* foundCoordinates) {
   char key[MAX_VALUE_LENGTH + 1];
   char value[MAX_VALUE_LENGTH + 1];
   waypoint->name = "";
+  waypoint->lat = 0;
+  waypoint->lon = 0;
   waypoint->ele = 0;
 
   // Read attributes of opening tag (until tag is closed)
@@ -238,11 +247,14 @@ bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name) {
       found_lon = true;
     }
   }
-  if (!found_lat) {
+  if (foundCoordinates) {
+    *foundCoordinates = found_lat && found_lon;
+  }
+  if (requireCoordinates && !found_lat) {
     _error = "couldn't find lat attribute in waypoint tag";
     return false;
   }
-  if (!found_lon) {
+  if (requireCoordinates && !found_lon) {
     _error = "couldn't find lon attribute in waypoint tag";
     return false;
   }
@@ -456,7 +468,8 @@ bool GPXParser::readRoute(Navigator* result, Route* route, bool storePoints) {
     } else if (tagEqualsIgnoreCase(key, "rtept")) {
       // This is an opening route point tag
       Waypoint waypoint;
-      if (!readWaypoint(&waypoint, "rtept")) {
+      bool foundCoordinates = false;
+      if (!readWaypoint(&waypoint, "rtept", false, &foundCoordinates)) {
         _error = " while reading rtept";
         return false;
       }
@@ -467,7 +480,15 @@ bool GPXParser::readRoute(Navigator* result, Route* route, bool storePoints) {
         Serial.println("WARNING: maximum number of GPX route point refs reached; skipping rtept");
         continue;
       }
-      WaypointID waypointIndex = result->addOrFindWaypoint(waypoint);
+      WaypointID waypointIndex = result->findWaypointByName(waypoint.name);
+      if (!waypointIndex && !foundCoordinates) {
+        Serial.print("WARNING: GPX route point without coordinates did not match waypoint: ");
+        Serial.println(waypoint.name);
+        continue;
+      }
+      if (!waypointIndex) {
+        waypointIndex = result->addOrFindWaypoint(waypoint);
+      }
       if (!waypointIndex) {
         Serial.println("WARNING: maximum number of GPX waypoints reached; skipping extra rtept");
         continue;

--- a/src/vario/navigation/gpx_parser.cpp
+++ b/src/vario/navigation/gpx_parser.cpp
@@ -4,6 +4,9 @@
 
 // The maximum length of a value in a GPX (tag name, latitude, longitude, elevation, etc)
 #define MAX_VALUE_LENGTH (64)
+// Safety fuse: the waypoint/route pools are small, so a GPX this large is almost certainly
+// malformed or far beyond what Leaf can use. Abort instead of delaying boot for a long scan.
+#define MAX_GPX_PARSE_CHARS (262144UL)
 
 inline bool isWhitespace(char c) { return c == ' ' || c == '\t' || c == '\r' || c == '\n'; }
 
@@ -98,14 +101,23 @@ bool GPXParser::parse(Navigator* result) {
     }
   }
 
-  return true;
+  return !_readAborted;
 }
 
 char GPXParser::getNextChar() {
+  if (_readAborted) {
+    return 0;
+  }
+  if (_charsReadTotal >= MAX_GPX_PARSE_CHARS) {
+    _error = "GPX parse limit exceeded";
+    _readAborted = true;
+    return 0;
+  }
   if (!_file_reader->contentRemaining()) {
     return 0;
   }
   char c = _file_reader->nextChar();
+  _charsReadTotal++;
   if ((++_charsReadSinceYield & 0xFF) == 0) {
     yield();
   }

--- a/src/vario/navigation/gpx_parser.cpp
+++ b/src/vario/navigation/gpx_parser.cpp
@@ -56,13 +56,10 @@ bool GPXParser::parse(Navigator* result) {
       return false;
     }
     if (tagEqualsIgnoreCase(value_buffer, "wpt")) {
-      if (name_result == ReadTagNameResult::TagClosed) {
-        _error = "missing lat and lon attributes for wpt tag";
-        return false;
-      }
       Waypoint waypoint;
       bool foundCoordinates = false;
-      if (readWaypoint(&waypoint, "wpt", false, &foundCoordinates)) {
+      if (readWaypoint(&waypoint, "wpt", false, &foundCoordinates,
+                       name_result == ReadTagNameResult::TagClosed, _lastTagSelfClosing)) {
         if (!foundCoordinates) {
           Serial.print("WARNING: GPX waypoint missing coordinates; skipping wpt: ");
           Serial.println(waypoint.name);
@@ -205,7 +202,8 @@ char GPXParser::skipWhitespace() {
 }
 
 bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name, bool requireCoordinates,
-                             bool* foundCoordinates) {
+                             bool* foundCoordinates, bool openingTagClosed,
+                             bool openingTagSelfClosing) {
   char key[MAX_VALUE_LENGTH + 1];
   char value[MAX_VALUE_LENGTH + 1];
   waypoint->name = "";
@@ -216,35 +214,37 @@ bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name, bool requ
   // Read attributes of opening tag (until tag is closed)
   bool found_lat = false;
   bool found_lon = false;
-  bool self_closing = false;
-  while (true) {
-    char c = skipWhitespace();
-    if (c == 0) {
-      _error = "reached end of file while looking for attributes in waypoint tag";
-      return false;
-    } else if (c == '>') {
-      break;
-    } else if (c == '/') {
-      c = skipWhitespace();
-      if (c != '>') {
-        _error = "unexpected character after self-closing marker in waypoint tag";
+  bool self_closing = openingTagSelfClosing;
+  if (!openingTagClosed) {
+    while (true) {
+      char c = skipWhitespace();
+      if (c == 0) {
+        _error = "reached end of file while looking for attributes in waypoint tag";
+        return false;
+      } else if (c == '>') {
+        break;
+      } else if (c == '/') {
+        c = skipWhitespace();
+        if (c != '>') {
+          _error = "unexpected character after self-closing marker in waypoint tag";
+          return false;
+        }
+        self_closing = true;
+        break;
+      }
+      key[0] = c;
+      bool attribute_success = readAttribute(key + 1, value);
+      if (!attribute_success) {
+        _error += " while reading attribute in waypoint tag";
         return false;
       }
-      self_closing = true;
-      break;
-    }
-    key[0] = c;
-    bool attribute_success = readAttribute(key + 1, value);
-    if (!attribute_success) {
-      _error += " while reading attribute in waypoint tag";
-      return false;
-    }
-    if (equalsIgnoreCase(key, "lat")) {
-      waypoint->lat = atof(value);
-      found_lat = true;
-    } else if (equalsIgnoreCase(key, "lon")) {
-      waypoint->lon = atof(value);
-      found_lon = true;
+      if (equalsIgnoreCase(key, "lat")) {
+        waypoint->lat = atof(value);
+        found_lat = true;
+      } else if (equalsIgnoreCase(key, "lon")) {
+        waypoint->lon = atof(value);
+        found_lon = true;
+      }
     }
   }
   if (foundCoordinates) {
@@ -469,7 +469,8 @@ bool GPXParser::readRoute(Navigator* result, Route* route, bool storePoints) {
       // This is an opening route point tag
       Waypoint waypoint;
       bool foundCoordinates = false;
-      if (!readWaypoint(&waypoint, "rtept", false, &foundCoordinates)) {
+      if (!readWaypoint(&waypoint, "rtept", false, &foundCoordinates,
+                        name_outcome == ReadTagNameResult::TagClosed, _lastTagSelfClosing)) {
         _error = " while reading rtept";
         return false;
       }

--- a/src/vario/navigation/gpx_parser.cpp
+++ b/src/vario/navigation/gpx_parser.cpp
@@ -62,7 +62,7 @@ bool GPXParser::parse(Navigator* result) {
       }
       Waypoint waypoint;
       if (readWaypoint(&waypoint, "wpt")) {
-        if (!result->addWaypoint(waypoint)) {
+        if (!result->addOrFindWaypoint(waypoint)) {
           Serial.println("WARNING: maximum number of GPX points reached; skipping extra wpt");
           continue;
         }
@@ -422,7 +422,7 @@ bool GPXParser::readFullTagName(char* key) {
 }
 
 bool GPXParser::readRoute(Navigator* result, Route* route, bool storePoints) {
-  route->firstPointIndex = 0;
+  route->firstRoutePointIndex = 0;
   route->totalPoints = 0;
 
   char key[MAX_VALUE_LENGTH + 1];
@@ -463,8 +463,17 @@ bool GPXParser::readRoute(Navigator* result, Route* route, bool storePoints) {
       if (!storePoints) {
         continue;
       }
-      if (!result->addRoutePoint(route, waypoint)) {
-        Serial.println("WARNING: maximum number of GPX points reached; skipping extra rtept");
+      if (result->totalRoutePointRefs >= maxRoutePointRefs) {
+        Serial.println("WARNING: maximum number of GPX route point refs reached; skipping rtept");
+        continue;
+      }
+      WaypointID waypointIndex = result->addOrFindWaypoint(waypoint);
+      if (!waypointIndex) {
+        Serial.println("WARNING: maximum number of GPX waypoints reached; skipping extra rtept");
+        continue;
+      }
+      if (!result->addRoutePoint(route, waypointIndex)) {
+        Serial.println("WARNING: maximum number of GPX route point refs reached; skipping rtept");
         continue;
       }
     } else if (tagEqualsIgnoreCase(key, "name")) {

--- a/src/vario/navigation/gpx_parser.h
+++ b/src/vario/navigation/gpx_parser.h
@@ -22,6 +22,8 @@ class GPXParser {
     _line = 1;
     _col = 1;
     _charsReadSinceYield = 0;
+    _charsReadTotal = 0;
+    _readAborted = false;
     _lastTagSelfClosing = false;
     _error = "";
   }
@@ -80,6 +82,8 @@ class GPXParser {
   uint16_t _line;
   uint16_t _col;
   uint16_t _charsReadSinceYield;
+  uint32_t _charsReadTotal;
+  bool _readAborted;
   bool _lastTagSelfClosing;
   String _error;
 };

--- a/src/vario/navigation/gpx_parser.h
+++ b/src/vario/navigation/gpx_parser.h
@@ -55,7 +55,8 @@ class GPXParser {
 
   /// @brief Read the data from a wpt or rtept tag into the provided waypoint
   /// @details Must start inside the wpt/rtept tag just after the tag name
-  bool readWaypoint(Waypoint* waypoint, const char* tag_name);
+  bool readWaypoint(Waypoint* waypoint, const char* tag_name, bool requireCoordinates,
+                    bool* foundCoordinates = nullptr);
 
   /// @brief  Read the key and value of an attribute
   /// @details Routine may start at whitespace before the attribute

--- a/src/vario/navigation/gpx_parser.h
+++ b/src/vario/navigation/gpx_parser.h
@@ -54,9 +54,11 @@ class GPXParser {
   char skipWhitespace();
 
   /// @brief Read the data from a wpt or rtept tag into the provided waypoint
-  /// @details Must start inside the wpt/rtept tag just after the tag name
+  /// @details Usually starts inside the wpt/rtept tag just after the tag name. If the caller
+  /// already consumed the end of the opening tag, set openingTagClosed to true.
   bool readWaypoint(Waypoint* waypoint, const char* tag_name, bool requireCoordinates,
-                    bool* foundCoordinates = nullptr);
+                    bool* foundCoordinates = nullptr, bool openingTagClosed = false,
+                    bool openingTagSelfClosing = false);
 
   /// @brief  Read the key and value of an attribute
   /// @details Routine may start at whitespace before the attribute


### PR DESCRIPTION
Rearchitects GPX file parsing.

Previously, we stored bare waypoints and also routepoints separately.  This created a lot of duplicate info, since most routes use waypoints that are already in the waypoint list.  This change refactors a route to be a list of indices pointing at the waypoint pool.  When loading a route, an index will be created if the waypoint (routepoint) already exists; or the (new, unique) routepoint will be added to the waypoint list, then an index created.

Also added GPX file parsing character-limit, so device doesn't hang on extremely large gpx files.   