### PR TITLE
Fix USB mass storage enumeration when plugged in from off state

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -78,10 +78,12 @@ extends = env:_base
 build_unflags = -D ARDUINO_USB_MODE
 build_flags = 
 	${env:_base.build_flags}
-	-D ARDUINO_USB_MODE=0
-    -D ARDUINO_USB_CDC_ON_BOOT=1 # Required for USB Serial on boot (for debugging)  
+    -D ARDUINO_USB_MODE=0
+    -D ARDUINO_USB_CDC_ON_BOOT=0
     -D ARDUINO_USB_MSC_ON_BOOT=0
     -D ARDUINO_USB_DFU_ON_BOOT=0
+    -Isrc/vario
+    -Isrc/vario/compat
 
 
 [env:_dev]

--- a/src/vario/compat/Arduino.h
+++ b/src/vario/compat/Arduino.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include_next <Arduino.h>
+
+#include "system/usb_serial.h"

--- a/src/vario/storage/sd_card.cpp
+++ b/src/vario/storage/sd_card.cpp
@@ -14,6 +14,7 @@
 #include "hardware/io_pins.h"
 #include "instruments/gps.h"
 #include "logging/log.h"
+#include "system/usb_state.h"
 
 #define DEBUG_SDCARD true
 
@@ -48,9 +49,16 @@ void SDCard::init(void) {
   if (!SD_DETECT_IOEX) pinMode(SD_DETECT, INPUT_PULLUP);
 
   // If SDcard present, mount and save state so we can track changes
-  if (isCardPresent()) {
+  const bool cardPresent = isCardPresent();
+  if (cardPresent) {
     mounted_ = sdcard.mount();
   }
+
+#ifndef DISABLE_MASS_STORAGE
+  if (!cardPresent || !mounted_) {
+    leaf_usb::begin();
+  }
+#endif
 }
 
 void SDCard::update() {
@@ -123,7 +131,7 @@ bool SDCard::setupMassStorage() {
   msc_.mediaPresent(true);
   msc_.begin(sectorCount, 512);
   firmwareMSC_.begin();
-  return USB.begin();
+  return leaf_usb::begin();
 }
 
 bool SDCard::mount() {
@@ -141,6 +149,7 @@ bool SDCard::mount() {
       if (DEBUG_SDCARD) Serial.println("Mass Storage Success");
     } else {
       if (DEBUG_SDCARD) Serial.println("Mass Storage Failed");
+      leaf_usb::begin();
     }
 #endif
   }

--- a/src/vario/system/usb_serial.cpp
+++ b/src/vario/system/usb_serial.cpp
@@ -1,0 +1,5 @@
+#include "system/usb_serial.h"
+
+#if !ARDUINO_USB_MODE && !ARDUINO_USB_CDC_ON_BOOT
+USBCDC USBSerial(0);
+#endif

--- a/src/vario/system/usb_serial.h
+++ b/src/vario/system/usb_serial.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <USBCDC.h>
+
+#if !ARDUINO_USB_MODE && !ARDUINO_USB_CDC_ON_BOOT
+extern USBCDC USBSerial;
+
+#undef Serial
+#define Serial USBSerial
+#endif

--- a/src/vario/system/usb_state.cpp
+++ b/src/vario/system/usb_state.cpp
@@ -1,0 +1,104 @@
+#include "system/usb_state.h"
+
+#include <Arduino.h>
+#include <USB.h>
+
+#include "system/usb_serial.h"
+
+#if CONFIG_IDF_TARGET_ESP32S3
+#include "soc/rtc_cntl_reg.h"
+#include "soc/soc.h"
+#include "soc/usb_pins.h"
+#include "soc/usb_serial_jtag_reg.h"
+#endif
+
+namespace leaf_usb {
+  namespace {
+    constexpr uint32_t HOST_ENUMERATION_GRACE_MS = 3000;
+    constexpr uint16_t LEAF_TINYUSB_PID = 0x0002;
+
+    bool initialized = false;
+    bool usb_started = false;
+    bool host_mounted = false;
+    bool host_suspended = false;
+    uint32_t usb_started_ms = 0;
+
+    void onUsbEvent(void*, esp_event_base_t, int32_t event_id, void*) {
+      switch (event_id) {
+        case ARDUINO_USB_STARTED_EVENT:
+          host_mounted = true;
+          host_suspended = false;
+          break;
+        case ARDUINO_USB_STOPPED_EVENT:
+          host_mounted = false;
+          host_suspended = false;
+          break;
+        case ARDUINO_USB_SUSPEND_EVENT:
+          host_suspended = true;
+          break;
+        case ARDUINO_USB_RESUME_EVENT:
+          host_suspended = false;
+          break;
+        default:
+          break;
+      }
+    }
+
+    void prepareNativeUsbTakeover() {
+#if CONFIG_IDF_TARGET_ESP32S3
+      CLEAR_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_USB_PAD_ENABLE);
+      CLEAR_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_PHY_SEL);
+      SET_PERI_REG_MASK(RTC_CNTL_USB_CONF_REG, RTC_CNTL_SW_HW_USB_PHY_SEL |
+                                                   RTC_CNTL_SW_USB_PHY_SEL |
+                                                   RTC_CNTL_USB_PAD_ENABLE);
+
+      pinMode(USBPHY_DM_NUM, OUTPUT_OPEN_DRAIN);
+      pinMode(USBPHY_DP_NUM, OUTPUT_OPEN_DRAIN);
+      digitalWrite(USBPHY_DM_NUM, LOW);
+      digitalWrite(USBPHY_DP_NUM, LOW);
+      delay(25);
+#endif
+    }
+  }  // namespace
+
+  void init() {
+    if (initialized) return;
+
+    USB.onEvent(onUsbEvent);
+    initialized = true;
+  }
+
+  bool begin() {
+    init();
+
+    if (usb_started) return true;
+
+#if !ARDUINO_USB_MODE && !ARDUINO_USB_CDC_ON_BOOT
+    USBSerial.begin(115200);
+#endif
+    USB.manufacturerName("Leaf");
+    USB.productName("Leaf Vario");
+    USB.PID(LEAF_TINYUSB_PID);
+
+    prepareNativeUsbTakeover();
+    const bool success = USB.begin();
+    if (success && !usb_started) {
+      usb_started = true;
+      usb_started_ms = millis();
+    }
+    return success;
+  }
+
+  bool started() { return usb_started; }
+
+  bool hostMounted() { return host_mounted; }
+
+  bool hostSuspended() { return host_suspended; }
+
+  bool shouldStayAwakeForHost() {
+    if (!usb_started) return false;
+    if (host_mounted && !host_suspended) return true;
+
+    return millis() - usb_started_ms < HOST_ENUMERATION_GRACE_MS;
+  }
+}  // namespace leaf_usb

--- a/src/vario/system/usb_state.h
+++ b/src/vario/system/usb_state.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace leaf_usb {
+  void init();
+  bool begin();
+
+  bool started();
+  bool hostMounted();
+  bool hostSuspended();
+  bool shouldStayAwakeForHost();
+}  // namespace leaf_usb

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -21,6 +21,7 @@
 #include "logging/log.h"
 #include "power.h"
 #include "storage/sd_card.h"
+#include "system/usb_state.h"
 #include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 #include "ui/input/buttons.h"
@@ -169,7 +170,8 @@ void TaskManager::updateWhileCharging() {
     buttons.update();  // check Button for any presses (user can turn ON from charging state)
 
     // Prep to end this cycle and sleep
-    if (buttons.inspectPins() == Button::NONE && diagnostic_network.canSleepWhileCharging()) {
+    if (buttons.inspectPins() == Button::NONE && diagnostic_network.canSleepWhileCharging() &&
+        !leaf_usb::shouldStayAwakeForHost()) {
       goToSleep = true;  // get ready to sleep if no button is being pushed
     } else {
       goToSleep = false;


### PR DESCRIPTION


**Summary**

This changes release USB startup so Leaf presents the final TinyUSB composite device only after MSC is ready, instead of allowing the ESP32-S3 hardware Serial/JTAG USB device to remain enumerated when the device boots from USB power.

When Leaf was off and then plugged into a computer, Windows enumerated the ESP32-S3 hardware Serial/JTAG device (`VID_303A&PID_1001`) before firmware reached SD/MSC setup. Later `USB.begin()` did not reliably make the host switch to the app MSC composite device, so mass storage never appeared. The firmware now explicitly hands the USB pins from Serial/JTAG to native TinyUSB, briefly forces host re-enumeration, and starts the app composite device as `VID_303A&PID_0002`.

**Changes**

- Disable release `ARDUINO_USB_CDC_ON_BOOT` so USB is not auto-started before MSC setup.
- Add a manual USB CDC serial instance so existing `Serial` logging still maps to app TinyUSB serial.
- Add `leaf_usb` helper for one-time USB startup, host mount/suspend tracking, and charging sleep decisions.
- Start USB through `leaf_usb::begin()` after SD MSC and firmware MSC are configured.
- Set app USB descriptors to `Leaf` / `Leaf Vario` and PID `0x0002`.
- On ESP32-S3, explicitly release USB Serial/JTAG pad ownership and pulse D+/D- low before TinyUSB startup.
- Prevent future charging light sleep while USB is enumerating or connected to an active host.
- Keep CDC-only fallback if SD is absent, mount fails, or MSC setup fails.

**Validation**

- Off → plug into computer:
  - device enumerates as `VID_303A&PID_0002`
  - mass storage appears
  - serial COM port appears
- On → plug into computer:
  - mass storage and serial still appear
- Serial monitor works after app USB enumeration.
- File copy/read through mass storage works.
- Dumb wall charger still enters charging state normally.
- Build passes:
  - `pio run -e leaf_3_2_6_release`

**Notes**

Early boot serial logs are still not captured in release mode because app USB serial now starts with the final TinyUSB composite device, not at reset through hardware Serial/JTAG. That is intentional for reliable MSC enumeration.