### PR TITLE
Don't allow log file creation until system time is synced

### DIFF
--- a/src/vario/logbook/flight.cpp
+++ b/src/vario/logbook/flight.cpp
@@ -11,7 +11,10 @@
 bool Flight::startFlight() {
   // Short circuit if the card is not mounted or reading properly
   if (!sdcard.isMounted()) return false;
-  gps.syncSystemClock();
+  if (!gps.syncSystemClock()) {
+    Serial.println("Flight::startFlight waiting for valid GPS date/time");
+    return false;
+  }
 
   Serial.printf("Sectors: %d\n", SD_MMC.numSectors());
   File trackLogsDir = SD_MMC.open(this->desiredFilePath());


### PR DESCRIPTION
This catches an edge case where GPS location could be valid, allowing log file creation, but time/data is not yet valid, so the system clock sync has yet to run and the log file is created with the default 1979 timestamp.