### PR TITLE
Improve vario startup readiness and default build target

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,7 +5,7 @@ src_dir = src/vario
 ; src_dir = utils/SD_Card_Testing/Stress_Test
 
 # Environment a new user should probably be using if they don't select a different one
-default_envs = leaf_3_2_5_release
+default_envs = leaf_3_2_7_release
 
 # Variants have their own configs.
 extra_configs = 

--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -24,7 +24,7 @@ SpeakerInteractiveTest speakerTest;
 
 constexpr size_t BUFFER_SIZE = 512;
 constexpr uint32_t GPS_SERIAL_TEST_TIMEOUT_MS = 5000;
-constexpr uint32_t IMU_TEST_TIMEOUT_MS = 20000;
+constexpr uint32_t IMU_TEST_TIMEOUT_MS = 30000;
 constexpr uint32_t GPS_FIX_TEST_TIMEOUT_MS = 30UL * 60UL * 1000UL;
 File self_test_file;
 String self_test_file_name = "";

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -29,6 +29,8 @@ constexpr uint32_t CLIMB_AVERAGE_INIT_S = 1;
 // sample rate of altitudes; used to compute smaple count from duration
 constexpr uint32_t SAMPLES_PER_SECOND = 20;
 
+constexpr size_t BARO_STARTUP_DISCARD_SAMPLES = 20;
+
 // Singleton barometer instance for device
 Barometer baro;
 
@@ -103,11 +105,16 @@ void Barometer::init(void) {
   }
 
   // Clear any state
+  validAltF_ = false;
+  validAltAdjusted_ = false;
+  validAltAtLaunch_ = false;
+  validAltInitial_ = false;
   validClimbRateRaw_ = false;
   validClimbRateFiltered_ = false;
   climbFilter.reset();
   climbRateAverage_ = 0;
   nInitSamplesRemaining_ = CLIMB_AVERAGE_INIT_S * SAMPLES_PER_SECOND;
+  startupDiscardSamplesRemaining_ = BARO_STARTUP_DISCARD_SAMPLES;
 
   state_ = State::WaitingForFirstReading;
 }
@@ -118,7 +125,11 @@ void Barometer::on_receive(const PressureUpdate& msg) {
   }
 
   if (state_ == State::WaitingForFirstReading) {
-    firstReading(msg);
+    if (startupDiscardSamplesRemaining_ > 0) {
+      startupDiscardSamplesRemaining_--;
+    } else {
+      firstReading(msg);
+    }
   } else if (state_ == State::Sleeping) {
     // Do nothing
   } else if (state_ == State::Ready) {
@@ -261,6 +272,14 @@ float Barometer::climbRateAverage() {
 bool Barometer::climbRateAverageValid() {
   return state_ == State::Ready && nInitSamplesRemaining_ == 0;
 }
+
+uint16_t Barometer::startupSamplesCompleted() const {
+  if (state_ == State::Uninitialized || state_ == State::Sleeping) return 0;
+  if (state_ != State::WaitingForFirstReading) return BARO_STARTUP_DISCARD_SAMPLES;
+  return BARO_STARTUP_DISCARD_SAMPLES - startupDiscardSamplesRemaining_;
+}
+
+uint16_t Barometer::startupSamplesRequired() const { return BARO_STARTUP_DISCARD_SAMPLES; }
 
 void Barometer::filterAltitude() {
   // Filter Pressure and calculate Final Altitude Values

--- a/src/vario/instruments/baro.h
+++ b/src/vario/instruments/baro.h
@@ -67,6 +67,9 @@ class Barometer : public MessageSink<Barometer, PressureUpdate>,
 
   bool climbRateAverageValid();
 
+  uint16_t startupSamplesCompleted() const;
+  uint16_t startupSamplesRequired() const;
+
   // == State adjustments ==
 
   // Change the number of samples over which pressure and climb rate are averaged
@@ -119,6 +122,7 @@ class Barometer : public MessageSink<Barometer, PressureUpdate>,
   // Number of remaining initial samples to be summed into climbRateAverage_ before declaring
   // climbRateAverage available
   size_t nInitSamplesRemaining_;
+  size_t startupDiscardSamplesRemaining_;
 
   int32_t altAdjusted_;
   bool validAltAdjusted_ = false;

--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -37,7 +37,7 @@ namespace {
   constexpr uint16_t GRAVITY_RECOVERY_VERTICAL_REJECT_SAMPLES = IMU_SAMPLE_RATE * 2;
   constexpr uint16_t KALMAN_STARTUP_REPORT_SAMPLES = IMU_SAMPLE_RATE;
   constexpr uint16_t STARTUP_NON_VERT_SAMPLES = IMU_SAMPLE_RATE;
-  constexpr uint32_t STARTUP_IMU_MAX_READINESS_MS = 5000;
+  constexpr uint32_t STARTUP_IMU_MAX_READINESS_MS = 8000;
 
   bool normalizeQuaternion(double* qw, double* qx, double* qy, double* qz) {
     double qVecMagnitude2 = (*qx * *qx) + (*qy * *qy) + (*qz * *qz);

--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -28,13 +28,16 @@ namespace {
 
   constexpr double MIN_GRAVITY_G = 0.9;
   constexpr double MAX_GRAVITY_G = 1.1;
-  constexpr double MIN_GRAVITY_ESTIMATE_G = 0.985;
-  constexpr double MAX_GRAVITY_ESTIMATE_G = 1.015;
+  constexpr double MIN_GRAVITY_ESTIMATE_G = 0.98;
+  constexpr double MAX_GRAVITY_ESTIMATE_G = 1.02;
   constexpr double GRAVITY_UPDATE_ACCEL_TOLERANCE_G = 0.05;
   constexpr double GRAVITY_UPDATE_VERTICAL_TOLERANCE_G = 0.10;
-  constexpr double GRAVITY_UPDATE_MAX_SLEW_G_PER_S = 0.025;
+  constexpr double GRAVITY_UPDATE_MAX_SLEW_G_PER_S = 0.05;
   constexpr uint8_t IMU_SAMPLE_RATE = 20;  // Hz
   constexpr uint16_t GRAVITY_RECOVERY_VERTICAL_REJECT_SAMPLES = IMU_SAMPLE_RATE * 2;
+  constexpr uint16_t KALMAN_STARTUP_REPORT_SAMPLES = IMU_SAMPLE_RATE;
+  constexpr uint16_t STARTUP_NON_VERT_SAMPLES = IMU_SAMPLE_RATE;
+  constexpr uint32_t STARTUP_IMU_MAX_READINESS_MS = 5000;
 
   bool normalizeQuaternion(double* qw, double* qx, double* qy, double* qz) {
     double qVecMagnitude2 = (*qx * *qx) + (*qy * *qy) + (*qz * *qz);
@@ -102,7 +105,8 @@ inline void printFloat(double v) {
 
 IMU::IMU()
     : kalmanvert_(pow(POSITION_MEASURE_STANDARD_DEVIATION, 2),
-                  pow(ACCELERATION_MEASURE_STANDARD_DEVIATION, 2)) {}
+                  pow(ACCELERATION_MEASURE_STANDARD_DEVIATION, 2)),
+      kalmanStartupSamplesRemaining_(KALMAN_STARTUP_REPORT_SAMPLES) {}
 
 void IMU::processMotion(const MotionUpdate& m) {
   double qw = 0;
@@ -188,6 +192,7 @@ void IMU::processMotion(const MotionUpdate& m) {
   // In steady-state (normally), actual vertical acceleration is the difference between measured
   // vertical acceleration and gravity
   accelVert_ = awz - gravity_;
+  kalmanAccelVert_ = accelVert_;
   validAccelVert_ = true;
 
   // Slowly update estimate of gravity
@@ -199,6 +204,7 @@ void IMU::processMotion(const MotionUpdate& m) {
     gravityVerticalRejectCount_ = 0;
   } else if (verticalDelta > GRAVITY_UPDATE_VERTICAL_TOLERANCE_G) {
     gravityUpdateRejectedVerticalCount_++;
+    kalmanAccelVert_ = 0.0;
     if (++gravityVerticalRejectCount_ >= GRAVITY_RECOVERY_VERTICAL_REJECT_SAMPLES &&
         fabs(gravity_ - 1.0) > GRAVITY_UPDATE_VERTICAL_TOLERANCE_G) {
       lastRejectedGravity_ = gravity_;
@@ -209,6 +215,9 @@ void IMU::processMotion(const MotionUpdate& m) {
     }
   } else {
     gravityVerticalRejectCount_ = 0;
+    if (startupNonVertSamples_ < STARTUP_NON_VERT_SAMPLES) {
+      startupNonVertSamples_++;
+    }
     double dt = ((double)m.t - tLastGravityUpdate_) * 0.001;
     if (dt > 0.0 && dt < 1.0) {
       double f = exp(K_UPDATE * dt);
@@ -250,7 +259,10 @@ void IMU::processMotion(const MotionUpdate& m) {
 void IMU::on_receive(const MotionUpdate& msg) {
   motionSampleCount_++;
   if (baro.state() != Barometer::State::Ready) {
-    // We can't do anything without simultaneous barometer-measured altitude
+    if (msg.hasAcceleration && msg.hasOrientation) {
+      processMotion(msg);
+    }
+    // Gravity can update without baro, but Kalman needs simultaneous barometer-measured altitude.
     motionSampleBaroNotReadyCount_++;
     return;
   }
@@ -262,12 +274,19 @@ void IMU::on_receive(const MotionUpdate& msg) {
     return;
   }
 
+  if (startupReadinessStartMs_ == 0) {
+    startupReadinessStartMs_ = millis();
+  }
+
   processMotion(msg);
 
   if (validAccelVert_) {
     // update kalman filter
-    kalmanvert_.update(millis() / 1000.0, baro.altF(), accelVert_ * 9.80665f);
+    kalmanvert_.update(millis() / 1000.0, baro.altF(), kalmanAccelVert_ * 9.80665f);
     kalmanUpdateSampleCount_++;
+    if (kalmanStartupSamplesRemaining_ > 0) {
+      kalmanStartupSamplesRemaining_--;
+    }
 
     if (LOG::KALMAN && bus_) {
       String kalmanName = "kalman,";
@@ -282,7 +301,10 @@ void IMU::on_receive(const MotionUpdate& msg) {
 void IMU::wake() {
   gravity_ = 1.0;
   gravityVerticalRejectCount_ = 0;
+  startupNonVertSamples_ = 0;
+  startupReadinessStartMs_ = 0;
   tLastGravityUpdate_ = 0;
+  kalmanStartupSamplesRemaining_ = KALMAN_STARTUP_REPORT_SAMPLES;
 }
 
 bool IMU::accelValid() { return validAccelTot_; }
@@ -294,7 +316,10 @@ float IMU::getAccel() {
   return accelTot_;
 }
 
-bool IMU::velocityValid() { return kalmanvert_.initialized(); }
+bool IMU::velocityValid() {
+  return kalmanvert_.initialized() && kalmanStartupSamplesRemaining_ == 0 &&
+         (startupNonVertSamples_ >= STARTUP_NON_VERT_SAMPLES || startupReadinessTimedOut());
+}
 
 float IMU::getVelocity() {
   if (!velocityValid()) {
@@ -348,3 +373,21 @@ uint32_t IMU::gravityUpdateRejectedPlausibilityCount() const {
 uint32_t IMU::gravityUpdateSlewLimitedCount() const { return gravityUpdateSlewLimitedCount_; }
 
 uint32_t IMU::kalmanUpdateSampleCount() const { return kalmanUpdateSampleCount_; }
+
+bool IMU::startupReadinessTimedOut() const {
+  return startupReadinessStartMs_ != 0 &&
+         static_cast<uint32_t>(millis() - startupReadinessStartMs_) >= STARTUP_IMU_MAX_READINESS_MS;
+}
+
+uint16_t IMU::startupSamplesCompleted() const {
+  uint16_t kalmanCompleted = KALMAN_STARTUP_REPORT_SAMPLES - kalmanStartupSamplesRemaining_;
+  if (kalmanStartupSamplesRemaining_ == 0 && startupReadinessTimedOut()) {
+    return KALMAN_STARTUP_REPORT_SAMPLES;
+  }
+  uint16_t nonVertCompleted =
+      startupNonVertSamples_ > STARTUP_NON_VERT_SAMPLES ? STARTUP_NON_VERT_SAMPLES
+                                                        : startupNonVertSamples_;
+  return kalmanCompleted < nonVertCompleted ? kalmanCompleted : nonVertCompleted;
+}
+
+uint16_t IMU::startupSamplesRequired() const { return KALMAN_STARTUP_REPORT_SAMPLES; }

--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -384,9 +384,9 @@ uint16_t IMU::startupSamplesCompleted() const {
   if (kalmanStartupSamplesRemaining_ == 0 && startupReadinessTimedOut()) {
     return KALMAN_STARTUP_REPORT_SAMPLES;
   }
-  uint16_t nonVertCompleted =
-      startupNonVertSamples_ > STARTUP_NON_VERT_SAMPLES ? STARTUP_NON_VERT_SAMPLES
-                                                        : startupNonVertSamples_;
+  uint16_t nonVertCompleted = startupNonVertSamples_ > STARTUP_NON_VERT_SAMPLES
+                                  ? STARTUP_NON_VERT_SAMPLES
+                                  : startupNonVertSamples_;
   return kalmanCompleted < nonVertCompleted ? kalmanCompleted : nonVertCompleted;
 }
 

--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -26,16 +26,14 @@ namespace {
   constexpr double AFTER_SECONDS = 5.0;           // ...after this number of seconds
   constexpr double K_UPDATE = constexpr_log(1 - NEW_MEASUREMENT_WEIGHT) / AFTER_SECONDS;
 
-  constexpr uint8_t IMU_SAMPLE_RATE = 20;  // Hz
-  constexpr double GRAVITY_INIT_S = 3.0;   // Time to take to estimate the initial gravity magnitude
-  // samples to bypass at startup while gravity is estimated
-  constexpr uint32_t GRAVITY_INIT_SAMPLES = IMU_SAMPLE_RATE * GRAVITY_INIT_S;
-
   constexpr double MIN_GRAVITY_G = 0.9;
   constexpr double MAX_GRAVITY_G = 1.1;
+  constexpr double MIN_GRAVITY_ESTIMATE_G = 0.985;
+  constexpr double MAX_GRAVITY_ESTIMATE_G = 1.015;
   constexpr double GRAVITY_UPDATE_ACCEL_TOLERANCE_G = 0.05;
   constexpr double GRAVITY_UPDATE_VERTICAL_TOLERANCE_G = 0.10;
   constexpr double GRAVITY_UPDATE_MAX_SLEW_G_PER_S = 0.025;
+  constexpr uint8_t IMU_SAMPLE_RATE = 20;  // Hz
   constexpr uint16_t GRAVITY_RECOVERY_VERTICAL_REJECT_SAMPLES = IMU_SAMPLE_RATE * 2;
 
   bool normalizeQuaternion(double* qw, double* qx, double* qy, double* qz) {
@@ -66,6 +64,12 @@ namespace {
     double magnitude = fabs(gravity);
     return !isnan(gravity) && !isinf(gravity) && magnitude >= MIN_GRAVITY_G &&
            magnitude <= MAX_GRAVITY_G;
+  }
+
+  double clampGravityEstimate(double gravity) {
+    if (gravity < MIN_GRAVITY_ESTIMATE_G) return MIN_GRAVITY_ESTIMATE_G;
+    if (gravity > MAX_GRAVITY_ESTIMATE_G) return MAX_GRAVITY_ESTIMATE_G;
+    return gravity;
   }
 }  // namespace
 
@@ -98,8 +102,7 @@ inline void printFloat(double v) {
 
 IMU::IMU()
     : kalmanvert_(pow(POSITION_MEASURE_STANDARD_DEVIATION, 2),
-                  pow(ACCELERATION_MEASURE_STANDARD_DEVIATION, 2)),
-      gravityInitCount_(GRAVITY_INIT_SAMPLES) {}
+                  pow(ACCELERATION_MEASURE_STANDARD_DEVIATION, 2)) {}
 
 void IMU::processMotion(const MotionUpdate& m) {
   double qw = 0;
@@ -182,79 +185,48 @@ void IMU::processMotion(const MotionUpdate& m) {
   needNewline = true;
 #endif
 
-  if (gravityInitCount_ > 0) {
-    validAccelVert_ = false;
-    gravityInitSampleCount_++;
-    gravity_ += awz;
-    if (--gravityInitCount_ == 0) {
-      gravity_ /= GRAVITY_INIT_SAMPLES;
-      if (!plausibleGravity(gravity_)) {
-        lastRejectedGravity_ = gravity_;
-        gravityInitResetCount_++;
-        char msg[160];
-        snprintf(msg, sizeof(msg),
-                 "IMU gravity init rejected: gravity=%g, awz=%g, accelTot=%g, resets=%u", gravity_,
-                 awz, accelTot_, static_cast<unsigned>(gravityInitResetCount_));
-        Serial.println(msg);
-        if (bus_) bus_->receive(CommentMessage(msg));
-        gravity_ = 0;
-        gravityInitCount_ = GRAVITY_INIT_SAMPLES;
-        validAccelVert_ = false;
-      } else {
-        char msg[160];
-        snprintf(msg, sizeof(msg),
-                 "IMU gravity init complete: gravity=%g, awz=%g, accelTot=%g, resets=%u", gravity_,
-                 awz, accelTot_, static_cast<unsigned>(gravityInitResetCount_));
-        Serial.println(msg);
-        if (bus_) bus_->receive(CommentMessage(msg));
-      }
-    }
-  }
-  if (gravityInitCount_ == 0) {
-    // In steady-state (normally), actual vertical acceleration is the difference between measured
-    // vertical acceleration and gravity
-    accelVert_ = awz - gravity_;
-    validAccelVert_ = true;
+  // In steady-state (normally), actual vertical acceleration is the difference between measured
+  // vertical acceleration and gravity
+  accelVert_ = awz - gravity_;
+  validAccelVert_ = true;
 
-    // Slowly update estimate of gravity
-    gravityUpdateCandidateCount_++;
-    double accelMagnitudeDelta = fabs(accelTot_ - 1.0);
-    double verticalDelta = fabs(accelVert_);
-    if (accelMagnitudeDelta > GRAVITY_UPDATE_ACCEL_TOLERANCE_G) {
-      gravityUpdateRejectedAccelCount_++;
+  // Slowly update estimate of gravity
+  gravityUpdateCandidateCount_++;
+  double accelMagnitudeDelta = fabs(accelTot_ - 1.0);
+  double verticalDelta = fabs(accelVert_);
+  if (accelMagnitudeDelta > GRAVITY_UPDATE_ACCEL_TOLERANCE_G) {
+    gravityUpdateRejectedAccelCount_++;
+    gravityVerticalRejectCount_ = 0;
+  } else if (verticalDelta > GRAVITY_UPDATE_VERTICAL_TOLERANCE_G) {
+    gravityUpdateRejectedVerticalCount_++;
+    if (++gravityVerticalRejectCount_ >= GRAVITY_RECOVERY_VERTICAL_REJECT_SAMPLES &&
+        fabs(gravity_ - 1.0) > GRAVITY_UPDATE_VERTICAL_TOLERANCE_G) {
+      lastRejectedGravity_ = gravity_;
+      gravityInitResetCount_++;
+      gravity_ = 1.0;
       gravityVerticalRejectCount_ = 0;
-    } else if (verticalDelta > GRAVITY_UPDATE_VERTICAL_TOLERANCE_G) {
-      gravityUpdateRejectedVerticalCount_++;
-      if (++gravityVerticalRejectCount_ >= GRAVITY_RECOVERY_VERTICAL_REJECT_SAMPLES &&
-          fabs(gravity_ - 1.0) > GRAVITY_UPDATE_VERTICAL_TOLERANCE_G) {
-        lastRejectedGravity_ = gravity_;
-        gravityInitResetCount_++;
-        gravity_ = 0;
-        gravityInitCount_ = GRAVITY_INIT_SAMPLES;
-        gravityVerticalRejectCount_ = 0;
-        validAccelVert_ = false;
+      validAccelVert_ = false;
+    }
+  } else {
+    gravityVerticalRejectCount_ = 0;
+    double dt = ((double)m.t - tLastGravityUpdate_) * 0.001;
+    if (dt > 0.0 && dt < 1.0) {
+      double f = exp(K_UPDATE * dt);
+      double nextGravity = gravity_ * f + awz * (1 - f);
+      double maxDelta = GRAVITY_UPDATE_MAX_SLEW_G_PER_S * dt;
+      double gravityDelta = nextGravity - gravity_;
+      if (fabs(gravityDelta) > maxDelta) {
+        nextGravity = gravity_ + (gravityDelta > 0.0 ? maxDelta : -maxDelta);
+        gravityUpdateSlewLimitedCount_++;
+      }
+      if (plausibleGravity(nextGravity)) {
+        gravity_ = clampGravityEstimate(nextGravity);
+        gravityUpdateAcceptedCount_++;
+      } else {
+        gravityUpdateRejectedPlausibilityCount_++;
       }
     } else {
-      gravityVerticalRejectCount_ = 0;
-      double dt = ((double)m.t - tLastGravityUpdate_) * 0.001;
-      if (dt > 0.0 && dt < 1.0) {
-        double f = exp(K_UPDATE * dt);
-        double nextGravity = gravity_ * f + awz * (1 - f);
-        double maxDelta = GRAVITY_UPDATE_MAX_SLEW_G_PER_S * dt;
-        double gravityDelta = nextGravity - gravity_;
-        if (fabs(gravityDelta) > maxDelta) {
-          nextGravity = gravity_ + (gravityDelta > 0.0 ? maxDelta : -maxDelta);
-          gravityUpdateSlewLimitedCount_++;
-        }
-        if (plausibleGravity(nextGravity)) {
-          gravity_ = nextGravity;
-          gravityUpdateAcceptedCount_++;
-        } else {
-          gravityUpdateRejectedPlausibilityCount_++;
-        }
-      } else {
-        gravityUpdateRejectedTimeCount_++;
-      }
+      gravityUpdateRejectedTimeCount_++;
     }
   }
 
@@ -307,7 +279,11 @@ void IMU::on_receive(const MotionUpdate& msg) {
   }
 }
 
-void IMU::wake() { gravityInitCount_ = GRAVITY_INIT_SAMPLES; }
+void IMU::wake() {
+  gravity_ = 1.0;
+  gravityVerticalRejectCount_ = 0;
+  tLastGravityUpdate_ = 0;
+}
 
 bool IMU::accelValid() { return validAccelTot_; }
 
@@ -318,7 +294,7 @@ float IMU::getAccel() {
   return accelTot_;
 }
 
-bool IMU::velocityValid() { return gravityInitCount_ == 0; }
+bool IMU::velocityValid() { return kalmanvert_.initialized(); }
 
 float IMU::getVelocity() {
   if (!velocityValid()) {
@@ -327,7 +303,7 @@ float IMU::getVelocity() {
   return (float)kalmanvert_.getVelocity();
 }
 
-uint16_t IMU::gravityInitSamplesRemaining() const { return gravityInitCount_; }
+uint16_t IMU::gravityInitSamplesRemaining() const { return 0; }
 
 float IMU::gravityEstimate() const { return (float)gravity_; }
 

--- a/src/vario/instruments/imu.h
+++ b/src/vario/instruments/imu.h
@@ -75,11 +75,8 @@ class IMU : public MessageSink<IMU, MotionUpdate>, public IMessageSource {
   double lastRejectedGravity_ = 0.0;
   uint16_t gravityInitResetCount_ = 0;
 
-  // Number of samples remaining to collect to initialize estimate of gravity
-  uint16_t gravityInitCount_;
-
   // Last time gravity estimate was updated
-  uint32_t tLastGravityUpdate_;
+  uint32_t tLastGravityUpdate_ = 0;
 
   uint32_t motionSampleCount_ = 0;
   uint32_t motionSampleBaroNotReadyCount_ = 0;

--- a/src/vario/instruments/imu.h
+++ b/src/vario/instruments/imu.h
@@ -50,18 +50,22 @@ class IMU : public MessageSink<IMU, MotionUpdate>, public IMessageSource {
   uint32_t gravityUpdateRejectedPlausibilityCount() const;
   uint32_t gravityUpdateSlewLimitedCount() const;
   uint32_t kalmanUpdateSampleCount() const;
+  uint16_t startupSamplesCompleted() const;
+  uint16_t startupSamplesRequired() const;
 
  private:
   void processMotion(const MotionUpdate& m);
+  bool startupReadinessTimedOut() const;
 
   etl::imessage_bus* bus_ = nullptr;
 
   // Kalman filter object for vertical climb rate and position
   KalmanFilterPA kalmanvert_;
 
-  bool kalmanInitialized_ = false;
+  uint16_t kalmanStartupSamplesRemaining_;
 
   double accelVert_;
+  double kalmanAccelVert_ = 0.0;
   bool validAccelVert_ = false;
 
   double accelTot_;
@@ -93,5 +97,7 @@ class IMU : public MessageSink<IMU, MotionUpdate>, public IMessageSource {
   uint32_t gravityUpdateSlewLimitedCount_ = 0;
   uint32_t kalmanUpdateSampleCount_ = 0;
   uint16_t gravityVerticalRejectCount_ = 0;
+  uint16_t startupNonVertSamples_ = 0;
+  uint32_t startupReadinessStartMs_ = 0;
 };
 extern IMU imu;

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -131,7 +131,10 @@ void Display::setPage(MainPage targetPage) {
   if (displayPage_ != tempPage) displayPagePrior_ = tempPage;
 }
 
-void Display::showOnSplash() { showSplashScreenFrames_ = 6; }
+void Display::showOnSplash() {
+  showStartupSplash_ = true;
+  showSplashScreenFrames_ = 6;
+}
 
 //*********************************************************************
 // MAIN DISPLAY UPDATE FUNCTION
@@ -150,9 +153,14 @@ void Display::update() {
     chargingPage_draw();
     return;
   }
-  if (showSplashScreenFrames_) {
+  if (showStartupSplash_) {
     display_on_splash();
-    showSplashScreenFrames_--;
+    if (showSplashScreenFrames_ > 0) {
+      showSplashScreenFrames_--;
+    }
+    if (showSplashScreenFrames_ == 0 && display_startupProgressComplete()) {
+      showStartupSplash_ = false;
+    }
     return;
   }
   // If user setting to SHOW_WARNING and also we need to showWarning, then display it

--- a/src/vario/ui/display/display.h
+++ b/src/vario/ui/display/display.h
@@ -59,6 +59,7 @@ class Display {
   MainPage displayPagePrior_ = MainPage::Thermal;
 
   uint8_t showSplashScreenFrames_ = 0;
+  bool showStartupSplash_ = false;
 
   bool showWarning_ = true;
 };

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -7,6 +7,7 @@
 #include "instruments/ambient.h"
 #include "instruments/baro.h"
 #include "instruments/gps.h"
+#include "instruments/imu.h"
 #include "logging/log.h"
 #include "navigation/gpx.h"
 #include "power.h"
@@ -1115,14 +1116,39 @@ void display_batteryDead_splash() {
   } while (u8g2.nextPage());
 }
 
+uint16_t display_startupProgressCompleted() {
+  return baro.startupSamplesCompleted() + imu.startupSamplesCompleted();
+}
+
+uint16_t display_startupProgressRequired() {
+  return baro.startupSamplesRequired() + imu.startupSamplesRequired();
+}
+
+bool display_startupProgressComplete() {
+  return display_startupProgressCompleted() >= display_startupProgressRequired();
+}
+
 void display_on_splash() {
   u8g2.firstPage();
   do {
     display_splashLogo();
 
     u8g2.setFont(leaf_6x12);
-    u8g2.setCursor(28, 155);
+    u8g2.setCursor(28, 149);
     u8g2.print("HELLO");
+
+    uint16_t progressCompleted = display_startupProgressCompleted();
+    uint16_t progressRequired = display_startupProgressRequired();
+    if (progressCompleted > progressRequired) progressCompleted = progressRequired;
+    constexpr uint8_t progressX = 18;
+    constexpr uint8_t progressY = 154;
+    constexpr uint8_t progressW = 60;
+    constexpr uint8_t progressH = 6;
+    uint8_t fillW = (progressW - 2) * progressCompleted / progressRequired;
+    u8g2.drawFrame(progressX, progressY, progressW, progressH);
+    if (fillW > 0) {
+      u8g2.drawBox(progressX + 1, progressY + 1, fillW, progressH - 2);
+    }
 
     u8g2.setFont(leaf_5x8);
     u8g2.setCursor(0, 172);

--- a/src/vario/ui/display/display_fields.h
+++ b/src/vario/ui/display/display_fields.h
@@ -74,5 +74,8 @@ void display_off_splash(void);
 void display_on_splash(void);
 void display_splashLogo(void);
 void display_batteryDead_splash(void);
+uint16_t display_startupProgressCompleted(void);
+uint16_t display_startupProgressRequired(void);
+bool display_startupProgressComplete(void);
 
 #endif


### PR DESCRIPTION
**Summary**
- Replace sampled gravity initialization with a `1.0g` startup estimate.
- Clamp gravity estimate updates to `0.98g - 1.02g` and raise gravity slew limit to `0.05g/s`.
- Discard the first `20` baro samples before setting initial/launch altitude.
- Allow gravity updates during baro warmup, before Kalman updates begin.
- Require Kalman warmup before reporting climb/sink rates.
- Gate startup on `20` clean IMU samples, with an `8s` fallback for tilted or turbulent startup.
- Add a splash-screen progress bar tied to baro + IMU/Kalman startup readiness.
- Prevent `vert!` rejected samples from injecting false vertical acceleration into Kalman.
- Increase firmware IMU self-test timeout from `20s` to `30s`.
- Change default PlatformIO build environment from `leaf_3_2_5_release` to `leaf_3_2_7_release`.
- Update factory/user defaults for sink alarm, volume, quiet mode, and auto-off.

**Testing**
- Built successfully with `pio run`.
- Verified default `pio run` now selects `leaf_3_2_7_release`.