### PR TITLE
Make SD card formatting a synchronous commissioning-only path

### DIFF
--- a/factory_interface/src/factory_interface/app.py
+++ b/factory_interface/src/factory_interface/app.py
@@ -16,6 +16,7 @@ from factory_interface.commissioning_sessions import (
     get_commissioning_session,
     list_commissioning_sessions,
     manually_rediscover_session_device,
+    submit_verification_command,
 )
 from factory_interface.commissioning_tasks import (
     cancel_flash_task,
@@ -501,6 +502,33 @@ async def cancel_setup_session(mac_address: str) -> JSONResponse:
     if session is None:
         return JSONResponse({"detail": "Commissioning session not found."}, status_code=404)
     return JSONResponse(session.snapshot())
+
+
+async def _submit_verification_command(mac_address: str, command: str) -> JSONResponse:
+    session = submit_verification_command(mac_address, command)
+    if session is None:
+        return JSONResponse({"detail": "Commissioning session not found."}, status_code=404)
+    return JSONResponse(session.snapshot())
+
+
+@app.post("/api/setup/sessions/{mac_address}/verification/start", response_class=JSONResponse)
+async def start_session_verification(mac_address: str) -> JSONResponse:
+    return await _submit_verification_command(mac_address, "run")
+
+
+@app.post("/api/setup/sessions/{mac_address}/verification/retry", response_class=JSONResponse)
+async def retry_session_verification(mac_address: str) -> JSONResponse:
+    return await _submit_verification_command(mac_address, "run")
+
+
+@app.post("/api/setup/sessions/{mac_address}/verification/stop", response_class=JSONResponse)
+async def stop_session_verification(mac_address: str) -> JSONResponse:
+    return await _submit_verification_command(mac_address, "stop")
+
+
+@app.post("/api/setup/sessions/{mac_address}/verification/format", response_class=JSONResponse)
+async def format_session_sd_card(mac_address: str) -> JSONResponse:
+    return await _submit_verification_command(mac_address, "format")
 
 
 @app.delete("/api/setup/sessions/{mac_address}", response_class=JSONResponse)

--- a/factory_interface/src/factory_interface/commissioning_sessions.py
+++ b/factory_interface/src/factory_interface/commissioning_sessions.py
@@ -48,6 +48,33 @@ RECONNECT_GRACE_SECONDS = 2.0
 RECONNECT_POLL_SECONDS = 1.0
 SELF_TEST_POLL_SECONDS = 1.0
 
+# Operator verification controls (Start / Stop / Retry / Format SD).
+VERIFICATION_RUN_COMMAND = "run"
+VERIFICATION_STOP_COMMAND = "stop"
+VERIFICATION_FORMAT_COMMAND = "format"
+VERIFICATION_COMMANDS = (
+    VERIFICATION_RUN_COMMAND,
+    VERIFICATION_STOP_COMMAND,
+    VERIFICATION_FORMAT_COMMAND,
+)
+VERIFICATION_START_PROMPT = 'Press "Start Test" to begin verification.'
+VERIFICATION_RETRY_PROMPT = 'Press "Retry Tests" to run verification again.'
+
+# How long to wait for an on-device SD card format to complete. Formatting larger cards over SDIO
+# can take a few minutes, so allow generous headroom before giving up.
+SD_FORMAT_POLL_SECONDS = 1.5
+SD_FORMAT_TIMEOUT_SECONDS = 600.0
+
+
+def verification_failed_on_sd_card(payload: dict | None) -> bool:
+    """True if the self-test result indicates the SD card test specifically failed."""
+    if not isinstance(payload, dict):
+        return False
+    results = payload.get("results")
+    if not isinstance(results, dict):
+        return False
+    return str(results.get("sd_card", "")).lower() in ("fail", "failure")
+
 
 def idle_task(details: str = "") -> dict:
     return {"status": "idle", "details": details}
@@ -72,6 +99,8 @@ class CommissioningSession:
     configuration_event_id: int | None = None
     tasks: dict[str, dict] = field(default_factory=dict)
     worker_task: asyncio.Task | None = None
+    # Operator verification commands ("run"/"stop"); lazily created on the event loop.
+    verification_queue: asyncio.Queue | None = None
 
     def __post_init__(self) -> None:
         if self.tasks:
@@ -488,6 +517,223 @@ def persist_configuration_event(session: CommissioningSession) -> int:
         return event.id or 0
 
 
+def _verification_queue(session: CommissioningSession) -> asyncio.Queue:
+    if session.verification_queue is None:
+        session.verification_queue = asyncio.Queue()
+    return session.verification_queue
+
+
+def _drain_for_stop(queue: asyncio.Queue) -> bool:
+    """Consume all queued commands, returning True if a stop was requested."""
+    stop_requested = False
+    while True:
+        try:
+            command = queue.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+        if command == VERIFICATION_STOP_COMMAND:
+            stop_requested = True
+    return stop_requested
+
+
+def submit_verification_command(
+    mac_address: str, command: str
+) -> CommissioningSession | None:
+    """Queue an operator verification command for a session.
+
+    Returns the session, or None if no session exists for the MAC address.
+    Raises ValueError for unrecognized commands.
+    """
+    if command not in VERIFICATION_COMMANDS:
+        raise ValueError(f"Unknown verification command: {command}")
+    session = get_commissioning_session(mac_address)
+    if session is None:
+        return None
+    _verification_queue(session).put_nowait(command)
+    return session
+
+
+async def _run_self_test_pass(
+    session: CommissioningSession,
+    base_url: str,
+    queue: asyncio.Queue,
+) -> str:
+    """Run a single verification pass.
+
+    Returns "success", "failure", or "stopped" (operator-requested stop).
+    """
+    self_test_task = session.tasks["interactive_self_test"]
+    self_test_task.update({"status": "running", "details": "Starting verification tests..."})
+    session.details = "Verification tests running..."
+    session.touch()
+    await asyncio.to_thread(fetch_json, f"{base_url}/interactive", method="POST")
+
+    while True:
+        if _drain_for_stop(queue):
+            return "stopped"
+
+        self_test_payload = await asyncio.to_thread(fetch_json, base_url)
+        session.self_test_result = self_test_payload
+        self_test_task["result"] = self_test_payload
+        self_test_task["details"] = json.dumps(self_test_payload, indent=2)
+        session.touch()
+
+        result = self_test_status(self_test_payload)
+        if result == "success":
+            self_test_task["status"] = "success"
+            return "success"
+
+        if result == "failure" or not self_test_payload.get("running", False):
+            self_test_task["status"] = "failure"
+            self_test_task["sd_format_available"] = verification_failed_on_sd_card(
+                self_test_payload
+            )
+            failure_prefix = (
+                "Verification tests failed."
+                if result == "failure"
+                else "Verification tests stopped without a pass/fail result."
+            )
+            try:
+                self_test_task["details"] = await retrieve_session_self_test_details(
+                    session, base_url
+                )
+            except Exception as details_exc:
+                self_test_task["details"] = (
+                    f"{failure_prefix}\n\n"
+                    f"Test details could not be retrieved: "
+                    f"{type(details_exc).__name__}: {details_exc}"
+                )
+            return "failure"
+
+        await asyncio.sleep(SELF_TEST_POLL_SECONDS)
+
+
+async def run_session_sd_format(session: CommissioningSession) -> None:
+    """Trigger an on-device SD card format and poll until it completes.
+
+    Used after the verification SD card test fails. On success, returns the step to the
+    awaiting state so the operator can retry; on failure/timeout, keeps the format offer.
+    """
+    self_test_task = session.tasks["interactive_self_test"]
+    self_test_task.update({"status": "formatting", "details": "Formatting SD card on device..."})
+    self_test_task["sd_format_available"] = False
+    session.details = "Formatting SD card on device..."
+    session.touch()
+
+    base_url = f"{device_base_url(session)}/sd-card/format"
+    try:
+        await asyncio.to_thread(fetch_json, base_url, method="POST")
+    except Exception as exc:
+        self_test_task.update(
+            {
+                "status": "failure",
+                "details": f"Could not start SD card format: {type(exc).__name__}: {exc}",
+            }
+        )
+        self_test_task["sd_format_available"] = True
+        session.details = "SD card format could not be started."
+        session.touch()
+        return
+
+    elapsed = 0.0
+    while elapsed < SD_FORMAT_TIMEOUT_SECONDS:
+        await asyncio.sleep(SD_FORMAT_POLL_SECONDS)
+        elapsed += SD_FORMAT_POLL_SECONDS
+        try:
+            status_payload = await asyncio.to_thread(fetch_json, base_url)
+        except Exception:
+            # Device may be momentarily busy formatting; keep polling.
+            continue
+
+        status = str(status_payload.get("status", "")).lower()
+        detail = str(status_payload.get("detail", "")).strip()
+        if status == "success":
+            self_test_task.update(
+                {"status": "awaiting", "details": f"SD card formatted. {VERIFICATION_RETRY_PROMPT}"}
+            )
+            self_test_task["sd_format_available"] = False
+            session.details = "SD card formatted. Awaiting retry."
+            session.touch()
+            return
+        if status == "failure":
+            self_test_task.update(
+                {"status": "failure", "details": f"SD card format failed. {detail}".strip()}
+            )
+            self_test_task["sd_format_available"] = True
+            session.details = "SD card format failed."
+            session.touch()
+            return
+
+        self_test_task["details"] = (
+            f"Formatting SD card on device... ({int(elapsed)}s elapsed)"
+        )
+        session.touch()
+
+    self_test_task.update(
+        {
+            "status": "failure",
+            "details": (
+                "SD card format did not report completion in time. It may have finished anyway "
+                '— try "Retry Tests", or "Format SD & Retry" again.'
+            ),
+        }
+    )
+    self_test_task["sd_format_available"] = True
+    session.details = "SD card format timed out."
+    session.touch()
+
+
+async def run_session_verification(session: CommissioningSession) -> None:
+    """Operator-gated verification step.
+
+    Pauses until the operator presses "Start Test", supports "Stop Test" while a
+    pass is running, "Retry Tests" after a stop/failure, and "Format SD & Retry" when
+    the SD card test specifically failed. Only returns once verification passes so the
+    rest of the commissioning session can continue.
+    """
+    queue = _verification_queue(session)
+    self_test_task = session.tasks["interactive_self_test"]
+
+    # Discard any commands queued before we reached this step.
+    _drain_for_stop(queue)
+
+    self_test_task.update({"status": "awaiting", "details": VERIFICATION_START_PROMPT})
+    self_test_task["sd_format_available"] = False
+    session.details = "Awaiting operator to start verification tests."
+    session.touch()
+
+    while True:
+        command = await queue.get()
+        if command == VERIFICATION_FORMAT_COMMAND:
+            await run_session_sd_format(session)
+            continue
+        if command != VERIFICATION_RUN_COMMAND:
+            # A stop while nothing is running is a no-op.
+            continue
+
+        outcome = await _run_self_test_pass(
+            session, f"{device_base_url(session)}/self-test", queue
+        )
+        session.touch()
+
+        if outcome == "success":
+            self_test_task["sd_format_available"] = False
+            session.details = "Verification tests passed."
+            return
+        if outcome == "stopped":
+            self_test_task.update(
+                {"status": "awaiting", "details": f"Verification stopped. {VERIFICATION_START_PROMPT}"}
+            )
+            self_test_task["sd_format_available"] = False
+            session.details = "Verification stopped by operator."
+        else:  # failure: keep the failure status/details and await a retry, format, or stop.
+            self_test_task["sd_format_available"] = verification_failed_on_sd_card(
+                session.self_test_result
+            )
+            session.details = "Verification tests failed. Retry or discard the session."
+        session.touch()
+
+
 async def run_commissioning_session(session: CommissioningSession) -> None:
     try:
         reset_task = session.tasks["reset_nonvolatile_memory"]
@@ -557,57 +803,8 @@ async def run_commissioning_session(session: CommissioningSession) -> None:
             }
         )
 
-        self_test_task = session.tasks["interactive_self_test"]
-        self_test_task.update(
-            {"status": "running", "details": "Starting verification tests..."}
-        )
-        session.touch()
+        await run_session_verification(session)
         base_url = f"{device_base_url(session)}/self-test"
-        await asyncio.to_thread(fetch_json, f"{base_url}/interactive", method="POST")
-
-        while True:
-            self_test_payload = await asyncio.to_thread(fetch_json, base_url)
-            session.self_test_result = self_test_payload
-            self_test_task["result"] = self_test_payload
-            self_test_task["details"] = json.dumps(self_test_payload, indent=2)
-            session.touch()
-
-            result = self_test_status(self_test_payload)
-            if result is not None:
-                self_test_task["status"] = result
-                if result == "failure":
-                    try:
-                        self_test_task["details"] = await retrieve_session_self_test_details(
-                            session, base_url
-                        )
-                    except Exception as details_exc:
-                        self_test_task["details"] = (
-                            "Verification tests failed.\n\n"
-                            f"Test details could not be retrieved: "
-                            f"{type(details_exc).__name__}: {details_exc}"
-                        )
-                    session.status = "failure"
-                    session.details = "Verification tests failed."
-                    return
-                break
-
-            if not self_test_payload.get("running", False):
-                self_test_task["status"] = "failure"
-                try:
-                    self_test_task["details"] = await retrieve_session_self_test_details(
-                        session, base_url
-                    )
-                except Exception as details_exc:
-                    self_test_task["details"] = (
-                        "Verification tests stopped without a pass/fail result.\n\n"
-                        f"Test details could not be retrieved: "
-                        f"{type(details_exc).__name__}: {details_exc}"
-                    )
-                session.status = "failure"
-                session.details = "Verification tests stopped without a pass/fail result."
-                return
-
-            await asyncio.sleep(SELF_TEST_POLL_SECONDS)
 
         retrieve_test_details_task = session.tasks["retrieve_test_details"]
         retrieve_test_details_task.update(

--- a/factory_interface/src/factory_interface/static/styles.css
+++ b/factory_interface/src/factory_interface/static/styles.css
@@ -225,6 +225,49 @@ button:focus-visible {
   outline: 3px solid rgb(208 139 44 / 35%);
 }
 
+.verification-controls {
+  grid-column: 2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.verification-controls:not(:has(.verification-control:not([hidden]))) {
+  display: none;
+}
+
+.verification-control {
+  min-height: 32px;
+  padding: 0 12px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.verification-control[hidden] {
+  display: none;
+}
+
+.verification-control-stop {
+  background: #b42318;
+}
+
+.verification-control-stop:hover,
+.verification-control-stop:focus-visible {
+  background: #912018;
+  outline: 3px solid rgb(180 35 24 / 30%);
+}
+
+.verification-control-format {
+  background: #b54708;
+}
+
+.verification-control-format:hover,
+.verification-control-format:focus-visible {
+  background: #93370d;
+  outline: 3px solid rgb(181 71 8 / 30%);
+}
+
 .button-link {
   display: inline-flex;
   align-items: center;

--- a/factory_interface/src/factory_interface/templates/setup_session.html
+++ b/factory_interface/src/factory_interface/templates/setup_session.html
@@ -118,6 +118,12 @@
     <div class="checklist-item checklist-item-with-details">
       <button class="task-icon task-icon-empty" id="self-test-task-icon" type="button" aria-label="Toggle verification test details" disabled></button>
       <span>Verification tests</span>
+      <span class="verification-controls" id="verification-controls">
+        <button class="verification-control verification-control-start" id="verification-start" type="button" hidden>Start Test</button>
+        <button class="verification-control verification-control-stop" id="verification-stop" type="button" hidden>Stop Test</button>
+        <button class="verification-control verification-control-retry" id="verification-retry" type="button" hidden>Retry Tests</button>
+        <button class="verification-control verification-control-format" id="verification-format" type="button" hidden>Format SD &amp; Retry</button>
+      </span>
       <div class="checklist-details verification-test-details" id="self-test-details" hidden></div>
     </div>
 
@@ -159,6 +165,14 @@
   const discardButton = document.querySelector("#discard-session");
   const flashTaskIcon = document.querySelector("#flash-task-icon");
   const flashConsole = document.querySelector("#flash-console");
+  const verificationButtons = {
+    start: document.querySelector("#verification-start"),
+    stop: document.querySelector("#verification-stop"),
+    retry: document.querySelector("#verification-retry"),
+    format: document.querySelector("#verification-format"),
+  };
+  const verificationUrl = (action) =>
+    `/api/setup/sessions/${encodeURIComponent(macAddress)}/verification/${action}`;
   const discoveryDetailsGroup = document.querySelector("#discovery-details-group");
   const discoveryManualIpForm = document.querySelector("#discovery-manual-ip-form");
   const discoveryManualIp = document.querySelector("#discovery-manual-ip");
@@ -217,7 +231,7 @@
   function setTaskIcon(icon, status) {
     icon.className = "task-icon";
     icon.disabled = status === "idle";
-    if (status === "running") {
+    if (status === "running" || status === "formatting") {
       icon.classList.add("task-icon-running");
     } else if (status === "success") {
       icon.classList.add("task-icon-success");
@@ -278,6 +292,7 @@
     setTaskIcon(control.icon, task.status);
     if (name === "interactive_self_test") {
       renderVerificationTests(control.details, task);
+      updateVerificationControls(task);
       return;
     }
     setDetails(control.details, task.details, task.status, control.detailsContainer || control.details);
@@ -389,6 +404,41 @@
   flashTaskIcon.addEventListener("click", () => {
     flashConsole.hidden = !flashConsole.hidden;
   });
+
+  function updateVerificationControls(task) {
+    const status = (task && task.status) || "idle";
+    const sdFormatAvailable = !!(task && task.sd_format_available);
+    // Start: paused awaiting operator. Stop: a pass is running. Retry: after a failure.
+    // Format SD & Retry: offered when the SD card test specifically failed. No controls while
+    // an on-device format is in progress ("formatting").
+    verificationButtons.start.hidden = status !== "awaiting";
+    verificationButtons.stop.hidden = status !== "running";
+    verificationButtons.retry.hidden = status !== "failure";
+    verificationButtons.format.hidden = !(status === "failure" && sdFormatAvailable);
+  }
+
+  async function sendVerificationCommand(action, button) {
+    button.disabled = true;
+    try {
+      await fetch(verificationUrl(action), { method: "POST" });
+      await refreshSession();
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  verificationButtons.start.addEventListener("click", () =>
+    sendVerificationCommand("start", verificationButtons.start)
+  );
+  verificationButtons.stop.addEventListener("click", () =>
+    sendVerificationCommand("stop", verificationButtons.stop)
+  );
+  verificationButtons.retry.addEventListener("click", () =>
+    sendVerificationCommand("retry", verificationButtons.retry)
+  );
+  verificationButtons.format.addEventListener("click", () =>
+    sendVerificationCommand("format", verificationButtons.format)
+  );
 
   Object.values(controls).forEach((control) => {
     control.icon.addEventListener("click", () => {

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -95,6 +95,30 @@ namespace {
     return json;
   }
 
+  const char* sdCardFormatStateName(SDCard::FormatState state) {
+    switch (state) {
+      case SDCard::FormatState::Running:
+        return "running";
+      case SDCard::FormatState::Success:
+        return "success";
+      case SDCard::FormatState::Failed:
+        return "failure";
+      case SDCard::FormatState::Idle:
+      default:
+        return "idle";
+    }
+  }
+
+  String sdCardFormatStatusJson() {
+    // format messages are fixed literals with no characters needing JSON escaping
+    String json = "{\"status\":\"";
+    json += sdCardFormatStateName(sdcard.formatState());
+    json += "\",\"detail\":\"";
+    json += sdcard.formatMessage();
+    json += "\"}";
+    return json;
+  }
+
   String latestSelfTestDetailsFileName() {
     String current_file_name = selfTest.resultsFileName();
     if (!current_file_name.isEmpty() && SD_MMC.exists(current_file_name)) {
@@ -482,6 +506,24 @@ void webserver_setup() {
 
   server.on("/self-test", HTTP_GET,
             []() { server.send(200, "application/json", selfTestSnapshotJson()); });
+
+  server.on("/sd-card/format", HTTP_POST, []() {
+    // Only allow formatting during a production self test so we never wipe an end user's card.
+    if (!selfTest.allowReformattingOfSDcard()) {
+      server.send(409, "application/json",
+                  "{\"detail\":\"SD format is only allowed during a production self test.\"}");
+      return;
+    }
+    if (!SDCard::isCardPresent()) {
+      server.send(409, "application/json", "{\"detail\":\"No SD card detected.\"}");
+      return;
+    }
+    sdcard.requestFormat();
+    server.send(200, "application/json", sdCardFormatStatusJson());
+  });
+
+  server.on("/sd-card/format", HTTP_GET,
+            []() { server.send(200, "application/json", sdCardFormatStatusJson()); });
 
   server.on("/commissioning/complete", HTTP_POST, []() {
     selfTest.confirmCommissioningComplete();

--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -603,6 +603,10 @@ SelfTest::Status SpeakerInteractiveTest::update() {
 
 void SelfTest::begin(bool markAsProductionChecked) {
   if (markAsProductionChecked) {
+    // Authorize SD card reformatting for this session's production test. Set before the
+    // settings.productionTest early-return so re-running a production test on an already-tested
+    // unit still permits formatting. Manual/home self tests use begin(false) and never set this.
+    allow_sd_reformat_ = true;
     if (settings.productionTest) {
       // do nothing, we've already checked the production test
       return;
@@ -641,6 +645,18 @@ SelfTest_PageCommissioningConfirmation selfTest_pageCommissioningConfirmation;
 bool SelfTest::update() {
   bool updateNeeded = true;  // assume we'll need to call this again
   if (status == Status::Running) {
+    // During a production test, a failed SD card test stops the remaining tests so the operator
+    // can reformat the card and retry, rather than working through the rest (including the
+    // interactive tests) first. Marking both phases complete lets the normal finalize path below
+    // tally the result as a failure.
+    if (allow_sd_reformat_ && results.sdCard == Status::Fail &&
+        (statusAutoTests != Status::Complete || statusInteractiveTests != Status::Complete)) {
+      selfTestInfo(
+          "`Test=SD_CARD`,    `Result=FAIL`, `Message=Stopping remaining tests for reformat`");
+      statusAutoTests = Status::Complete;
+      statusInteractiveTests = Status::Complete;
+    }
+
     if (statusAutoTests == Status::Running || statusAutoTests == Status::Unknown) {
       statusAutoTests = runAutoTests(false);  // false = keep file open
     } else if (statusInteractiveTests == Status::Running ||

--- a/src/vario/diagnostics/self_test/selfTest.h
+++ b/src/vario/diagnostics/self_test/selfTest.h
@@ -16,6 +16,11 @@ class SelfTest {
   void confirmCommissioningComplete();
   bool commissioningCompleteConfirmed() const;
 
+  // True when the current self test was started as a production test (begin(true)). Authorizes
+  // the device to reformat the SD card during commissioning so we never wipe an end user's card
+  // when they run a self test themselves. RAM-only and session-sticky (resets on reboot).
+  bool allowReformattingOfSDcard() const { return allow_sd_reformat_; }
+
   // results for all self tests, including both automated and interactive
   struct Results {
     Status sdCard = Status::Unknown;
@@ -47,6 +52,7 @@ class SelfTest {
   bool tallyResults();
   void clearResults();
   bool commissioning_complete_confirmed = false;
+  bool allow_sd_reformat_ = false;
 
   // Individual automated test functions
   static Status testBaro();

--- a/src/vario/navigation/gpx.cpp
+++ b/src/vario/navigation/gpx.cpp
@@ -34,38 +34,58 @@ void Navigator::init() {
 }
 
 void Navigator::clear() {
-  totalPoints = 0;
   totalWaypoints = 0;
+  totalRoutePointRefs = 0;
   totalRoutes = 0;
 }
 
 bool Navigator::addWaypoint(const Waypoint& waypoint) {
-  if (totalPoints >= maxNavPoints || totalWaypoints >= maxNavPoints) {
+  if (totalWaypoints >= maxNavPoints) {
     return false;
   }
-  points[++totalPoints] = waypoint;
-  waypointPointIndexes[++totalWaypoints] = totalPoints;
+  waypoints[++totalWaypoints] = waypoint;
   return true;
 }
 
-bool Navigator::addRoutePoint(Route* route, const Waypoint& waypoint) {
-  if (totalPoints >= maxNavPoints) {
+WaypointID Navigator::findWaypointByName(const String& name) const {
+  if (name == "") {
+    return WaypointID::None;
+  }
+  for (uint8_t i = 1; i <= totalWaypoints; i++) {
+    if (waypoints[i].name == name) {
+      return WaypointID(i);
+    }
+  }
+  return WaypointID::None;
+}
+
+WaypointID Navigator::addOrFindWaypoint(const Waypoint& waypoint) {
+  WaypointID existingIndex = findWaypointByName(waypoint.name);
+  if (existingIndex) {
+    return existingIndex;
+  }
+  if (!addWaypoint(waypoint)) {
+    return WaypointID::None;
+  }
+  return WaypointID(totalWaypoints);
+}
+
+bool Navigator::addRoutePoint(Route* route, WaypointID waypointIndex) {
+  if (!waypointIndex || totalRoutePointRefs >= maxRoutePointRefs) {
     return false;
   }
-  points[++totalPoints] = waypoint;
   if (route->totalPoints == 0) {
-    route->firstPointIndex = totalPoints;
+    route->firstRoutePointIndex = totalRoutePointRefs + 1;
   }
+  routeWaypointIndexes[++totalRoutePointRefs] = waypointIndex;
   route->totalPoints++;
   return true;
 }
 
-const Waypoint& Navigator::waypoint(WaypointID pointIndex) const {
-  return points[waypointPointIndexes[pointIndex]];
-}
+const Waypoint& Navigator::waypoint(WaypointID pointIndex) const { return waypoints[pointIndex]; }
 
 const Waypoint& Navigator::routePoint(RouteID routeIndex, RouteIndex pointIndex) const {
-  return points[routes[routeIndex].firstPointIndex + pointIndex - 1];
+  return waypoint(routeWaypointIndexes[routes[routeIndex].firstRoutePointIndex + pointIndex - 1]);
 }
 
 // update nav data every second
@@ -282,9 +302,6 @@ bool gpx_readFile(fs::FS& fs, String fileName) {
   if (success) {
     Serial.println("gpx_readFile was successful:");
     Serial.print("  ");
-    Serial.print(parse_result.totalPoints);
-    Serial.println(" total points");
-    Serial.print("  ");
     Serial.print(parse_result.totalWaypoints);
     Serial.println(" waypoints");
     for (uint8_t wp = 1; wp <= parse_result.totalWaypoints; wp++) {
@@ -321,8 +338,6 @@ bool gpx_readFile(fs::FS& fs, String fileName) {
     }
     navigator = parse_result;
     Serial.print("Navigator loaded ");
-    Serial.print(navigator.totalPoints);
-    Serial.print(" total points, ");
     Serial.print(navigator.totalWaypoints);
     Serial.print(" waypoints and ");
     Serial.print(navigator.totalRoutes);
@@ -345,29 +360,29 @@ void Navigator::loadRoutes() {
   totalRoutes = 4;
 
   routes[1].name = "R: TheCircuit";
-  addRoutePoint(&routes[1], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[1], waypoint(WaypointID(7)));
-  addRoutePoint(&routes[1], waypoint(WaypointID(8)));
-  addRoutePoint(&routes[1], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[1], waypoint(WaypointID(2)));
+  addRoutePoint(&routes[1], WaypointID(1));
+  addRoutePoint(&routes[1], WaypointID(7));
+  addRoutePoint(&routes[1], WaypointID(8));
+  addRoutePoint(&routes[1], WaypointID(1));
+  addRoutePoint(&routes[1], WaypointID(2));
 
   routes[2].name = "R: Scenic";
-  addRoutePoint(&routes[2], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[2], waypoint(WaypointID(3)));
-  addRoutePoint(&routes[2], waypoint(WaypointID(4)));
-  addRoutePoint(&routes[2], waypoint(WaypointID(5)));
-  addRoutePoint(&routes[2], waypoint(WaypointID(2)));
+  addRoutePoint(&routes[2], WaypointID(1));
+  addRoutePoint(&routes[2], WaypointID(3));
+  addRoutePoint(&routes[2], WaypointID(4));
+  addRoutePoint(&routes[2], WaypointID(5));
+  addRoutePoint(&routes[2], WaypointID(2));
 
   routes[3].name = "R: Downhill";
-  addRoutePoint(&routes[3], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[3], waypoint(WaypointID(5)));
-  addRoutePoint(&routes[3], waypoint(WaypointID(2)));
+  addRoutePoint(&routes[3], WaypointID(1));
+  addRoutePoint(&routes[3], WaypointID(5));
+  addRoutePoint(&routes[3], WaypointID(2));
 
   routes[4].name = "R: MiniTri";
-  addRoutePoint(&routes[4], waypoint(WaypointID(1)));
-  addRoutePoint(&routes[4], waypoint(WaypointID(4)));
-  addRoutePoint(&routes[4], waypoint(WaypointID(5)));
-  addRoutePoint(&routes[4], waypoint(WaypointID(1)));
+  addRoutePoint(&routes[4], WaypointID(1));
+  addRoutePoint(&routes[4], WaypointID(4));
+  addRoutePoint(&routes[4], WaypointID(5));
+  addRoutePoint(&routes[4], WaypointID(1));
 }
 
 void Navigator::loadWaypoints() {

--- a/src/vario/navigation/gpx.h
+++ b/src/vario/navigation/gpx.h
@@ -9,8 +9,9 @@
 
 // Waypoint definition and memory allocation
 #define waypointRadius 150  // meters radius to count as "reaching/crossing" a waypoint
-#define maxRoutes 5
-#define maxNavPoints 75
+#define maxRoutes 10
+#define maxNavPoints 100
+#define maxRoutePointRefs 75
 
 struct Waypoint {
   String name;
@@ -22,7 +23,7 @@ struct Waypoint {
 // Route definition and memory allocation
 struct Route {
   String name;
-  uint8_t firstPointIndex = 0;
+  uint8_t firstRoutePointIndex = 0;
   uint8_t totalPoints = 0;
 };
 
@@ -41,14 +42,16 @@ class Navigator {
 
   void clear();
   bool addWaypoint(const Waypoint& waypoint);
-  bool addRoutePoint(Route* route, const Waypoint& waypoint);
+  WaypointID addOrFindWaypoint(const Waypoint& waypoint);
+  WaypointID findWaypointByName(const String& name) const;
+  bool addRoutePoint(Route* route, WaypointID waypointIndex);
   const Waypoint& waypoint(WaypointID pointIndex) const;
   const Waypoint& routePoint(RouteID routeIndex, RouteIndex pointIndex) const;
 
-  Waypoint points[maxNavPoints + 1];
-  uint8_t totalPoints = 0;
-  uint8_t waypointPointIndexes[maxNavPoints + 1];
+  Waypoint waypoints[maxNavPoints + 1];
   uint8_t totalWaypoints = 0;
+  WaypointID routeWaypointIndexes[maxRoutePointRefs + 1];
+  uint8_t totalRoutePointRefs = 0;
   Route routes[maxRoutes + 1];
   uint8_t totalRoutes = 0;
 

--- a/src/vario/navigation/gpx_parser.cpp
+++ b/src/vario/navigation/gpx_parser.cpp
@@ -4,6 +4,9 @@
 
 // The maximum length of a value in a GPX (tag name, latitude, longitude, elevation, etc)
 #define MAX_VALUE_LENGTH (64)
+// Safety fuse: the waypoint/route pools are small, so a GPX this large is almost certainly
+// malformed or far beyond what Leaf can use. Abort instead of delaying boot for a long scan.
+#define MAX_GPX_PARSE_CHARS (262144UL)
 
 inline bool isWhitespace(char c) { return c == ' ' || c == '\t' || c == '\r' || c == '\n'; }
 
@@ -56,13 +59,16 @@ bool GPXParser::parse(Navigator* result) {
       return false;
     }
     if (tagEqualsIgnoreCase(value_buffer, "wpt")) {
-      if (name_result == ReadTagNameResult::TagClosed) {
-        _error = "missing lat and lon attributes for wpt tag";
-        return false;
-      }
       Waypoint waypoint;
-      if (readWaypoint(&waypoint, "wpt")) {
-        if (!result->addWaypoint(waypoint)) {
+      bool foundCoordinates = false;
+      if (readWaypoint(&waypoint, "wpt", false, &foundCoordinates,
+                       name_result == ReadTagNameResult::TagClosed, _lastTagSelfClosing)) {
+        if (!foundCoordinates) {
+          Serial.print("WARNING: GPX waypoint missing coordinates; skipping wpt: ");
+          Serial.println(waypoint.name);
+          continue;
+        }
+        if (!result->addOrFindWaypoint(waypoint)) {
           Serial.println("WARNING: maximum number of GPX points reached; skipping extra wpt");
           continue;
         }
@@ -95,14 +101,23 @@ bool GPXParser::parse(Navigator* result) {
     }
   }
 
-  return true;
+  return !_readAborted;
 }
 
 char GPXParser::getNextChar() {
+  if (_readAborted) {
+    return 0;
+  }
+  if (_charsReadTotal >= MAX_GPX_PARSE_CHARS) {
+    _error = "GPX parse limit exceeded";
+    _readAborted = true;
+    return 0;
+  }
   if (!_file_reader->contentRemaining()) {
     return 0;
   }
   char c = _file_reader->nextChar();
+  _charsReadTotal++;
   if ((++_charsReadSinceYield & 0xFF) == 0) {
     yield();
   }
@@ -198,51 +213,60 @@ char GPXParser::skipWhitespace() {
   return c;
 }
 
-bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name) {
+bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name, bool requireCoordinates,
+                             bool* foundCoordinates, bool openingTagClosed,
+                             bool openingTagSelfClosing) {
   char key[MAX_VALUE_LENGTH + 1];
   char value[MAX_VALUE_LENGTH + 1];
   waypoint->name = "";
+  waypoint->lat = 0;
+  waypoint->lon = 0;
   waypoint->ele = 0;
 
   // Read attributes of opening tag (until tag is closed)
   bool found_lat = false;
   bool found_lon = false;
-  bool self_closing = false;
-  while (true) {
-    char c = skipWhitespace();
-    if (c == 0) {
-      _error = "reached end of file while looking for attributes in waypoint tag";
-      return false;
-    } else if (c == '>') {
-      break;
-    } else if (c == '/') {
-      c = skipWhitespace();
-      if (c != '>') {
-        _error = "unexpected character after self-closing marker in waypoint tag";
+  bool self_closing = openingTagSelfClosing;
+  if (!openingTagClosed) {
+    while (true) {
+      char c = skipWhitespace();
+      if (c == 0) {
+        _error = "reached end of file while looking for attributes in waypoint tag";
+        return false;
+      } else if (c == '>') {
+        break;
+      } else if (c == '/') {
+        c = skipWhitespace();
+        if (c != '>') {
+          _error = "unexpected character after self-closing marker in waypoint tag";
+          return false;
+        }
+        self_closing = true;
+        break;
+      }
+      key[0] = c;
+      bool attribute_success = readAttribute(key + 1, value);
+      if (!attribute_success) {
+        _error += " while reading attribute in waypoint tag";
         return false;
       }
-      self_closing = true;
-      break;
-    }
-    key[0] = c;
-    bool attribute_success = readAttribute(key + 1, value);
-    if (!attribute_success) {
-      _error += " while reading attribute in waypoint tag";
-      return false;
-    }
-    if (equalsIgnoreCase(key, "lat")) {
-      waypoint->lat = atof(value);
-      found_lat = true;
-    } else if (equalsIgnoreCase(key, "lon")) {
-      waypoint->lon = atof(value);
-      found_lon = true;
+      if (equalsIgnoreCase(key, "lat")) {
+        waypoint->lat = atof(value);
+        found_lat = true;
+      } else if (equalsIgnoreCase(key, "lon")) {
+        waypoint->lon = atof(value);
+        found_lon = true;
+      }
     }
   }
-  if (!found_lat) {
+  if (foundCoordinates) {
+    *foundCoordinates = found_lat && found_lon;
+  }
+  if (requireCoordinates && !found_lat) {
     _error = "couldn't find lat attribute in waypoint tag";
     return false;
   }
-  if (!found_lon) {
+  if (requireCoordinates && !found_lon) {
     _error = "couldn't find lon attribute in waypoint tag";
     return false;
   }
@@ -422,7 +446,7 @@ bool GPXParser::readFullTagName(char* key) {
 }
 
 bool GPXParser::readRoute(Navigator* result, Route* route, bool storePoints) {
-  route->firstPointIndex = 0;
+  route->firstRoutePointIndex = 0;
   route->totalPoints = 0;
 
   char key[MAX_VALUE_LENGTH + 1];
@@ -456,15 +480,34 @@ bool GPXParser::readRoute(Navigator* result, Route* route, bool storePoints) {
     } else if (tagEqualsIgnoreCase(key, "rtept")) {
       // This is an opening route point tag
       Waypoint waypoint;
-      if (!readWaypoint(&waypoint, "rtept")) {
+      bool foundCoordinates = false;
+      if (!readWaypoint(&waypoint, "rtept", false, &foundCoordinates,
+                        name_outcome == ReadTagNameResult::TagClosed, _lastTagSelfClosing)) {
         _error = " while reading rtept";
         return false;
       }
       if (!storePoints) {
         continue;
       }
-      if (!result->addRoutePoint(route, waypoint)) {
-        Serial.println("WARNING: maximum number of GPX points reached; skipping extra rtept");
+      if (result->totalRoutePointRefs >= maxRoutePointRefs) {
+        Serial.println("WARNING: maximum number of GPX route point refs reached; skipping rtept");
+        continue;
+      }
+      WaypointID waypointIndex = result->findWaypointByName(waypoint.name);
+      if (!waypointIndex && !foundCoordinates) {
+        Serial.print("WARNING: GPX route point without coordinates did not match waypoint: ");
+        Serial.println(waypoint.name);
+        continue;
+      }
+      if (!waypointIndex) {
+        waypointIndex = result->addOrFindWaypoint(waypoint);
+      }
+      if (!waypointIndex) {
+        Serial.println("WARNING: maximum number of GPX waypoints reached; skipping extra rtept");
+        continue;
+      }
+      if (!result->addRoutePoint(route, waypointIndex)) {
+        Serial.println("WARNING: maximum number of GPX route point refs reached; skipping rtept");
         continue;
       }
     } else if (tagEqualsIgnoreCase(key, "name")) {

--- a/src/vario/navigation/gpx_parser.h
+++ b/src/vario/navigation/gpx_parser.h
@@ -22,6 +22,8 @@ class GPXParser {
     _line = 1;
     _col = 1;
     _charsReadSinceYield = 0;
+    _charsReadTotal = 0;
+    _readAborted = false;
     _lastTagSelfClosing = false;
     _error = "";
   }
@@ -54,8 +56,11 @@ class GPXParser {
   char skipWhitespace();
 
   /// @brief Read the data from a wpt or rtept tag into the provided waypoint
-  /// @details Must start inside the wpt/rtept tag just after the tag name
-  bool readWaypoint(Waypoint* waypoint, const char* tag_name);
+  /// @details Usually starts inside the wpt/rtept tag just after the tag name. If the caller
+  /// already consumed the end of the opening tag, set openingTagClosed to true.
+  bool readWaypoint(Waypoint* waypoint, const char* tag_name, bool requireCoordinates,
+                    bool* foundCoordinates = nullptr, bool openingTagClosed = false,
+                    bool openingTagSelfClosing = false);
 
   /// @brief  Read the key and value of an attribute
   /// @details Routine may start at whitespace before the attribute
@@ -77,6 +82,8 @@ class GPXParser {
   uint16_t _line;
   uint16_t _col;
   uint16_t _charsReadSinceYield;
+  uint32_t _charsReadTotal;
+  bool _readAborted;
   bool _lastTagSelfClosing;
   String _error;
 };

--- a/src/vario/storage/sd_card.cpp
+++ b/src/vario/storage/sd_card.cpp
@@ -46,6 +46,9 @@ void SDCard::init(void) {
 }
 
 void SDCard::update() {
+  // Don't touch the SD bus from the main loop while a background format is in progress.
+  if (format_state_.load() == FormatState::Running) return;
+
   bool cardPresentNow = isCardPresent();
   // if we have a card when we didn't before...
   if (cardPresentNow && !mounted_) {
@@ -133,4 +136,51 @@ bool SDCard::mount() {
   }
 
   return success;
+}
+
+void SDCard::requestFormat() {
+  // Only start a format if one isn't already running. compare_exchange avoids a TOCTOU race where
+  // two near-simultaneous requests both spawn a task and both call SD_MMC.end().
+  FormatState expected = format_state_.load();
+  do {
+    if (expected == FormatState::Running) return;  // already formatting
+  } while (!format_state_.compare_exchange_weak(expected, FormatState::Running));
+
+  format_message_.store("SD card format in progress...");
+
+  if (xTaskCreate(formatTaskEntry, "SDFormat", 8192, this, 1, &format_task_) != pdPASS) {
+    format_task_ = nullptr;
+    format_state_.store(FormatState::Failed);
+    format_message_.store("Could not start the SD card format task.");
+  }
+}
+
+void SDCard::formatTaskEntry(void* arg) {
+  SDCard* self = static_cast<SDCard*>(arg);
+  self->runFormat();
+  self->format_task_ = nullptr;
+  vTaskDelete(nullptr);
+}
+
+void SDCard::runFormat() {
+  Serial.println("SDcard: starting format");
+  SD_MMC.end();
+  mounted_ = false;
+
+  // format_if_mount_failed = true: if the card can't be mounted (corrupt/unformatted), create a
+  // partition table and a fresh FAT filesystem, then mount it.
+  const bool ok = SD_MMC.begin("/sdcard", false, /*format_if_mount_failed=*/true);
+  if (ok) {
+    mounted_ = true;
+    // NOTE: intentionally do NOT call setupMassStorage() here. It re-runs USB.begin(), which is
+    // unsafe to call from this background task and hangs. USB mass storage is not needed during
+    // commissioning; the card just needs to be mounted so the self test can log to it.
+    Serial.println("SDcard: format success");
+    format_message_.store("SD card formatted successfully.");
+    format_state_.store(FormatState::Success);
+  } else {
+    Serial.println("SDcard: format failed");
+    format_message_.store("SD card format failed.");
+    format_state_.store(FormatState::Failed);
+  }
 }

--- a/src/vario/storage/sd_card.cpp
+++ b/src/vario/storage/sd_card.cpp
@@ -46,9 +46,6 @@ void SDCard::init(void) {
 }
 
 void SDCard::update() {
-  // Don't touch the SD bus from the main loop while a background format is in progress.
-  if (format_state_.load() == FormatState::Running) return;
-
   bool cardPresentNow = isCardPresent();
   // if we have a card when we didn't before...
   if (cardPresentNow && !mounted_) {
@@ -139,27 +136,15 @@ bool SDCard::mount() {
 }
 
 void SDCard::requestFormat() {
-  // Only start a format if one isn't already running. compare_exchange avoids a TOCTOU race where
-  // two near-simultaneous requests both spawn a task and both call SD_MMC.end().
+  // Formatting is a rare factory recovery path. Run it synchronously so the normal SD update and
+  // mass-storage paths do not need special "format in progress" behavior.
   FormatState expected = format_state_.load();
   do {
     if (expected == FormatState::Running) return;  // already formatting
   } while (!format_state_.compare_exchange_weak(expected, FormatState::Running));
 
   format_message_.store("SD card format in progress...");
-
-  if (xTaskCreate(formatTaskEntry, "SDFormat", 8192, this, 1, &format_task_) != pdPASS) {
-    format_task_ = nullptr;
-    format_state_.store(FormatState::Failed);
-    format_message_.store("Could not start the SD card format task.");
-  }
-}
-
-void SDCard::formatTaskEntry(void* arg) {
-  SDCard* self = static_cast<SDCard*>(arg);
-  self->runFormat();
-  self->format_task_ = nullptr;
-  vTaskDelete(nullptr);
+  runFormat();
 }
 
 void SDCard::runFormat() {

--- a/src/vario/storage/sd_card.h
+++ b/src/vario/storage/sd_card.h
@@ -1,10 +1,17 @@
 #pragma once
 
+#include <atomic>
+
 #include "FirmwareMSC.h"
 #include "USBMSC.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 class SDCard {
  public:
+  // Asynchronous SD card (re)format state, driven by requestFormat() and a background task.
+  enum class FormatState : uint8_t { Idle, Running, Success, Failed };
+
   void init();
   void update();
 
@@ -14,10 +21,27 @@ class SDCard {
   bool setupMassStorage();
   static bool isCardPresent();
 
+  // Request an asynchronous reformat of the SD card. Spawns a background FreeRTOS task that
+  // reformats the card if it cannot be mounted (the corrupt/unformatted case). No-op if a format
+  // is already running. Poll formatState()/formatMessage() for progress. Callers are responsible
+  // for any authorization gating (see SelfTest::allowReformattingOfSDcard()).
+  void requestFormat();
+  FormatState formatState() const { return format_state_.load(); }
+  const char* formatMessage() const { return format_message_.load(); }
+
  private:
+  void runFormat();
+  static void formatTaskEntry(void* arg);
+
   // Whether the SD card is currently mounted (used to compare against the SD_DETECT
   // pin so we can tell if a card has been inserted or removed)
   bool mounted_ = false;
+
+  // Cross-task format state. Only a status byte and a pointer to a string literal are shared with
+  // the main loop, so plain atomics are sufficient (no String, which would not be safe to share).
+  std::atomic<FormatState> format_state_{FormatState::Idle};
+  std::atomic<const char*> format_message_{""};
+  TaskHandle_t format_task_ = nullptr;
 
   FirmwareMSC firmwareMSC_;
   USBMSC msc_;

--- a/src/vario/storage/sd_card.h
+++ b/src/vario/storage/sd_card.h
@@ -4,12 +4,10 @@
 
 #include "FirmwareMSC.h"
 #include "USBMSC.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 
 class SDCard {
  public:
-  // Asynchronous SD card (re)format state, driven by requestFormat() and a background task.
+  // One-off SD card (re)format state, driven by requestFormat().
   enum class FormatState : uint8_t { Idle, Running, Success, Failed };
 
   void init();
@@ -21,27 +19,23 @@ class SDCard {
   bool setupMassStorage();
   static bool isCardPresent();
 
-  // Request an asynchronous reformat of the SD card. Spawns a background FreeRTOS task that
-  // reformats the card if it cannot be mounted (the corrupt/unformatted case). No-op if a format
-  // is already running. Poll formatState()/formatMessage() for progress. Callers are responsible
-  // for any authorization gating (see SelfTest::allowReformattingOfSDcard()).
+  // Request a reformat of the SD card. This runs synchronously and is only intended for the rare
+  // corrupt/unformatted commissioning case. Callers are responsible for any authorization gating
+  // (see SelfTest::allowReformattingOfSDcard()).
   void requestFormat();
   FormatState formatState() const { return format_state_.load(); }
   const char* formatMessage() const { return format_message_.load(); }
 
  private:
   void runFormat();
-  static void formatTaskEntry(void* arg);
 
   // Whether the SD card is currently mounted (used to compare against the SD_DETECT
   // pin so we can tell if a card has been inserted or removed)
   bool mounted_ = false;
 
-  // Cross-task format state. Only a status byte and a pointer to a string literal are shared with
-  // the main loop, so plain atomics are sufficient (no String, which would not be safe to share).
+  // Format status exposed to the webserver as a simple polling-friendly state/message pair.
   std::atomic<FormatState> format_state_{FormatState::Idle};
   std::atomic<const char*> format_message_{""};
-  TaskHandle_t format_task_ = nullptr;
 
   FirmwareMSC firmwareMSC_;
   USBMSC msc_;


### PR DESCRIPTION
- Remove the SD format-in-progress guard from SDCard::update() so normal SD card polling and mass-storage behavior are unaffected by the rare factory format flow
- Stop spawning a background FreeRTOS task for SD card formatting
- Run requestFormat() synchronously and directly call runFormat()
- Remove the now-unused format task entry point, task handle, and FreeRTOS includes
- Update comments to describe formatting as a rare commissioning recovery path rather than an asynchronous background operation

This keeps normal mass-storage behavior unchanged while isolating formatting to the explicit factory/commissioning request path.

(this was to address bug of not being able to access the SDcard mass storage during normal operation)