### PR TITLE
Adjust timeout of IMU test

### DIFF
--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -24,6 +24,7 @@ SpeakerInteractiveTest speakerTest;
 
 constexpr size_t BUFFER_SIZE = 512;
 constexpr uint32_t GPS_SERIAL_TEST_TIMEOUT_MS = 5000;
+constexpr uint32_t IMU_TEST_TIMEOUT_MS = 20000;
 constexpr uint32_t GPS_FIX_TEST_TIMEOUT_MS = 30UL * 60UL * 1000UL;
 File self_test_file;
 String self_test_file_name = "";
@@ -178,15 +179,28 @@ SelfTest::Status SelfTest::testBaro() {
 }
 /////////////////////////////////////////////
 // IMU TEST
-uint16_t imuTestCounter = 0;
+bool imuTestInitialized = false;
+uint32_t imuTestStartMillis = 0;
 SelfTest::Status SelfTest::testIMU() {
   Status result = Status::Running;
+  if (!imuTestInitialized) {
+    imuTestInitialized = true;
+    imuTestStartMillis = millis();
+  }
+
   if (!imu.accelValid() || !imu.velocityValid()) {
-    if (imuTestCounter++ >= 1000) {
+    uint32_t elapsedMillis = millis() - imuTestStartMillis;
+    if (elapsedMillis >= IMU_TEST_TIMEOUT_MS) {
       selfTestInfo(
           "`Test=IMU`,        `Result=FAIL`, `Message=IMU timeout waiting for valid accel and "
-          "gravity`");
+          "gravity`, `Elapsed_ms=%u`, `AccelValid=%d`, `GravityReady=%d`, "
+          "`GravityRemaining=%u`, `Gravity=%g`, `AwzValid=%d`, `Awz=%g`, "
+          "`GravityResets=%u`, `LastRejectedGravity=%g`",
+          elapsedMillis, imu.accelValid(), imu.velocityValid(), imu.gravityInitSamplesRemaining(),
+          imu.gravityEstimate(), imu.worldVerticalAccelValid(), imu.lastWorldVerticalAccel(),
+          imu.gravityInitResetCount(), imu.lastRejectedGravityEstimate());
       result = Status::Fail;
+      imuTestInitialized = false;
     }
   } else {
     float accelTotal = imu.getAccel();
@@ -199,6 +213,7 @@ SelfTest::Status SelfTest::testIMU() {
                    accelTotal);
       result = Status::Fail;
     }
+    imuTestInitialized = false;
   }
   return result;
 }
@@ -763,7 +778,7 @@ void SelfTest::clearResults() {
   selfTest.statusAutoTests = Status::Unknown;
   selfTest.statusInteractiveTests = Status::Unknown;
   ambientTestCounter = 0;
-  imuTestCounter = 0;
+  imuTestInitialized = false;
 
   // reset interactive tests
   buttonsTest.status = Status::Unknown;

--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -150,6 +150,8 @@ void IMU::processMotion(const MotionUpdate& m) {
         m.ay, m.az, qw, qx, qy, qz, awx, awy, awz);
     fatalError("IMU awz was invalid");
   }
+  lastWorldVerticalAccel_ = awz;
+  validLastWorldVerticalAccel_ = true;
 
 #ifdef SHOW_WORLD_ACCEL
   if (needComma) {
@@ -182,9 +184,24 @@ void IMU::processMotion(const MotionUpdate& m) {
     if (--gravityInitCount_ == 0) {
       gravity_ /= GRAVITY_INIT_SAMPLES;
       if (!plausibleGravity(gravity_)) {
+        lastRejectedGravity_ = gravity_;
+        gravityInitResetCount_++;
+        char msg[160];
+        snprintf(msg, sizeof(msg),
+                 "IMU gravity init rejected: gravity=%g, awz=%g, accelTot=%g, resets=%u", gravity_,
+                 awz, accelTot_, static_cast<unsigned>(gravityInitResetCount_));
+        Serial.println(msg);
+        if (bus_) bus_->receive(CommentMessage(msg));
         gravity_ = 0;
         gravityInitCount_ = GRAVITY_INIT_SAMPLES;
         validAccelVert_ = false;
+      } else {
+        char msg[160];
+        snprintf(msg, sizeof(msg),
+                 "IMU gravity init complete: gravity=%g, awz=%g, accelTot=%g, resets=%u", gravity_,
+                 awz, accelTot_, static_cast<unsigned>(gravityInitResetCount_));
+        Serial.println(msg);
+        if (bus_) bus_->receive(CommentMessage(msg));
       }
     }
   }
@@ -273,3 +290,15 @@ float IMU::getVelocity() {
   }
   return (float)kalmanvert_.getVelocity();
 }
+
+uint16_t IMU::gravityInitSamplesRemaining() const { return gravityInitCount_; }
+
+float IMU::gravityEstimate() const { return (float)gravity_; }
+
+float IMU::lastWorldVerticalAccel() const { return (float)lastWorldVerticalAccel_; }
+
+bool IMU::worldVerticalAccelValid() const { return validLastWorldVerticalAccel_; }
+
+uint16_t IMU::gravityInitResetCount() const { return gravityInitResetCount_; }
+
+float IMU::lastRejectedGravityEstimate() const { return (float)lastRejectedGravity_; }

--- a/src/vario/instruments/imu.h
+++ b/src/vario/instruments/imu.h
@@ -30,6 +30,13 @@ class IMU : public MessageSink<IMU, MotionUpdate>, public IMessageSource {
   bool velocityValid();
   float getVelocity();
 
+  uint16_t gravityInitSamplesRemaining() const;
+  float gravityEstimate() const;
+  float lastWorldVerticalAccel() const;
+  bool worldVerticalAccelValid() const;
+  uint16_t gravityInitResetCount() const;
+  float lastRejectedGravityEstimate() const;
+
  private:
   void processMotion(const MotionUpdate& m);
 
@@ -48,6 +55,11 @@ class IMU : public MessageSink<IMU, MotionUpdate>, public IMessageSource {
 
   // Best estimate for strength of gravity
   double gravity_ = 1.0;
+
+  double lastWorldVerticalAccel_ = 0.0;
+  bool validLastWorldVerticalAccel_ = false;
+  double lastRejectedGravity_ = 0.0;
+  uint16_t gravityInitResetCount_ = 0;
 
   // Number of samples remaining to collect to initialize estimate of gravity
   uint16_t gravityInitCount_;


### PR DESCRIPTION
increase IMU timeout during self test to allow for both valid accel values as well as a proper gravity estimate (which takes several seconds)