### PR TITLE
IMU Self Test Fixes

### DIFF
--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -180,7 +180,7 @@ SelfTest::Status SelfTest::testBaro() {
 uint16_t imuTestCounter = 0;
 SelfTest::Status SelfTest::testIMU() {
   Status result = Status::Running;
-  if (!imu.accelValid() || !baro.climbRateFilteredValid()) {
+  if (!imu.accelValid()) {
     if (imuTestCounter++ >= 1000) {
       selfTestInfo(
           "`Test=IMU`,        `Result=FAIL`, `Message=IMU timeout waiting for valid accel and "

--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -43,6 +43,7 @@ SelfTest_PageGPSFix selfTest_pageGPSFix{&gpsFixRemainingSeconds, &gpsFixTestCanc
 bool waitForVarioStartButton = false;
 bool varioStartPromptComplete = false;
 SelfTest_PageVarioReady selfTest_pageVarioReady;
+SelfTest_PageRunning selfTest_pageRunning;
 
 bool useSDFile() {
   if (self_test_file) {
@@ -620,6 +621,8 @@ void SelfTest::begin(bool markAsProductionChecked) {
     selfTest.clearResults();  // clear any previous results
     speaker.playSound(fx::confirm);
     selfTest.status = SelfTest::Status::Running;
+    selfTest_pageRunning.show();
+    display.update();
   }
 }
 
@@ -661,6 +664,7 @@ bool SelfTest::update() {
         speaker.playSound(fx::fatalerror);
       }
       closeTestFile();
+      selfTest_pageRunning.close();
       if (selfTest.results.allTests == Status::Pass) {
         selfTest_pageCommissioningConfirmation.show();
       } else {

--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -220,6 +220,7 @@ SelfTest::Status SelfTest::testAmbient() {
     } else {
       selfTestInfo("`Test=AMBIENT`,    `Result=FAIL`, `Temp=%g`, `Message=Out of range`",
                    temperature);
+      result = Status::Fail;
     }
   }
   return result;

--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -181,11 +181,11 @@ SelfTest::Status SelfTest::testBaro() {
 uint16_t imuTestCounter = 0;
 SelfTest::Status SelfTest::testIMU() {
   Status result = Status::Running;
-  if (!imu.accelValid()) {
+  if (!imu.accelValid() || !imu.velocityValid()) {
     if (imuTestCounter++ >= 1000) {
       selfTestInfo(
           "`Test=IMU`,        `Result=FAIL`, `Message=IMU timeout waiting for valid accel and "
-          "climb rate`");
+          "gravity`");
       result = Status::Fail;
     }
   } else {

--- a/src/vario/diagnostics/self_test/selfTest_displayScreens.cpp
+++ b/src/vario/diagnostics/self_test/selfTest_displayScreens.cpp
@@ -9,6 +9,22 @@
 #include "ui/display/pages.h"
 
 //////////////////////////////////////////////
+// Running Self-Test Page
+void SelfTest_PageRunning::show() { push_page(this); }
+
+void SelfTest_PageRunning::draw_extra() {
+  u8g2.setFont(leaf_6x12);
+  u8g2.setCursor(9, 65);
+  u8g2.print("Running Test...");
+}
+
+void SelfTest_PageRunning::close() {
+  if (get_modal_page() == this) {
+    pop_page();
+  }
+}
+
+//////////////////////////////////////////////
 // Button Self-Test Page
 void SelfTest_PageButtons::show() { push_page(this); }
 

--- a/src/vario/diagnostics/self_test/selfTest_displayScreens.h
+++ b/src/vario/diagnostics/self_test/selfTest_displayScreens.h
@@ -2,6 +2,20 @@
 
 #include "ui/display/menu_page.h"
 
+// Running Self-Test Page
+class SelfTest_PageRunning : public SimpleSettingsMenuPage {
+ public:
+  const char* get_title() const override { return "Self Test"; }
+
+  bool button_event(Button button, ButtonEvent state, uint8_t count) override {
+    // The self-test runner owns flow control while tests are running.
+    return false;
+  }
+  void show();
+  void draw_extra() override;
+  void close();
+};
+
 // Buttons Self-Test Page
 class SelfTest_PageButtons : public SimpleSettingsMenuPage {
  public:


### PR DESCRIPTION
* Remove baro dependency inside IMU test
* Add valid velocity into IMU test (ensures gravity estimate initializes properly, and not just getting valid accel values out of IMU)
* Increase IMU test timeout to allow for gravity estimate to stabilize
* Add additional logging values in IMU test
* Add general "Self Test Running" display page underneath all the other individual test update pages (otherwise screen sometimes jumps back to showing Vario/Menu pages between various self tests)