### PR TITLE
Added User Webserver and Custom Wifi Setup Captive Portal

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -49,9 +49,6 @@ lib_deps =
 	; STL like library for Arduino platform and embedded systems
 	etlcpp/Embedded Template Library@20.39.4
 
-	; WiFi Manager for configuring WiFi credentials over captive portal 
-	WiFiManager@2.0.17
-
 	; IGC Logger
 	https://github.com/scottyob/IgcLogger.git#v0.0.4
 

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -46,6 +46,16 @@ namespace {
   uint32_t interactive_self_test_start_ms = 0;
 
   uint32_t wifi_setup_cycle = 0;
+  uint32_t wifi_setup_started_ms = 0;
+
+  void logWifiSetupTiming(const char* event) {
+    Serial.printf("Leaf WiFi setup cycle %lu +%lums: %s heap=%u maxAlloc=%u\n",
+                  static_cast<unsigned long>(wifi_setup_cycle),
+                  static_cast<unsigned long>(millis() - wifi_setup_started_ms),
+                  event,
+                  ESP.getFreeHeap(),
+                  ESP.getMaxAllocHeap());
+  }
 
   const char* selfTestModeName(SelfTestMode mode) {
     switch (mode) {
@@ -346,6 +356,11 @@ namespace {
     return url;
   }
 
+  bool stationConnectionReady() {
+    return WiFi.status() == WL_CONNECTED && !WiFi.SSID().isEmpty() &&
+           WiFi.localIP() != IPAddress(0, 0, 0, 0);
+  }
+
   void sendNoStoreHeaders(WebServer& target) {
     target.sendHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
     target.sendHeader("Pragma", "no-cache");
@@ -366,18 +381,22 @@ namespace {
 
   String wifiStatusJson() {
     wl_status_t status = WiFi.status();
-    if (wifi_setup_connecting && status == WL_CONNECTED) {
+    if (wifi_setup_connecting && stationConnectionReady()) {
       wifi_setup_connecting = false;
       wifi_setup_connect_error = "";
-    } else if (wifi_setup_connecting && status == WL_CONNECT_FAILED) {
-      stopFailedWifiSetupAttempt("connect_failed");
-      status = WiFi.status();
-    } else if (wifi_setup_connecting && status == WL_NO_SSID_AVAIL) {
-      stopFailedWifiSetupAttempt("network_not_found");
-      status = WiFi.status();
     } else if (wifi_setup_connecting &&
                millis() - wifi_setup_connect_started_ms > WIFI_SETUP_CONNECT_TIMEOUT_MS) {
-      stopFailedWifiSetupAttempt("timeout");
+      const wl_status_t timed_out_status = WiFi.status();
+      if (timed_out_status == WL_CONNECTED) {
+        wifi_setup_connecting = false;
+        wifi_setup_connect_error = "";
+      } else if (timed_out_status == WL_NO_SSID_AVAIL) {
+        stopFailedWifiSetupAttempt("network_not_found");
+      } else if (timed_out_status == WL_CONNECT_FAILED) {
+        stopFailedWifiSetupAttempt("connect_failed");
+      } else {
+        stopFailedWifiSetupAttempt("timeout");
+      }
       status = WiFi.status();
     }
 
@@ -388,7 +407,7 @@ namespace {
     json += ",\"connecting\":";
     json += wifi_setup_connecting ? "true" : "false";
     json += ",\"ssid\":\"";
-    json += jsonEscape(WiFi.SSID());
+    json += jsonEscape(WiFi.SSID().isEmpty() && status == WL_CONNECTED ? wifi_setup_connect_ssid : WiFi.SSID());
     json += "\",\"target_ssid\":\"";
     json += jsonEscape(wifi_setup_connect_ssid);
     json += "\",\"ip_address\":\"";
@@ -627,8 +646,9 @@ namespace {
       Serial.printf("Leaf WiFi setup scan failed: %d\n", result);
     }
     wifi_setup_networks_json = wifiNetworksJsonFromScan(result);
-    Serial.printf("Leaf WiFi setup cycle %lu: scan=%d cachedJson=%u heap=%u maxAlloc=%u\n",
+    Serial.printf("Leaf WiFi setup cycle %lu +%lums: scan=%d cachedJson=%u heap=%u maxAlloc=%u\n",
                   static_cast<unsigned long>(wifi_setup_cycle),
+                  static_cast<unsigned long>(millis() - wifi_setup_started_ms),
                   result,
                   wifi_setup_networks_json.length(),
                   ESP.getFreeHeap(),
@@ -647,6 +667,7 @@ namespace {
   }
 
   void startWifiNetworkScan() {
+    logWifiSetupTiming("scan-start");
     WiFi.scanDelete();
     wifi_setup_networks_json = "{\"scanning\":true,\"networks\":[]}";
     const int16_t result = WiFi.scanNetworks(/*async=*/true, /*hidden=*/false);
@@ -1025,17 +1046,25 @@ void webserver_enable_user_app(bool useLeafWifi) {
 
 void webserver_enable_wifi_setup() {
   wifi_setup_cycle++;
-  leaf_wifi::prepareForUserWifiSetup();
+  wifi_setup_started_ms = millis();
+  logWifiSetupTiming("start");
+  leaf_wifi::prepareForUserWifiSetupFast();
+  logWifiSetupTiming("after-fast-prepare");
   WiFi.mode(WIFI_AP_STA);
   WiFi.setSleep(false);
   WiFi.softAP("Leaf WiFi");
+  logWifiSetupTiming("after-softAP");
   user_app_enabled = true;
   user_app_using_leaf_wifi = true;
   user_app_provisioning = true;
   setupUserAppServer();
+  logWifiSetupTiming("after-user-server");
   dns_server.start(53, "*", WiFi.softAPIP());
+  logWifiSetupTiming("after-dns");
   webserver_setup();
+  logWifiSetupTiming("after-main-server");
   startWifiNetworkScan();
+  logWifiSetupTiming("after-scan-start");
   Serial.printf("Leaf WiFi setup started: http://%s/app/wifi\n", WiFi.softAPIP().toString().c_str());
 }
 

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -430,7 +430,7 @@ namespace {
 
   bool handleCaptivePortalRequest(WebServer& target) {
     if (!user_app_provisioning) return false;
-    sendRedirect(target, "/app/wifi");
+    sendRedirect(target, "/wifi");
     return true;
   }
 
@@ -713,9 +713,10 @@ namespace {
 
     if (!user_server_routes_configured) {
       user_server.on("/", HTTP_GET, []() {
-        sendRedirect(user_server, user_app_provisioning ? "/app/wifi" : "/app");
+        sendRedirect(user_server, user_app_provisioning ? "/wifi" : "/app");
       });
       user_server.on("/app", HTTP_GET, []() { sendUserAppShell(user_server); });
+      user_server.on("/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
       user_server.on("/app/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
       user_server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(user_server); });
       user_server.on("/api/wifi/status", HTTP_GET, []() { user_server.send(200, "application/json", wifiStatusJson()); });
@@ -1065,7 +1066,7 @@ void webserver_enable_wifi_setup() {
   logWifiSetupTiming("after-main-server");
   startWifiNetworkScan();
   logWifiSetupTiming("after-scan-start");
-  Serial.printf("Leaf WiFi setup started: http://%s/app/wifi\n", WiFi.softAPIP().toString().c_str());
+  Serial.printf("Leaf WiFi setup started: http://%s/wifi\n", WiFi.softAPIP().toString().c_str());
 }
 
 void webserver_disable_user_app() {

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -7,6 +7,7 @@
 #include <ctype.h>
 #include "comms/factory_discovery.h"
 #include "comms/fanet_radio.h"
+#include "comms/wifi_coordinator.h"
 #include "diagnostics/memory_report.h"
 #include "diagnostics/self_test/selfTest.h"
 #include "etl/string_stream.h"
@@ -24,10 +25,11 @@ namespace {
   String send_buffer = "";
   bool webserver_started = false;
   bool user_server_started = false;
+  bool user_server_routes_configured = false;
   bool user_app_enabled = false;
   bool user_app_using_leaf_wifi = false;
   bool user_app_provisioning = false;
-  bool wifi_setup_scan_started = false;
+  String wifi_setup_networks_json = "{\"scanning\":false,\"networks\":[]}";
   bool wifi_setup_connecting = false;
   uint32_t wifi_setup_connect_started_ms = 0;
   String wifi_setup_connect_ssid = "";
@@ -41,6 +43,8 @@ namespace {
   SelfTestMode last_self_test_mode = SelfTestMode::None;
   bool interactive_self_test_pending = false;
   uint32_t interactive_self_test_start_ms = 0;
+
+  uint32_t wifi_setup_cycle = 0;
 
   const char* selfTestModeName(SelfTestMode mode) {
     switch (mode) {
@@ -341,6 +345,12 @@ namespace {
     return url;
   }
 
+  void sendNoStoreHeaders(WebServer& target) {
+    target.sendHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+    target.sendHeader("Pragma", "no-cache");
+    target.sendHeader("Expires", "0");
+  }
+
   void stopFailedWifiSetupAttempt(const char* error) {
     wifi_setup_connecting = false;
     wifi_setup_connect_error = error;
@@ -393,6 +403,7 @@ namespace {
   }
 
   void sendRedirect(WebServer& target, const char* location) {
+    sendNoStoreHeaders(target);
     target.sendHeader("Location", location, true);
     target.send(302, "text/plain", "");
   }
@@ -540,201 +551,9 @@ namespace {
       return;
     }
 
-    target.send(200, "text/html", R"(
-      <!DOCTYPE html>
-      <html lang="en">
-        <head>
-          <meta charset="utf-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1">
-          <title>Leaf WiFi Setup</title>
-          <style>
-            :root {
-              color-scheme: light;
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-              line-height: 1.35;
-            }
-            body {
-              margin: 0;
-              background: #f5f7f2;
-              color: #172016;
-            }
-            header {
-              background: #172016;
-              color: white;
-              padding: 18px 20px;
-            }
-            main {
-              max-width: 560px;
-              margin: 0 auto;
-              padding: 20px;
-            }
-            h1 {
-              font-size: 24px;
-              margin: 0;
-            }
-            label {
-              display: block;
-              font-size: 14px;
-              font-weight: 650;
-              margin: 14px 0 6px;
-            }
-            input, select, button {
-              box-sizing: border-box;
-              width: 100%;
-              border: 1px solid #bac3b4;
-              border-radius: 6px;
-              font: inherit;
-              padding: 12px;
-            }
-            button {
-              background: #172016;
-              color: white;
-              font-weight: 700;
-              margin-top: 16px;
-            }
-            .status {
-              border-bottom: 1px solid #d9dfd3;
-              color: #596256;
-              font-size: 14px;
-              margin-bottom: 18px;
-              padding-bottom: 16px;
-            }
-            .manual {
-              margin-top: 10px;
-            }
-            .password-row {
-              display: flex;
-              gap: 10px;
-            }
-            .password-row input {
-              flex: 1;
-              min-width: 0;
-            }
-            .show-password {
-              align-items: center;
-              border: 1px solid #bac3b4;
-              border-radius: 6px;
-              display: flex;
-              gap: 6px;
-              padding: 0 10px;
-              white-space: nowrap;
-            }
-            .show-password input {
-              width: auto;
-            }
-          </style>
-        </head>
-        <body>
-          <header>
-            <h1>Leaf WiFi Setup</h1>
-          </header>
-          <main>
-            <div class="status" id="status">Scanning for networks...</div>
-            <form id="wifi-form">
-              <label for="ssid-list">Network</label>
-              <select id="ssid-list">
-                <option value="">Select network...</option>
-              </select>
-              <input class="manual" id="ssid" name="ssid" autocomplete="off" placeholder="Type network name">
-              <label for="password">Password</label>
-              <div class="password-row">
-                <input id="password" name="password" type="password" autocomplete="current-password">
-                <label class="show-password">
-                  <input id="show-password" type="checkbox">
-                  Show
-                </label>
-              </div>
-              <button type="submit">Save and Connect</button>
-            </form>
-          </main>
-          <script>
-            const statusEl = document.getElementById('status');
-            const ssidList = document.getElementById('ssid-list');
-            const ssidInput = document.getElementById('ssid');
-            const passwordInput = document.getElementById('password');
-            const showPasswordInput = document.getElementById('show-password');
-            const form = document.getElementById('wifi-form');
-
-            ssidList.addEventListener('change', () => {
-              if (ssidList.value) ssidInput.value = ssidList.value;
-            });
-
-            showPasswordInput.addEventListener('change', () => {
-              passwordInput.type = showPasswordInput.checked ? 'text' : 'password';
-            });
-
-            async function loadNetworks() {
-              try {
-                const response = await fetch('/api/wifi/networks');
-                const data = await response.json();
-                if (data.scanning) {
-                  statusEl.textContent = 'Scanning for networks...';
-                  setTimeout(loadNetworks, 1500);
-                  return;
-                }
-                ssidList.innerHTML = '<option value="">Select network...</option>';
-                data.networks.forEach((network) => {
-                  const option = document.createElement('option');
-                  option.value = network.ssid;
-                  option.textContent = `${network.ssid} (${network.rssi} dBm)`;
-                  ssidList.appendChild(option);
-                });
-                statusEl.textContent = data.networks.length ? 'Choose a network or type one manually.' : 'No networks found. Type the network name manually.';
-              } catch (error) {
-                statusEl.textContent = 'Unable to read network list. Type the network name manually.';
-              }
-            }
-
-            async function pollConnection() {
-              try {
-                const response = await fetch('/api/wifi/status');
-                const data = await response.json();
-                if (data.connected) {
-                  statusEl.textContent = `Connected to ${data.ssid}. Open ${data.ip_address}:81/app from your browser.`;
-                  return;
-                }
-                if (data.error) {
-                  const messages = {
-                    connect_failed: 'Unable to connect. Check the password and try again.',
-                    network_not_found: 'Network not found. Check the network name and try again.',
-                    timeout: 'Connection timed out. Check the password or move closer to the router.'
-                  };
-                  statusEl.textContent = messages[data.error] || 'Unable to connect. Check the network details and try again.';
-                  return;
-                }
-                statusEl.textContent = data.target_ssid ? `Trying to connect to ${data.target_ssid}...` : 'Trying to connect...';
-                setTimeout(pollConnection, 1500);
-              } catch (error) {
-                statusEl.textContent = 'Trying to connect...';
-                setTimeout(pollConnection, 2000);
-              }
-            }
-
-            form.addEventListener('submit', async (event) => {
-              event.preventDefault();
-              const ssid = ssidInput.value.trim();
-              if (!ssid) {
-                statusEl.textContent = 'Enter a network name.';
-                return;
-              }
-              statusEl.textContent = 'Saving credentials...';
-              try {
-                await fetch('/api/wifi/connect', {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ ssid, password: passwordInput.value })
-                });
-                pollConnection();
-              } catch (error) {
-                statusEl.textContent = 'Unable to save network details. Try again.';
-              }
-            });
-
-            loadNetworks();
-          </script>
-        </body>
-      </html>
-    )");
+    sendNoStoreHeaders(target);
+    static constexpr char WIFI_SETUP_PAGE[] = R"leafhtml(<!doctype html><html><head><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf WiFi</title><style>body{margin:0;background:#f5f7f2;color:#172016;font:16px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}h1{margin:0;padding:18px 20px;background:#172016;color:white;font-size:24px}main{padding:20px;max-width:560px;margin:auto}label{display:block;font-weight:650;margin:14px 0 6px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:12px;border:1px solid #bac3b4;border-radius:6px}button{margin-top:16px;background:#172016;color:white;font-weight:700}.status{border-bottom:1px solid #d9dfd3;color:#596256;padding-bottom:14px}.row{display:flex;gap:10px}.row input{flex:1}.show{display:flex;align-items:center;gap:6px;width:auto;white-space:nowrap}.show input{width:auto}</style><script>async function init(){let s=document.getElementById('s'),l=document.getElementById('l'),n=document.getElementById('n'),p=document.getElementById('p'),w=document.getElementById('w'),f=document.getElementById('f');l.onchange=()=>{if(l.value)n.value=l.value};w.onchange=()=>p.type=w.checked?'text':'password';async function nets(){try{let d=await(await fetch('/api/wifi/networks')).json();l.innerHTML='<option value="">Select network...</option>';d.networks.forEach(x=>{let o=document.createElement('option');o.value=x.ssid;o.textContent=x.ssid+' ('+x.rssi+' dBm)';l.appendChild(o)});s.textContent=d.networks.length?'Choose a network or type one manually.':'No networks found. Type the network name manually.'}catch(e){s.textContent='Unable to read network list. Type the network name manually.'}}async function poll(){try{let d=await(await fetch('/api/wifi/status')).json();if(d.connected){s.textContent='Connected to '+d.ssid+'. Open '+d.ip_address+':81/app';return}if(d.error){s.textContent='Unable to connect. Check password and try again.';return}s.textContent=d.target_ssid?'Trying to connect to '+d.target_ssid+'...':'Trying to connect...';setTimeout(poll,1500)}catch(e){s.textContent='Trying to connect...';setTimeout(poll,2000)}}f.onsubmit=async e=>{e.preventDefault();let ssid=n.value.trim();if(!ssid){s.textContent='Enter a network name.';return}s.textContent='Saving credentials...';try{await fetch('/api/wifi/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:ssid,password:p.value})});poll()}catch(x){s.textContent='Unable to save network details. Try again.'}};nets()}</script></head><body onload=init()><h1>Leaf WiFi Setup</h1><main><p class=status id=s>Loading...</p><form id=f><label>Network</label><select id=l><option>Select network...</option></select><input id=n autocomplete=off placeholder="Type network name"><label>Password</label><div class=row><input id=p type=password autocomplete=current-password><label class=show><input id=w type=checkbox>Show</label></div><button>Save and Connect</button></form></main></body></html>)leafhtml";
+    target.send(200, "text/html", WIFI_SETUP_PAGE);
   }
 
   void sendUserStatus(WebServer& target) {
@@ -754,41 +573,42 @@ namespace {
     json += "\",\"firmware_version\":\"";
     json += LeafVersionInfo::firmwareVersion();
     json += "\"}";
+    sendNoStoreHeaders(target);
     target.send(200, "application/json", json);
   }
 
-  void startWifiScan() {
-    WiFi.scanDelete();
-    const int16_t result = WiFi.scanNetworks(/*async=*/true, /*hidden=*/false);
-    if (result != WIFI_SCAN_RUNNING) {
-      Serial.printf("Leaf WiFi setup scan did not start: %d\n", result);
-    } else {
-      wifi_setup_scan_started = true;
-    }
-  }
-
-  void sendWifiNetworks(WebServer& target) {
-    if (!wifi_setup_scan_started) {
-      startWifiScan();
-      target.send(200, "application/json", "{\"scanning\":true,\"networks\":[]}");
-      return;
+  String wifiNetworksJsonFromScan(int16_t scan_result) {
+    if (scan_result < 0) {
+      return "{\"scanning\":false,\"networks\":[]}";
     }
 
-    int16_t scan_result = WiFi.scanComplete();
-    if (scan_result == WIFI_SCAN_RUNNING) {
-      target.send(200, "application/json", "{\"scanning\":true,\"networks\":[]}");
-      return;
-    }
+    static constexpr int16_t MAX_WIFI_SETUP_NETWORKS = 10;
+    int16_t top_indices[MAX_WIFI_SETUP_NETWORKS];
+    int32_t top_rssi[MAX_WIFI_SETUP_NETWORKS];
+    int16_t top_count = 0;
 
-    if (scan_result == WIFI_SCAN_FAILED || scan_result < 0) {
-      startWifiScan();
-      target.send(200, "application/json", "{\"scanning\":true,\"networks\":[]}");
-      return;
+    for (int16_t i = 0; i < scan_result; i++) {
+      const int32_t rssi = WiFi.RSSI(i);
+      int16_t insert_at = top_count;
+      while (insert_at > 0 && rssi > top_rssi[insert_at - 1]) {
+        insert_at--;
+      }
+      if (insert_at >= MAX_WIFI_SETUP_NETWORKS) continue;
+
+      const int16_t limit = top_count < MAX_WIFI_SETUP_NETWORKS ? top_count : MAX_WIFI_SETUP_NETWORKS - 1;
+      for (int16_t j = limit; j > insert_at; j--) {
+        top_indices[j] = top_indices[j - 1];
+        top_rssi[j] = top_rssi[j - 1];
+      }
+      top_indices[insert_at] = i;
+      top_rssi[insert_at] = rssi;
+      if (top_count < MAX_WIFI_SETUP_NETWORKS) top_count++;
     }
 
     String json = "{\"scanning\":false,\"networks\":[";
-    for (int16_t i = 0; i < scan_result; i++) {
-      if (i > 0) json += ",";
+    for (int16_t top_i = 0; top_i < top_count; top_i++) {
+      const int16_t i = top_indices[top_i];
+      if (top_i > 0) json += ",";
       json += "{\"ssid\":\"";
       json += jsonEscape(WiFi.SSID(i));
       json += "\",\"rssi\":";
@@ -798,7 +618,28 @@ namespace {
       json += "}";
     }
     json += "]}";
-    target.send(200, "application/json", json);
+    return json;
+  }
+
+  void buildWifiNetworkCache() {
+    WiFi.scanDelete();
+    const int16_t result = WiFi.scanNetworks(/*async=*/false, /*hidden=*/false);
+    if (result < 0) {
+      Serial.printf("Leaf WiFi setup scan failed: %d\n", result);
+    }
+    wifi_setup_networks_json = wifiNetworksJsonFromScan(result);
+    Serial.printf("Leaf WiFi setup cycle %lu: scan=%d cachedJson=%u heap=%u maxAlloc=%u\n",
+                  static_cast<unsigned long>(wifi_setup_cycle),
+                  result,
+                  wifi_setup_networks_json.length(),
+                  ESP.getFreeHeap(),
+                  ESP.getMaxAllocHeap());
+    WiFi.scanDelete();
+  }
+
+  void sendWifiNetworks(WebServer& target) {
+    sendNoStoreHeaders(target);
+    target.send(200, "application/json", wifi_setup_networks_json);
   }
 
   void connectToWifiFromRequest(WebServer& target) {
@@ -826,27 +667,31 @@ namespace {
   void setupUserAppServer() {
     if (user_server_started) return;
 
-    user_server.on("/", HTTP_GET, []() {
-      sendRedirect(user_server, user_app_provisioning ? "/app/wifi" : "/app");
-    });
-    user_server.on("/app", HTTP_GET, []() { sendUserAppShell(user_server); });
-    user_server.on("/app/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
-    user_server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(user_server); });
-    user_server.on("/api/wifi/status", HTTP_GET, []() { user_server.send(200, "application/json", wifiStatusJson()); });
-    user_server.on("/api/wifi/networks", HTTP_GET, []() { sendWifiNetworks(user_server); });
-    user_server.on("/api/wifi/connect", HTTP_POST, []() { connectToWifiFromRequest(user_server); });
-    user_server.on("/generate_204", HTTP_GET, []() { sendNoCaptivePortalResponse(user_server); });
-    user_server.on("/gen_204", HTTP_GET, []() { sendNoCaptivePortalResponse(user_server); });
-    user_server.on("/hotspot-detect.html", HTTP_GET,
-                   []() { sendNoCaptivePortalResponse(user_server, "Success"); });
-    user_server.on("/library/test/success.html", HTTP_GET,
-                   []() { sendNoCaptivePortalResponse(user_server, "Success"); });
-    user_server.on("/ncsi.txt", HTTP_GET,
-                   []() { sendNoCaptivePortalResponse(user_server, "Microsoft NCSI"); });
-    user_server.onNotFound([]() {
-      if (handleCaptivePortalRequest(user_server)) return;
-      user_server.send(404, "text/plain", "Not found");
-    });
+    if (!user_server_routes_configured) {
+      user_server.on("/", HTTP_GET, []() {
+        sendRedirect(user_server, user_app_provisioning ? "/app/wifi" : "/app");
+      });
+      user_server.on("/app", HTTP_GET, []() { sendUserAppShell(user_server); });
+      user_server.on("/app/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
+      user_server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(user_server); });
+      user_server.on("/api/wifi/status", HTTP_GET, []() { user_server.send(200, "application/json", wifiStatusJson()); });
+      user_server.on("/api/wifi/networks", HTTP_GET, []() { sendWifiNetworks(user_server); });
+      user_server.on("/api/wifi/connect", HTTP_POST, []() { connectToWifiFromRequest(user_server); });
+      user_server.on("/generate_204", HTTP_GET, []() { sendNoCaptivePortalResponse(user_server); });
+      user_server.on("/gen_204", HTTP_GET, []() { sendNoCaptivePortalResponse(user_server); });
+      user_server.on("/hotspot-detect.html", HTTP_GET,
+                     []() { sendNoCaptivePortalResponse(user_server, "Success"); });
+      user_server.on("/library/test/success.html", HTTP_GET,
+                     []() { sendNoCaptivePortalResponse(user_server, "Success"); });
+      user_server.on("/ncsi.txt", HTTP_GET,
+                     []() { sendNoCaptivePortalResponse(user_server, "Microsoft NCSI"); });
+      user_server.onNotFound([]() {
+        if (handleCaptivePortalRequest(user_server)) return;
+        user_server.send(404, "text/plain", "Not found");
+      });
+      user_server_routes_configured = true;
+    }
+
     user_server.begin();
     user_server_started = true;
     Serial.printf("Leaf Web App started: %s\n", userAppUrl().c_str());
@@ -1139,6 +984,7 @@ void webserver_loop() {
 
 void webserver_enable_user_app(bool useLeafWifi) {
   if (useLeafWifi || WiFi.status() != WL_CONNECTED) {
+    leaf_wifi::prepareForLeafAccessPoint();
     WiFi.mode(WIFI_AP);
     WiFi.setSleep(false);
     WiFi.softAP("Leaf WiFi");
@@ -1154,16 +1000,17 @@ void webserver_enable_user_app(bool useLeafWifi) {
 }
 
 void webserver_enable_wifi_setup() {
+  wifi_setup_cycle++;
+  leaf_wifi::prepareForUserWifiSetup();
+  buildWifiNetworkCache();
   WiFi.mode(WIFI_AP_STA);
   WiFi.setSleep(false);
   WiFi.softAP("Leaf WiFi");
   user_app_enabled = true;
   user_app_using_leaf_wifi = true;
   user_app_provisioning = true;
-  wifi_setup_scan_started = false;
   setupUserAppServer();
   dns_server.start(53, "*", WiFi.softAPIP());
-  startWifiScan();
   webserver_setup();
   Serial.printf("Leaf WiFi setup started: http://%s/app/wifi\n", WiFi.softAPIP().toString().c_str());
 }
@@ -1172,7 +1019,7 @@ void webserver_disable_user_app() {
   user_app_enabled = false;
   if (user_app_provisioning) dns_server.stop();
   user_app_provisioning = false;
-  wifi_setup_scan_started = false;
+  wifi_setup_networks_json = "{\"scanning\":false,\"networks\":[]}";
   wifi_setup_connecting = false;
   wifi_setup_connect_ssid = "";
   wifi_setup_connect_error = "";

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -1,6 +1,6 @@
 #include "comms/webserver.h"
-#include <FS.h>
 #include <DNSServer.h>
+#include <FS.h>
 #include <SD_MMC.h>
 #include <WebServer.h>
 #include <WiFi.h>
@@ -51,10 +51,8 @@ namespace {
   void logWifiSetupTiming(const char* event) {
     Serial.printf("Leaf WiFi setup cycle %lu +%lums: %s heap=%u maxAlloc=%u\n",
                   static_cast<unsigned long>(wifi_setup_cycle),
-                  static_cast<unsigned long>(millis() - wifi_setup_started_ms),
-                  event,
-                  ESP.getFreeHeap(),
-                  ESP.getMaxAllocHeap());
+                  static_cast<unsigned long>(millis() - wifi_setup_started_ms), event,
+                  ESP.getFreeHeap(), ESP.getMaxAllocHeap());
   }
 
   const char* selfTestModeName(SelfTestMode mode) {
@@ -407,7 +405,8 @@ namespace {
     json += ",\"connecting\":";
     json += wifi_setup_connecting ? "true" : "false";
     json += ",\"ssid\":\"";
-    json += jsonEscape(WiFi.SSID().isEmpty() && status == WL_CONNECTED ? wifi_setup_connect_ssid : WiFi.SSID());
+    json += jsonEscape(WiFi.SSID().isEmpty() && status == WL_CONNECTED ? wifi_setup_connect_ssid
+                                                                       : WiFi.SSID());
     json += "\",\"target_ssid\":\"";
     json += jsonEscape(wifi_setup_connect_ssid);
     json += "\",\"ip_address\":\"";
@@ -572,7 +571,8 @@ namespace {
     }
 
     sendNoStoreHeaders(target);
-    static constexpr char WIFI_SETUP_PAGE[] = R"leafhtml(<!doctype html><html><head><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf WiFi</title><style>body{margin:0;background:#f5f7f2;color:#172016;font:16px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}h1{margin:0;padding:18px 20px;background:#172016;color:white;font-size:24px}main{padding:20px;max-width:560px;margin:auto}label{display:block;font-weight:650;margin:14px 0 6px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:12px;border:1px solid #bac3b4;border-radius:6px}button{margin-top:16px;background:#172016;color:white;font-weight:700}.status{border-bottom:1px solid #d9dfd3;color:#596256;padding-bottom:14px}.row{display:flex;gap:10px}.row input{flex:1}.show{display:flex;align-items:center;gap:6px;width:auto;white-space:nowrap}.show input{width:auto}</style><script>async function init(){let s=document.getElementById('s'),l=document.getElementById('l'),n=document.getElementById('n'),p=document.getElementById('p'),w=document.getElementById('w'),f=document.getElementById('f');l.onchange=()=>{if(l.value)n.value=l.value};w.onchange=()=>p.type=w.checked?'text':'password';async function nets(){try{let d=await(await fetch('/api/wifi/networks')).json();if(d.scanning){s.textContent='Scanning for networks...';setTimeout(nets,1500);return}l.innerHTML='<option value="">Select network...</option>';d.networks.forEach(x=>{let o=document.createElement('option');o.value=x.ssid;o.textContent=x.ssid+' ('+x.rssi+' dBm)';l.appendChild(o)});s.textContent=d.networks.length?'Choose a network or type one manually.':'No networks found. Type the network name manually.'}catch(e){s.textContent='Unable to read network list. Type the network name manually.'}}async function poll(){try{let d=await(await fetch('/api/wifi/status')).json();if(d.connected){s.textContent='Connected to '+d.ssid+'. Open '+d.ip_address+':81/app';return}if(d.error){s.textContent='Unable to connect. Check password and try again.';return}s.textContent=d.target_ssid?'Trying to connect to '+d.target_ssid+'...':'Trying to connect...';setTimeout(poll,1500)}catch(e){s.textContent='Trying to connect...';setTimeout(poll,2000)}}f.onsubmit=async e=>{e.preventDefault();let ssid=n.value.trim();if(!ssid){s.textContent='Enter a network name.';return}s.textContent='Saving credentials...';try{await fetch('/api/wifi/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:ssid,password:p.value})});poll()}catch(x){s.textContent='Unable to save network details. Try again.'}};nets()}</script></head><body onload=init()><h1>Leaf WiFi Setup</h1><main><p class=status id=s>Loading...</p><form id=f><label>Network</label><select id=l><option>Select network...</option></select><input id=n autocomplete=off placeholder="Type network name"><label>Password</label><div class=row><input id=p type=password autocomplete=current-password><label class=show><input id=w type=checkbox>Show</label></div><button>Save and Connect</button></form></main></body></html>)leafhtml";
+    static constexpr char WIFI_SETUP_PAGE[] =
+        R"leafhtml(<!doctype html><html><head><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf WiFi</title><style>body{margin:0;background:#f5f7f2;color:#172016;font:16px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}h1{margin:0;padding:18px 20px;background:#172016;color:white;font-size:24px}main{padding:20px;max-width:560px;margin:auto}label{display:block;font-weight:650;margin:14px 0 6px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:12px;border:1px solid #bac3b4;border-radius:6px}button{margin-top:16px;background:#172016;color:white;font-weight:700}.status{border-bottom:1px solid #d9dfd3;color:#596256;padding-bottom:14px}.row{display:flex;gap:10px}.row input{flex:1}.show{display:flex;align-items:center;gap:6px;width:auto;white-space:nowrap}.show input{width:auto}</style><script>async function init(){let s=document.getElementById('s'),l=document.getElementById('l'),n=document.getElementById('n'),p=document.getElementById('p'),w=document.getElementById('w'),f=document.getElementById('f');l.onchange=()=>{if(l.value)n.value=l.value};w.onchange=()=>p.type=w.checked?'text':'password';async function nets(){try{let d=await(await fetch('/api/wifi/networks')).json();if(d.scanning){s.textContent='Scanning for networks...';setTimeout(nets,1500);return}l.innerHTML='<option value="">Select network...</option>';d.networks.forEach(x=>{let o=document.createElement('option');o.value=x.ssid;o.textContent=x.ssid+' ('+x.rssi+' dBm)';l.appendChild(o)});s.textContent=d.networks.length?'Choose a network or type one manually.':'No networks found. Type the network name manually.'}catch(e){s.textContent='Unable to read network list. Type the network name manually.'}}async function poll(){try{let d=await(await fetch('/api/wifi/status')).json();if(d.connected){s.textContent='Connected to '+d.ssid+'. Open '+d.ip_address+':81/app';return}if(d.error){s.textContent='Unable to connect. Check password and try again.';return}s.textContent=d.target_ssid?'Trying to connect to '+d.target_ssid+'...':'Trying to connect...';setTimeout(poll,1500)}catch(e){s.textContent='Trying to connect...';setTimeout(poll,2000)}}f.onsubmit=async e=>{e.preventDefault();let ssid=n.value.trim();if(!ssid){s.textContent='Enter a network name.';return}s.textContent='Saving credentials...';try{await fetch('/api/wifi/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:ssid,password:p.value})});poll()}catch(x){s.textContent='Unable to save network details. Try again.'}};nets()}</script></head><body onload=init()><h1>Leaf WiFi Setup</h1><main><p class=status id=s>Loading...</p><form id=f><label>Network</label><select id=l><option>Select network...</option></select><input id=n autocomplete=off placeholder="Type network name"><label>Password</label><div class=row><input id=p type=password autocomplete=current-password><label class=show><input id=w type=checkbox>Show</label></div><button>Save and Connect</button></form></main></body></html>)leafhtml";
     target.send(200, "text/html", WIFI_SETUP_PAGE);
   }
 
@@ -615,7 +615,8 @@ namespace {
       }
       if (insert_at >= MAX_WIFI_SETUP_NETWORKS) continue;
 
-      const int16_t limit = top_count < MAX_WIFI_SETUP_NETWORKS ? top_count : MAX_WIFI_SETUP_NETWORKS - 1;
+      const int16_t limit =
+          top_count < MAX_WIFI_SETUP_NETWORKS ? top_count : MAX_WIFI_SETUP_NETWORKS - 1;
       for (int16_t j = limit; j > insert_at; j--) {
         top_indices[j] = top_indices[j - 1];
         top_rssi[j] = top_rssi[j - 1];
@@ -648,11 +649,8 @@ namespace {
     wifi_setup_networks_json = wifiNetworksJsonFromScan(result);
     Serial.printf("Leaf WiFi setup cycle %lu +%lums: scan=%d cachedJson=%u heap=%u maxAlloc=%u\n",
                   static_cast<unsigned long>(wifi_setup_cycle),
-                  static_cast<unsigned long>(millis() - wifi_setup_started_ms),
-                  result,
-                  wifi_setup_networks_json.length(),
-                  ESP.getFreeHeap(),
-                  ESP.getMaxAllocHeap());
+                  static_cast<unsigned long>(millis() - wifi_setup_started_ms), result,
+                  wifi_setup_networks_json.length(), ESP.getFreeHeap(), ESP.getMaxAllocHeap());
     WiFi.scanDelete();
   }
 
@@ -712,16 +710,17 @@ namespace {
     if (user_server_started) return;
 
     if (!user_server_routes_configured) {
-      user_server.on("/", HTTP_GET, []() {
-        sendRedirect(user_server, user_app_provisioning ? "/wifi" : "/app");
-      });
+      user_server.on("/", HTTP_GET,
+                     []() { sendRedirect(user_server, user_app_provisioning ? "/wifi" : "/app"); });
       user_server.on("/app", HTTP_GET, []() { sendUserAppShell(user_server); });
       user_server.on("/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
       user_server.on("/app/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
       user_server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(user_server); });
-      user_server.on("/api/wifi/status", HTTP_GET, []() { user_server.send(200, "application/json", wifiStatusJson()); });
+      user_server.on("/api/wifi/status", HTTP_GET,
+                     []() { user_server.send(200, "application/json", wifiStatusJson()); });
       user_server.on("/api/wifi/networks", HTTP_GET, []() { sendWifiNetworks(user_server); });
-      user_server.on("/api/wifi/connect", HTTP_POST, []() { connectToWifiFromRequest(user_server); });
+      user_server.on("/api/wifi/connect", HTTP_POST,
+                     []() { connectToWifiFromRequest(user_server); });
       user_server.on("/generate_204", HTTP_GET, []() { sendNoCaptivePortalResponse(user_server); });
       user_server.on("/gen_204", HTTP_GET, []() { sendNoCaptivePortalResponse(user_server); });
       user_server.on("/hotspot-detect.html", HTTP_GET,
@@ -910,13 +909,9 @@ void webserver_setup() {
 
   server.on("/memory", HTTP_GET, []() { server.send(200, "text/plain", getMemoryUsage()); });
 
-  server.on("/app", HTTP_GET, []() {
-    sendUserAppShell(server);
-  });
+  server.on("/app", HTTP_GET, []() { sendUserAppShell(server); });
 
-  server.on("/api/user/status", HTTP_GET, []() {
-    sendUserStatus(server);
-  });
+  server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(server); });
 
   server.on("/mac-address", HTTP_GET, []() {
     String json = "{\"mac_address\":\"";
@@ -1092,6 +1087,4 @@ void webserver_disable_user_app() {
 
 bool webserver_user_app_active() { return user_app_enabled; }
 
-String webserver_user_app_url() {
-  return userAppUrl();
-}
+String webserver_user_app_url() { return userAppUrl(); }

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -28,10 +28,15 @@ namespace {
   bool user_app_using_leaf_wifi = false;
   bool user_app_provisioning = false;
   bool wifi_setup_scan_started = false;
+  bool wifi_setup_connecting = false;
+  uint32_t wifi_setup_connect_started_ms = 0;
+  String wifi_setup_connect_ssid = "";
+  String wifi_setup_connect_error = "";
 
   enum class SelfTestMode { None, Interactive };
 
   static constexpr uint32_t SELF_TEST_POWER_ON_DELAY_MS = 10000;
+  static constexpr uint32_t WIFI_SETUP_CONNECT_TIMEOUT_MS = 12000;
 
   SelfTestMode last_self_test_mode = SelfTestMode::None;
   bool interactive_self_test_pending = false;
@@ -336,19 +341,52 @@ namespace {
     return url;
   }
 
+  void stopFailedWifiSetupAttempt(const char* error) {
+    wifi_setup_connecting = false;
+    wifi_setup_connect_error = error;
+
+    // A failed WiFi.begin() can leave bad setup credentials saved and the STA
+    // side retrying. Stop that while keeping the Leaf AP available.
+    WiFi.disconnect(false, true);
+    WiFi.mode(WIFI_AP_STA);
+    WiFi.setSleep(false);
+    WiFi.softAP("Leaf WiFi");
+  }
+
   String wifiStatusJson() {
     wl_status_t status = WiFi.status();
+    if (wifi_setup_connecting && status == WL_CONNECTED) {
+      wifi_setup_connecting = false;
+      wifi_setup_connect_error = "";
+    } else if (wifi_setup_connecting && status == WL_CONNECT_FAILED) {
+      stopFailedWifiSetupAttempt("connect_failed");
+      status = WiFi.status();
+    } else if (wifi_setup_connecting && status == WL_NO_SSID_AVAIL) {
+      stopFailedWifiSetupAttempt("network_not_found");
+      status = WiFi.status();
+    } else if (wifi_setup_connecting &&
+               millis() - wifi_setup_connect_started_ms > WIFI_SETUP_CONNECT_TIMEOUT_MS) {
+      stopFailedWifiSetupAttempt("timeout");
+      status = WiFi.status();
+    }
+
     String json = "{\"status\":";
     json += (int)status;
     json += ",\"connected\":";
     json += status == WL_CONNECTED ? "true" : "false";
+    json += ",\"connecting\":";
+    json += wifi_setup_connecting ? "true" : "false";
     json += ",\"ssid\":\"";
     json += jsonEscape(WiFi.SSID());
+    json += "\",\"target_ssid\":\"";
+    json += jsonEscape(wifi_setup_connect_ssid);
     json += "\",\"ip_address\":\"";
     json += status == WL_CONNECTED ? WiFi.localIP().toString() : "";
     json += "\",\"setup_active\":";
     json += user_app_provisioning ? "true" : "false";
-    json += ",\"app_url\":\"";
+    json += ",\"error\":\"";
+    json += jsonEscape(wifi_setup_connect_error);
+    json += "\",\"app_url\":\"";
     json += userAppUrl();
     json += "\"}";
     return json;
@@ -655,7 +693,16 @@ namespace {
                   statusEl.textContent = `Connected to ${data.ssid}. Open ${data.ip_address}:81/app from your browser.`;
                   return;
                 }
-                statusEl.textContent = 'Trying to connect...';
+                if (data.error) {
+                  const messages = {
+                    connect_failed: 'Unable to connect. Check the password and try again.',
+                    network_not_found: 'Network not found. Check the network name and try again.',
+                    timeout: 'Connection timed out. Check the password or move closer to the router.'
+                  };
+                  statusEl.textContent = messages[data.error] || 'Unable to connect. Check the network details and try again.';
+                  return;
+                }
+                statusEl.textContent = data.target_ssid ? `Trying to connect to ${data.target_ssid}...` : 'Trying to connect...';
                 setTimeout(pollConnection, 1500);
               } catch (error) {
                 statusEl.textContent = 'Trying to connect...';
@@ -671,12 +718,16 @@ namespace {
                 return;
               }
               statusEl.textContent = 'Saving credentials...';
-              await fetch('/api/wifi/connect', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ ssid, password: passwordInput.value })
-              });
-              pollConnection();
+              try {
+                await fetch('/api/wifi/connect', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ ssid, password: passwordInput.value })
+                });
+                pollConnection();
+              } catch (error) {
+                statusEl.textContent = 'Unable to save network details. Try again.';
+              }
             });
 
             loadNetworks();
@@ -764,6 +815,10 @@ namespace {
     WiFi.setSleep(false);
     WiFi.persistent(true);
     WiFi.begin(ssid.c_str(), password.c_str());
+    wifi_setup_connecting = true;
+    wifi_setup_connect_started_ms = millis();
+    wifi_setup_connect_ssid = ssid;
+    wifi_setup_connect_error = "";
     Serial.printf("Leaf WiFi setup connecting to SSID: %s\n", ssid.c_str());
     target.send(202, "application/json", "{\"ok\":true}");
   }
@@ -1118,6 +1173,9 @@ void webserver_disable_user_app() {
   if (user_app_provisioning) dns_server.stop();
   user_app_provisioning = false;
   wifi_setup_scan_started = false;
+  wifi_setup_connecting = false;
+  wifi_setup_connect_ssid = "";
+  wifi_setup_connect_error = "";
   if (user_server_started) {
     user_server.stop();
     user_server_started = false;

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -18,8 +18,12 @@
 
 namespace {
   ::WebServer server;
+  ::WebServer user_server(80);
   String send_buffer = "";
   bool webserver_started = false;
+  bool user_server_started = false;
+  bool user_app_enabled = false;
+  bool user_app_using_leaf_wifi = false;
 
   enum class SelfTestMode { None, Interactive };
 
@@ -278,6 +282,162 @@ namespace {
     if (body.substring(value_start, value_start + 5) == "false") return false;
     return defaultValue;
   }
+
+  String userAppMode() {
+    if (!user_app_enabled) return "off";
+    if (user_app_using_leaf_wifi) return "leaf_wifi";
+    return "network";
+  }
+
+  String userAppAddress() {
+    if (!user_app_enabled) return "";
+    if (user_app_using_leaf_wifi) return WiFi.softAPIP().toString();
+    return WiFi.localIP().toString();
+  }
+
+  String userAppUrl() {
+    if (!user_app_enabled) return "";
+    String url = "http://";
+    url += userAppAddress();
+    url += "/app";
+    return url;
+  }
+
+  void sendUserAppShell(WebServer& target) {
+    if (!user_app_enabled) {
+      target.send(404, "text/plain", "Leaf Web App is not active.");
+      return;
+    }
+
+    target.send(200, "text/html", R"(
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>Leaf Web App</title>
+          <style>
+            :root {
+              color-scheme: light;
+              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+              line-height: 1.35;
+            }
+            body {
+              margin: 0;
+              background: #f5f7f2;
+              color: #172016;
+            }
+            header {
+              background: #172016;
+              color: white;
+              padding: 20px;
+            }
+            main {
+              max-width: 720px;
+              margin: 0 auto;
+              padding: 20px;
+            }
+            h1 {
+              font-size: 28px;
+              margin: 0;
+            }
+            h2 {
+              font-size: 18px;
+              margin: 0 0 8px;
+            }
+            section {
+              border-bottom: 1px solid #d9dfd3;
+              padding: 18px 0;
+            }
+            .status {
+              display: grid;
+              gap: 6px;
+              font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+              font-size: 14px;
+            }
+            .muted {
+              color: #596256;
+            }
+          </style>
+        </head>
+        <body>
+          <header>
+            <h1>Leaf Web App</h1>
+          </header>
+          <main>
+            <section>
+              <h2>Status</h2>
+              <div class="status" id="status">Loading...</div>
+            </section>
+            <section>
+              <h2>Settings</h2>
+              <p class="muted">Settings tools will be added here.</p>
+            </section>
+            <section>
+              <h2>Flight Logs</h2>
+              <p class="muted">Logbook tools will be added here.</p>
+            </section>
+            <section>
+              <h2>Waypoints & Routes</h2>
+              <p class="muted">Navigation file tools will be added here.</p>
+            </section>
+          </main>
+          <script>
+            async function loadStatus() {
+              const target = document.getElementById('status');
+              try {
+                const response = await fetch('/api/user/status');
+                const status = await response.json();
+                target.innerHTML = [
+                  `mode: ${status.mode}`,
+                  `ssid: ${status.ssid || '(none)'}`,
+                  `ip: ${status.ip_address || '(none)'}`,
+                  `firmware: ${status.firmware_version}`
+                ].join('<br>');
+              } catch (error) {
+                target.textContent = 'Unable to read status.';
+              }
+            }
+            loadStatus();
+          </script>
+        </body>
+      </html>
+    )");
+  }
+
+  void sendUserStatus(WebServer& target) {
+    if (!user_app_enabled) {
+      target.send(404, "application/json", "{\"active\":false}");
+      return;
+    }
+
+    String json = "{\"active\":true,\"mode\":\"";
+    json += userAppMode();
+    json += "\",\"ssid\":\"";
+    json += user_app_using_leaf_wifi ? "Leaf WiFi" : WiFi.SSID();
+    json += "\",\"ip_address\":\"";
+    json += userAppAddress();
+    json += "\",\"url\":\"";
+    json += userAppUrl();
+    json += "\",\"firmware_version\":\"";
+    json += LeafVersionInfo::firmwareVersion();
+    json += "\"}";
+    target.send(200, "application/json", json);
+  }
+
+  void setupUserAppServer() {
+    if (user_server_started) return;
+
+    user_server.on("/", HTTP_GET, []() {
+      user_server.sendHeader("Location", "/app", true);
+      user_server.send(302, "text/plain", "");
+    });
+    user_server.on("/app", HTTP_GET, []() { sendUserAppShell(user_server); });
+    user_server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(user_server); });
+    user_server.begin();
+    user_server_started = true;
+    Serial.printf("Leaf Web App started: %s\n", userAppUrl().c_str());
+  }
 }  // namespace
 
 constexpr auto endl = "\n";
@@ -288,7 +448,7 @@ void writeScreenshotBuffer(const char* buffer) {
 }
 
 void webserver_setup() {
-  if (WiFi.status() != WL_CONNECTED) return;
+  if (WiFi.status() != WL_CONNECTED && !user_app_enabled) return;
 
   if (webserver_started) return;
 
@@ -447,6 +607,14 @@ void webserver_setup() {
 
   server.on("/memory", HTTP_GET, []() { server.send(200, "text/plain", getMemoryUsage()); });
 
+  server.on("/app", HTTP_GET, []() {
+    sendUserAppShell(server);
+  });
+
+  server.on("/api/user/status", HTTP_GET, []() {
+    sendUserStatus(server);
+  });
+
   server.on("/mac-address", HTTP_GET, []() {
     String json = "{\"mac_address\":\"";
     json += settings.getMacAddress();
@@ -546,8 +714,43 @@ void webserver_setup() {
 }
 
 void webserver_loop() {
-  if (WiFi.status() == WL_CONNECTED) {
+  if (WiFi.status() == WL_CONNECTED || user_app_enabled) {
     server.handleClient();
+    if (user_app_enabled) user_server.handleClient();
     updatePendingInteractiveSelfTest();
   }
+}
+
+void webserver_enable_user_app(bool useLeafWifi) {
+  if (useLeafWifi || WiFi.status() != WL_CONNECTED) {
+    WiFi.mode(WIFI_AP);
+    WiFi.setSleep(false);
+    WiFi.softAP("Leaf WiFi");
+    user_app_using_leaf_wifi = true;
+  } else {
+    user_app_using_leaf_wifi = false;
+  }
+
+  user_app_enabled = true;
+  setupUserAppServer();
+  webserver_setup();
+}
+
+void webserver_disable_user_app() {
+  user_app_enabled = false;
+  if (user_server_started) {
+    user_server.stop();
+    user_server_started = false;
+  }
+  if (user_app_using_leaf_wifi) {
+    WiFi.softAPdisconnect(true);
+    WiFi.mode(WIFI_STA);
+  }
+  user_app_using_leaf_wifi = false;
+}
+
+bool webserver_user_app_active() { return user_app_enabled; }
+
+String webserver_user_app_url() {
+  return userAppUrl();
 }

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -1,5 +1,6 @@
 #include "comms/webserver.h"
 #include <FS.h>
+#include <DNSServer.h>
 #include <SD_MMC.h>
 #include <WebServer.h>
 #include <WiFi.h>
@@ -19,11 +20,14 @@
 namespace {
   ::WebServer server;
   ::WebServer user_server(80);
+  DNSServer dns_server;
   String send_buffer = "";
   bool webserver_started = false;
   bool user_server_started = false;
   bool user_app_enabled = false;
   bool user_app_using_leaf_wifi = false;
+  bool user_app_provisioning = false;
+  bool wifi_setup_scan_started = false;
 
   enum class SelfTestMode { None, Interactive };
 
@@ -251,15 +255,26 @@ namespace {
     }
     if (value_start >= body.length() || body[value_start] != '"') return "";
 
-    int value_end = value_start + 1;
-    while (value_end < body.length()) {
-      if (body[value_end] == '"' && body[value_end - 1] != '\\') {
-        return body.substring(value_start + 1, value_end);
+    String value;
+    for (int i = value_start + 1; i < body.length(); i++) {
+      const char c = body[i];
+      if (c == '"') break;
+      if (c == '\\' && i + 1 < body.length()) {
+        i++;
+        const char escaped = body[i];
+        if (escaped == 'n') {
+          value += '\n';
+        } else if (escaped == 'r') {
+          value += '\r';
+        } else {
+          value += escaped;
+        }
+      } else {
+        value += c;
       }
-      value_end++;
     }
 
-    return "";
+    return value;
   }
 
   bool extractJsonBoolValue(const String& body, const char* key, bool defaultValue = false) {
@@ -283,8 +298,26 @@ namespace {
     return defaultValue;
   }
 
+  String jsonEscape(const String& value) {
+    String escaped;
+    escaped.reserve(value.length() + 4);
+    for (uint16_t i = 0; i < value.length(); i++) {
+      const char c = value[i];
+      if (c == '"' || c == '\\') escaped += '\\';
+      if (c == '\n') {
+        escaped += "\\n";
+      } else if (c == '\r') {
+        escaped += "\\r";
+      } else {
+        escaped += c;
+      }
+    }
+    return escaped;
+  }
+
   String userAppMode() {
     if (!user_app_enabled) return "off";
+    if (user_app_provisioning) return "provisioning";
     if (user_app_using_leaf_wifi) return "leaf_wifi";
     return "network";
   }
@@ -301,6 +334,44 @@ namespace {
     url += userAppAddress();
     url += "/app";
     return url;
+  }
+
+  String wifiStatusJson() {
+    wl_status_t status = WiFi.status();
+    String json = "{\"status\":";
+    json += (int)status;
+    json += ",\"connected\":";
+    json += status == WL_CONNECTED ? "true" : "false";
+    json += ",\"ssid\":\"";
+    json += jsonEscape(WiFi.SSID());
+    json += "\",\"ip_address\":\"";
+    json += status == WL_CONNECTED ? WiFi.localIP().toString() : "";
+    json += "\",\"setup_active\":";
+    json += user_app_provisioning ? "true" : "false";
+    json += ",\"app_url\":\"";
+    json += userAppUrl();
+    json += "\"}";
+    return json;
+  }
+
+  void sendRedirect(WebServer& target, const char* location) {
+    target.sendHeader("Location", location, true);
+    target.send(302, "text/plain", "");
+  }
+
+  bool handleCaptivePortalRequest(WebServer& target) {
+    if (!user_app_provisioning) return false;
+    sendRedirect(target, "/app/wifi");
+    return true;
+  }
+
+  void sendNoCaptivePortalResponse(WebServer& target, const char* body = "") {
+    if (handleCaptivePortalRequest(target)) return;
+    if (strlen(body) == 0) {
+      target.send(204, "text/plain", "");
+    } else {
+      target.send(200, "text/plain", body);
+    }
   }
 
   void sendUserAppShell(WebServer& target) {
@@ -348,6 +419,26 @@ namespace {
             section {
               border-bottom: 1px solid #d9dfd3;
               padding: 18px 0;
+            }
+            label {
+              display: block;
+              font-size: 14px;
+              font-weight: 650;
+              margin: 14px 0 6px;
+            }
+            input, select, button {
+              box-sizing: border-box;
+              width: 100%;
+              border: 1px solid #bac3b4;
+              border-radius: 6px;
+              font: inherit;
+              padding: 12px;
+            }
+            button {
+              background: #172016;
+              color: white;
+              font-weight: 700;
+              margin-top: 16px;
             }
             .status {
               display: grid;
@@ -405,6 +496,196 @@ namespace {
     )");
   }
 
+  void sendWifiSetupPage(WebServer& target) {
+    if (!user_app_enabled) {
+      target.send(404, "text/plain", "Leaf Web App is not active.");
+      return;
+    }
+
+    target.send(200, "text/html", R"(
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>Leaf WiFi Setup</title>
+          <style>
+            :root {
+              color-scheme: light;
+              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+              line-height: 1.35;
+            }
+            body {
+              margin: 0;
+              background: #f5f7f2;
+              color: #172016;
+            }
+            header {
+              background: #172016;
+              color: white;
+              padding: 18px 20px;
+            }
+            main {
+              max-width: 560px;
+              margin: 0 auto;
+              padding: 20px;
+            }
+            h1 {
+              font-size: 24px;
+              margin: 0;
+            }
+            label {
+              display: block;
+              font-size: 14px;
+              font-weight: 650;
+              margin: 14px 0 6px;
+            }
+            input, select, button {
+              box-sizing: border-box;
+              width: 100%;
+              border: 1px solid #bac3b4;
+              border-radius: 6px;
+              font: inherit;
+              padding: 12px;
+            }
+            button {
+              background: #172016;
+              color: white;
+              font-weight: 700;
+              margin-top: 16px;
+            }
+            .status {
+              border-bottom: 1px solid #d9dfd3;
+              color: #596256;
+              font-size: 14px;
+              margin-bottom: 18px;
+              padding-bottom: 16px;
+            }
+            .manual {
+              margin-top: 10px;
+            }
+            .password-row {
+              display: flex;
+              gap: 10px;
+            }
+            .password-row input {
+              flex: 1;
+              min-width: 0;
+            }
+            .show-password {
+              align-items: center;
+              border: 1px solid #bac3b4;
+              border-radius: 6px;
+              display: flex;
+              gap: 6px;
+              padding: 0 10px;
+              white-space: nowrap;
+            }
+            .show-password input {
+              width: auto;
+            }
+          </style>
+        </head>
+        <body>
+          <header>
+            <h1>Leaf WiFi Setup</h1>
+          </header>
+          <main>
+            <div class="status" id="status">Scanning for networks...</div>
+            <form id="wifi-form">
+              <label for="ssid-list">Network</label>
+              <select id="ssid-list">
+                <option value="">Select network...</option>
+              </select>
+              <input class="manual" id="ssid" name="ssid" autocomplete="off" placeholder="Type network name">
+              <label for="password">Password</label>
+              <div class="password-row">
+                <input id="password" name="password" type="password" autocomplete="current-password">
+                <label class="show-password">
+                  <input id="show-password" type="checkbox">
+                  Show
+                </label>
+              </div>
+              <button type="submit">Save and Connect</button>
+            </form>
+          </main>
+          <script>
+            const statusEl = document.getElementById('status');
+            const ssidList = document.getElementById('ssid-list');
+            const ssidInput = document.getElementById('ssid');
+            const passwordInput = document.getElementById('password');
+            const showPasswordInput = document.getElementById('show-password');
+            const form = document.getElementById('wifi-form');
+
+            ssidList.addEventListener('change', () => {
+              if (ssidList.value) ssidInput.value = ssidList.value;
+            });
+
+            showPasswordInput.addEventListener('change', () => {
+              passwordInput.type = showPasswordInput.checked ? 'text' : 'password';
+            });
+
+            async function loadNetworks() {
+              try {
+                const response = await fetch('/api/wifi/networks');
+                const data = await response.json();
+                if (data.scanning) {
+                  statusEl.textContent = 'Scanning for networks...';
+                  setTimeout(loadNetworks, 1500);
+                  return;
+                }
+                ssidList.innerHTML = '<option value="">Select network...</option>';
+                data.networks.forEach((network) => {
+                  const option = document.createElement('option');
+                  option.value = network.ssid;
+                  option.textContent = `${network.ssid} (${network.rssi} dBm)`;
+                  ssidList.appendChild(option);
+                });
+                statusEl.textContent = data.networks.length ? 'Choose a network or type one manually.' : 'No networks found. Type the network name manually.';
+              } catch (error) {
+                statusEl.textContent = 'Unable to read network list. Type the network name manually.';
+              }
+            }
+
+            async function pollConnection() {
+              try {
+                const response = await fetch('/api/wifi/status');
+                const data = await response.json();
+                if (data.connected) {
+                  statusEl.textContent = `Connected to ${data.ssid}. Open ${data.ip_address}:81/app from your browser.`;
+                  return;
+                }
+                statusEl.textContent = 'Trying to connect...';
+                setTimeout(pollConnection, 1500);
+              } catch (error) {
+                statusEl.textContent = 'Trying to connect...';
+                setTimeout(pollConnection, 2000);
+              }
+            }
+
+            form.addEventListener('submit', async (event) => {
+              event.preventDefault();
+              const ssid = ssidInput.value.trim();
+              if (!ssid) {
+                statusEl.textContent = 'Enter a network name.';
+                return;
+              }
+              statusEl.textContent = 'Saving credentials...';
+              await fetch('/api/wifi/connect', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ssid, password: passwordInput.value })
+              });
+              pollConnection();
+            });
+
+            loadNetworks();
+          </script>
+        </body>
+      </html>
+    )");
+  }
+
   void sendUserStatus(WebServer& target) {
     if (!user_app_enabled) {
       target.send(404, "application/json", "{\"active\":false}");
@@ -414,7 +695,7 @@ namespace {
     String json = "{\"active\":true,\"mode\":\"";
     json += userAppMode();
     json += "\",\"ssid\":\"";
-    json += user_app_using_leaf_wifi ? "Leaf WiFi" : WiFi.SSID();
+    json += jsonEscape(user_app_using_leaf_wifi ? "Leaf WiFi" : WiFi.SSID());
     json += "\",\"ip_address\":\"";
     json += userAppAddress();
     json += "\",\"url\":\"";
@@ -425,15 +706,92 @@ namespace {
     target.send(200, "application/json", json);
   }
 
+  void startWifiScan() {
+    WiFi.scanDelete();
+    const int16_t result = WiFi.scanNetworks(/*async=*/true, /*hidden=*/false);
+    if (result != WIFI_SCAN_RUNNING) {
+      Serial.printf("Leaf WiFi setup scan did not start: %d\n", result);
+    } else {
+      wifi_setup_scan_started = true;
+    }
+  }
+
+  void sendWifiNetworks(WebServer& target) {
+    if (!wifi_setup_scan_started) {
+      startWifiScan();
+      target.send(200, "application/json", "{\"scanning\":true,\"networks\":[]}");
+      return;
+    }
+
+    int16_t scan_result = WiFi.scanComplete();
+    if (scan_result == WIFI_SCAN_RUNNING) {
+      target.send(200, "application/json", "{\"scanning\":true,\"networks\":[]}");
+      return;
+    }
+
+    if (scan_result == WIFI_SCAN_FAILED || scan_result < 0) {
+      startWifiScan();
+      target.send(200, "application/json", "{\"scanning\":true,\"networks\":[]}");
+      return;
+    }
+
+    String json = "{\"scanning\":false,\"networks\":[";
+    for (int16_t i = 0; i < scan_result; i++) {
+      if (i > 0) json += ",";
+      json += "{\"ssid\":\"";
+      json += jsonEscape(WiFi.SSID(i));
+      json += "\",\"rssi\":";
+      json += WiFi.RSSI(i);
+      json += ",\"secure\":";
+      json += WiFi.encryptionType(i) == WIFI_AUTH_OPEN ? "false" : "true";
+      json += "}";
+    }
+    json += "]}";
+    target.send(200, "application/json", json);
+  }
+
+  void connectToWifiFromRequest(WebServer& target) {
+    const String body = target.arg("plain");
+    const String ssid = extractJsonStringValue(body, "ssid");
+    const String password = extractJsonStringValue(body, "password");
+
+    if (ssid.isEmpty()) {
+      target.send(400, "application/json", "{\"ok\":false,\"error\":\"missing_ssid\"}");
+      return;
+    }
+
+    WiFi.mode(WIFI_AP_STA);
+    WiFi.setSleep(false);
+    WiFi.persistent(true);
+    WiFi.begin(ssid.c_str(), password.c_str());
+    Serial.printf("Leaf WiFi setup connecting to SSID: %s\n", ssid.c_str());
+    target.send(202, "application/json", "{\"ok\":true}");
+  }
+
   void setupUserAppServer() {
     if (user_server_started) return;
 
     user_server.on("/", HTTP_GET, []() {
-      user_server.sendHeader("Location", "/app", true);
-      user_server.send(302, "text/plain", "");
+      sendRedirect(user_server, user_app_provisioning ? "/app/wifi" : "/app");
     });
     user_server.on("/app", HTTP_GET, []() { sendUserAppShell(user_server); });
+    user_server.on("/app/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
     user_server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(user_server); });
+    user_server.on("/api/wifi/status", HTTP_GET, []() { user_server.send(200, "application/json", wifiStatusJson()); });
+    user_server.on("/api/wifi/networks", HTTP_GET, []() { sendWifiNetworks(user_server); });
+    user_server.on("/api/wifi/connect", HTTP_POST, []() { connectToWifiFromRequest(user_server); });
+    user_server.on("/generate_204", HTTP_GET, []() { sendNoCaptivePortalResponse(user_server); });
+    user_server.on("/gen_204", HTTP_GET, []() { sendNoCaptivePortalResponse(user_server); });
+    user_server.on("/hotspot-detect.html", HTTP_GET,
+                   []() { sendNoCaptivePortalResponse(user_server, "Success"); });
+    user_server.on("/library/test/success.html", HTTP_GET,
+                   []() { sendNoCaptivePortalResponse(user_server, "Success"); });
+    user_server.on("/ncsi.txt", HTTP_GET,
+                   []() { sendNoCaptivePortalResponse(user_server, "Microsoft NCSI"); });
+    user_server.onNotFound([]() {
+      if (handleCaptivePortalRequest(user_server)) return;
+      user_server.send(404, "text/plain", "Not found");
+    });
     user_server.begin();
     user_server_started = true;
     Serial.printf("Leaf Web App started: %s\n", userAppUrl().c_str());
@@ -716,7 +1074,10 @@ void webserver_setup() {
 void webserver_loop() {
   if (WiFi.status() == WL_CONNECTED || user_app_enabled) {
     server.handleClient();
-    if (user_app_enabled) user_server.handleClient();
+    if (user_app_enabled) {
+      if (user_app_provisioning) dns_server.processNextRequest();
+      user_server.handleClient();
+    }
     updatePendingInteractiveSelfTest();
   }
 }
@@ -732,12 +1093,31 @@ void webserver_enable_user_app(bool useLeafWifi) {
   }
 
   user_app_enabled = true;
+  user_app_provisioning = false;
   setupUserAppServer();
   webserver_setup();
 }
 
+void webserver_enable_wifi_setup() {
+  WiFi.mode(WIFI_AP_STA);
+  WiFi.setSleep(false);
+  WiFi.softAP("Leaf WiFi");
+  user_app_enabled = true;
+  user_app_using_leaf_wifi = true;
+  user_app_provisioning = true;
+  wifi_setup_scan_started = false;
+  setupUserAppServer();
+  dns_server.start(53, "*", WiFi.softAPIP());
+  startWifiScan();
+  webserver_setup();
+  Serial.printf("Leaf WiFi setup started: http://%s/app/wifi\n", WiFi.softAPIP().toString().c_str());
+}
+
 void webserver_disable_user_app() {
   user_app_enabled = false;
+  if (user_app_provisioning) dns_server.stop();
+  user_app_provisioning = false;
+  wifi_setup_scan_started = false;
   if (user_server_started) {
     user_server.stop();
     user_server_started = false;

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -30,6 +30,7 @@ namespace {
   bool user_app_using_leaf_wifi = false;
   bool user_app_provisioning = false;
   String wifi_setup_networks_json = "{\"scanning\":false,\"networks\":[]}";
+  bool wifi_setup_scan_running = false;
   bool wifi_setup_connecting = false;
   uint32_t wifi_setup_connect_started_ms = 0;
   String wifi_setup_connect_ssid = "";
@@ -552,7 +553,7 @@ namespace {
     }
 
     sendNoStoreHeaders(target);
-    static constexpr char WIFI_SETUP_PAGE[] = R"leafhtml(<!doctype html><html><head><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf WiFi</title><style>body{margin:0;background:#f5f7f2;color:#172016;font:16px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}h1{margin:0;padding:18px 20px;background:#172016;color:white;font-size:24px}main{padding:20px;max-width:560px;margin:auto}label{display:block;font-weight:650;margin:14px 0 6px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:12px;border:1px solid #bac3b4;border-radius:6px}button{margin-top:16px;background:#172016;color:white;font-weight:700}.status{border-bottom:1px solid #d9dfd3;color:#596256;padding-bottom:14px}.row{display:flex;gap:10px}.row input{flex:1}.show{display:flex;align-items:center;gap:6px;width:auto;white-space:nowrap}.show input{width:auto}</style><script>async function init(){let s=document.getElementById('s'),l=document.getElementById('l'),n=document.getElementById('n'),p=document.getElementById('p'),w=document.getElementById('w'),f=document.getElementById('f');l.onchange=()=>{if(l.value)n.value=l.value};w.onchange=()=>p.type=w.checked?'text':'password';async function nets(){try{let d=await(await fetch('/api/wifi/networks')).json();l.innerHTML='<option value="">Select network...</option>';d.networks.forEach(x=>{let o=document.createElement('option');o.value=x.ssid;o.textContent=x.ssid+' ('+x.rssi+' dBm)';l.appendChild(o)});s.textContent=d.networks.length?'Choose a network or type one manually.':'No networks found. Type the network name manually.'}catch(e){s.textContent='Unable to read network list. Type the network name manually.'}}async function poll(){try{let d=await(await fetch('/api/wifi/status')).json();if(d.connected){s.textContent='Connected to '+d.ssid+'. Open '+d.ip_address+':81/app';return}if(d.error){s.textContent='Unable to connect. Check password and try again.';return}s.textContent=d.target_ssid?'Trying to connect to '+d.target_ssid+'...':'Trying to connect...';setTimeout(poll,1500)}catch(e){s.textContent='Trying to connect...';setTimeout(poll,2000)}}f.onsubmit=async e=>{e.preventDefault();let ssid=n.value.trim();if(!ssid){s.textContent='Enter a network name.';return}s.textContent='Saving credentials...';try{await fetch('/api/wifi/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:ssid,password:p.value})});poll()}catch(x){s.textContent='Unable to save network details. Try again.'}};nets()}</script></head><body onload=init()><h1>Leaf WiFi Setup</h1><main><p class=status id=s>Loading...</p><form id=f><label>Network</label><select id=l><option>Select network...</option></select><input id=n autocomplete=off placeholder="Type network name"><label>Password</label><div class=row><input id=p type=password autocomplete=current-password><label class=show><input id=w type=checkbox>Show</label></div><button>Save and Connect</button></form></main></body></html>)leafhtml";
+    static constexpr char WIFI_SETUP_PAGE[] = R"leafhtml(<!doctype html><html><head><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf WiFi</title><style>body{margin:0;background:#f5f7f2;color:#172016;font:16px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}h1{margin:0;padding:18px 20px;background:#172016;color:white;font-size:24px}main{padding:20px;max-width:560px;margin:auto}label{display:block;font-weight:650;margin:14px 0 6px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:12px;border:1px solid #bac3b4;border-radius:6px}button{margin-top:16px;background:#172016;color:white;font-weight:700}.status{border-bottom:1px solid #d9dfd3;color:#596256;padding-bottom:14px}.row{display:flex;gap:10px}.row input{flex:1}.show{display:flex;align-items:center;gap:6px;width:auto;white-space:nowrap}.show input{width:auto}</style><script>async function init(){let s=document.getElementById('s'),l=document.getElementById('l'),n=document.getElementById('n'),p=document.getElementById('p'),w=document.getElementById('w'),f=document.getElementById('f');l.onchange=()=>{if(l.value)n.value=l.value};w.onchange=()=>p.type=w.checked?'text':'password';async function nets(){try{let d=await(await fetch('/api/wifi/networks')).json();if(d.scanning){s.textContent='Scanning for networks...';setTimeout(nets,1500);return}l.innerHTML='<option value="">Select network...</option>';d.networks.forEach(x=>{let o=document.createElement('option');o.value=x.ssid;o.textContent=x.ssid+' ('+x.rssi+' dBm)';l.appendChild(o)});s.textContent=d.networks.length?'Choose a network or type one manually.':'No networks found. Type the network name manually.'}catch(e){s.textContent='Unable to read network list. Type the network name manually.'}}async function poll(){try{let d=await(await fetch('/api/wifi/status')).json();if(d.connected){s.textContent='Connected to '+d.ssid+'. Open '+d.ip_address+':81/app';return}if(d.error){s.textContent='Unable to connect. Check password and try again.';return}s.textContent=d.target_ssid?'Trying to connect to '+d.target_ssid+'...':'Trying to connect...';setTimeout(poll,1500)}catch(e){s.textContent='Trying to connect...';setTimeout(poll,2000)}}f.onsubmit=async e=>{e.preventDefault();let ssid=n.value.trim();if(!ssid){s.textContent='Enter a network name.';return}s.textContent='Saving credentials...';try{await fetch('/api/wifi/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:ssid,password:p.value})});poll()}catch(x){s.textContent='Unable to save network details. Try again.'}};nets()}</script></head><body onload=init()><h1>Leaf WiFi Setup</h1><main><p class=status id=s>Loading...</p><form id=f><label>Network</label><select id=l><option>Select network...</option></select><input id=n autocomplete=off placeholder="Type network name"><label>Password</label><div class=row><input id=p type=password autocomplete=current-password><label class=show><input id=w type=checkbox>Show</label></div><button>Save and Connect</button></form></main></body></html>)leafhtml";
     target.send(200, "text/html", WIFI_SETUP_PAGE);
   }
 
@@ -621,9 +622,7 @@ namespace {
     return json;
   }
 
-  void buildWifiNetworkCache() {
-    WiFi.scanDelete();
-    const int16_t result = WiFi.scanNetworks(/*async=*/false, /*hidden=*/false);
+  void finishWifiNetworkScan(int16_t result) {
     if (result < 0) {
       Serial.printf("Leaf WiFi setup scan failed: %d\n", result);
     }
@@ -637,7 +636,31 @@ namespace {
     WiFi.scanDelete();
   }
 
+  void updateWifiNetworkScan() {
+    if (!wifi_setup_scan_running) return;
+
+    const int16_t result = WiFi.scanComplete();
+    if (result == WIFI_SCAN_RUNNING) return;
+
+    wifi_setup_scan_running = false;
+    finishWifiNetworkScan(result);
+  }
+
+  void startWifiNetworkScan() {
+    WiFi.scanDelete();
+    wifi_setup_networks_json = "{\"scanning\":true,\"networks\":[]}";
+    const int16_t result = WiFi.scanNetworks(/*async=*/true, /*hidden=*/false);
+    if (result == WIFI_SCAN_RUNNING) {
+      wifi_setup_scan_running = true;
+      return;
+    }
+
+    wifi_setup_scan_running = false;
+    finishWifiNetworkScan(result);
+  }
+
   void sendWifiNetworks(WebServer& target) {
+    updateWifiNetworkScan();
     sendNoStoreHeaders(target);
     target.send(200, "application/json", wifi_setup_networks_json);
   }
@@ -975,6 +998,7 @@ void webserver_loop() {
   if (WiFi.status() == WL_CONNECTED || user_app_enabled) {
     server.handleClient();
     if (user_app_enabled) {
+      if (user_app_provisioning) updateWifiNetworkScan();
       if (user_app_provisioning) dns_server.processNextRequest();
       user_server.handleClient();
     }
@@ -1002,7 +1026,6 @@ void webserver_enable_user_app(bool useLeafWifi) {
 void webserver_enable_wifi_setup() {
   wifi_setup_cycle++;
   leaf_wifi::prepareForUserWifiSetup();
-  buildWifiNetworkCache();
   WiFi.mode(WIFI_AP_STA);
   WiFi.setSleep(false);
   WiFi.softAP("Leaf WiFi");
@@ -1012,6 +1035,7 @@ void webserver_enable_wifi_setup() {
   setupUserAppServer();
   dns_server.start(53, "*", WiFi.softAPIP());
   webserver_setup();
+  startWifiNetworkScan();
   Serial.printf("Leaf WiFi setup started: http://%s/app/wifi\n", WiFi.softAPIP().toString().c_str());
 }
 
@@ -1019,6 +1043,8 @@ void webserver_disable_user_app() {
   user_app_enabled = false;
   if (user_app_provisioning) dns_server.stop();
   user_app_provisioning = false;
+  if (wifi_setup_scan_running) WiFi.scanDelete();
+  wifi_setup_scan_running = false;
   wifi_setup_networks_json = "{\"scanning\":false,\"networks\":[]}";
   wifi_setup_connecting = false;
   wifi_setup_connect_ssid = "";

--- a/src/vario/comms/webserver.h
+++ b/src/vario/comms/webserver.h
@@ -1,4 +1,10 @@
 #pragma once
 
+#include <Arduino.h>
+
 void webserver_setup();
 void webserver_loop();
+void webserver_enable_user_app(bool useLeafWifi);
+void webserver_disable_user_app();
+bool webserver_user_app_active();
+String webserver_user_app_url();

--- a/src/vario/comms/webserver.h
+++ b/src/vario/comms/webserver.h
@@ -5,6 +5,7 @@
 void webserver_setup();
 void webserver_loop();
 void webserver_enable_user_app(bool useLeafWifi);
+void webserver_enable_wifi_setup();
 void webserver_disable_user_app();
 bool webserver_user_app_active();
 String webserver_user_app_url();

--- a/src/vario/comms/wifi_coordinator.cpp
+++ b/src/vario/comms/wifi_coordinator.cpp
@@ -1,0 +1,87 @@
+#include "comms/wifi_coordinator.h"
+
+#include <Arduino.h>
+#include <WiFi.h>
+
+namespace leaf_wifi {
+namespace {
+  bool diagnostics_disabled_until_reboot = false;
+  constexpr uint32_t WIFI_SETTLE_MS = 150;
+  constexpr uint32_t WIFI_HARD_RESET_SETTLE_MS = 500;
+
+  void settleWifi() {
+    delay(WIFI_SETTLE_MS);
+  }
+
+  void hardSettleWifi() {
+    delay(WIFI_HARD_RESET_SETTLE_MS);
+  }
+
+  void disableDiagnostics() {
+    if (!diagnostics_disabled_until_reboot) {
+      Serial.println("WiFi coordinator: diagnostic network disabled until reboot");
+    }
+    diagnostics_disabled_until_reboot = true;
+  }
+
+  void stopScansAndSta(bool eraseCredentials) {
+    WiFi.scanDelete();
+    WiFi.disconnect(/*wifioff=*/false, eraseCredentials);
+    WiFi.mode(WIFI_STA);
+    WiFi.setSleep(false);
+    settleWifi();
+    WiFi.scanDelete();
+  }
+
+  void resetRadioForSetup(bool eraseCredentials) {
+    WiFi.scanDelete();
+    WiFi.softAPdisconnect(true);
+    WiFi.disconnect(/*wifioff=*/false, eraseCredentials);
+    WiFi.mode(WIFI_OFF);
+    hardSettleWifi();
+    WiFi.mode(WIFI_STA);
+    WiFi.setSleep(false);
+    hardSettleWifi();
+    WiFi.scanDelete();
+  }
+}  // namespace
+
+void disableDiagnosticsUntilReboot() {
+  disableDiagnostics();
+}
+
+bool diagnosticsAllowed() {
+  return !diagnostics_disabled_until_reboot;
+}
+
+void prepareForUserWifiSetup() {
+  disableDiagnostics();
+  resetRadioForSetup(/*eraseCredentials=*/false);
+}
+
+void prepareForLeafAccessPoint() {
+  disableDiagnostics();
+  stopScansAndSta(/*eraseCredentials=*/false);
+}
+
+void resetUserWifiSettings() {
+  disableDiagnostics();
+  resetRadioForSetup(/*eraseCredentials=*/true);
+  Serial.println("WiFi settings reset");
+}
+
+void attemptSavedNetworkConnection() {
+  disableDiagnostics();
+  WiFi.scanDelete();
+  WiFi.mode(WIFI_STA);
+  WiFi.setSleep(false);
+  WiFi.begin();
+}
+
+void disconnectFromNetwork() {
+  WiFi.scanDelete();
+  WiFi.disconnect();
+  WiFi.mode(WIFI_STA);
+}
+
+}  // namespace leaf_wifi

--- a/src/vario/comms/wifi_coordinator.cpp
+++ b/src/vario/comms/wifi_coordinator.cpp
@@ -84,6 +84,14 @@ void prepareForUserWifiSetup() {
   resetRadioForSetup(/*eraseCredentials=*/false);
 }
 
+void prepareForUserWifiSetupFast() {
+  disableDiagnostics();
+  clearSavedNetworkAttempt();
+  WiFi.scanDelete();
+  WiFi.mode(WIFI_STA);
+  WiFi.setSleep(false);
+}
+
 void prepareForLeafAccessPoint() {
   disableDiagnostics();
   stopScansAndSta(/*eraseCredentials=*/false);

--- a/src/vario/comms/wifi_coordinator.cpp
+++ b/src/vario/comms/wifi_coordinator.cpp
@@ -5,128 +5,120 @@
 #include <esp_wifi.h>
 
 namespace leaf_wifi {
-namespace {
-  bool diagnostics_disabled_until_reboot = false;
-  bool saved_network_connecting = false;
-  uint32_t saved_network_connect_started_ms = 0;
-  constexpr uint32_t WIFI_SETTLE_MS = 150;
-  constexpr uint32_t WIFI_HARD_RESET_SETTLE_MS = 500;
-  constexpr uint32_t SAVED_NETWORK_CONNECT_DISPLAY_MS = 6500;
+  namespace {
+    bool diagnostics_disabled_until_reboot = false;
+    bool saved_network_connecting = false;
+    uint32_t saved_network_connect_started_ms = 0;
+    constexpr uint32_t WIFI_SETTLE_MS = 150;
+    constexpr uint32_t WIFI_HARD_RESET_SETTLE_MS = 500;
+    constexpr uint32_t SAVED_NETWORK_CONNECT_DISPLAY_MS = 6500;
 
-  void settleWifi() {
-    delay(WIFI_SETTLE_MS);
-  }
+    void settleWifi() { delay(WIFI_SETTLE_MS); }
 
-  void hardSettleWifi() {
-    delay(WIFI_HARD_RESET_SETTLE_MS);
-  }
+    void hardSettleWifi() { delay(WIFI_HARD_RESET_SETTLE_MS); }
 
-  void disableDiagnostics() {
-    if (!diagnostics_disabled_until_reboot) {
-      Serial.println("WiFi coordinator: diagnostic network disabled until reboot");
+    void disableDiagnostics() {
+      if (!diagnostics_disabled_until_reboot) {
+        Serial.println("WiFi coordinator: diagnostic network disabled until reboot");
+      }
+      diagnostics_disabled_until_reboot = true;
     }
-    diagnostics_disabled_until_reboot = true;
-  }
 
-  void clearSavedNetworkAttempt() {
-    saved_network_connecting = false;
-    saved_network_connect_started_ms = 0;
-  }
+    void clearSavedNetworkAttempt() {
+      saved_network_connecting = false;
+      saved_network_connect_started_ms = 0;
+    }
 
-  void updateSavedNetworkAttempt() {
-    if (!saved_network_connecting) return;
-    if (WiFi.status() == WL_CONNECTED ||
-        millis() - saved_network_connect_started_ms > SAVED_NETWORK_CONNECT_DISPLAY_MS) {
+    void updateSavedNetworkAttempt() {
+      if (!saved_network_connecting) return;
+      if (WiFi.status() == WL_CONNECTED ||
+          millis() - saved_network_connect_started_ms > SAVED_NETWORK_CONNECT_DISPLAY_MS) {
+        clearSavedNetworkAttempt();
+      }
+    }
+
+    bool hasSavedStationConfig() {
+      wifi_config_t config = {};
+      if (esp_wifi_get_config(WIFI_IF_STA, &config) != ESP_OK) return false;
+      return config.sta.ssid[0] != '\0';
+    }
+
+    void stopScansAndSta(bool eraseCredentials) {
       clearSavedNetworkAttempt();
+      WiFi.scanDelete();
+      WiFi.disconnect(/*wifioff=*/false, eraseCredentials);
+      WiFi.mode(WIFI_STA);
+      WiFi.setSleep(false);
+      settleWifi();
+      WiFi.scanDelete();
     }
+
+    void resetRadioForSetup(bool eraseCredentials) {
+      clearSavedNetworkAttempt();
+      WiFi.scanDelete();
+      WiFi.softAPdisconnect(true);
+      WiFi.disconnect(/*wifioff=*/false, eraseCredentials);
+      WiFi.mode(WIFI_OFF);
+      hardSettleWifi();
+      WiFi.mode(WIFI_STA);
+      WiFi.setSleep(false);
+      hardSettleWifi();
+      WiFi.scanDelete();
+    }
+  }  // namespace
+
+  void disableDiagnosticsUntilReboot() { disableDiagnostics(); }
+
+  bool diagnosticsAllowed() { return !diagnostics_disabled_until_reboot; }
+
+  void prepareForUserWifiSetup() {
+    disableDiagnostics();
+    resetRadioForSetup(/*eraseCredentials=*/false);
   }
 
-  bool hasSavedStationConfig() {
-    wifi_config_t config = {};
-    if (esp_wifi_get_config(WIFI_IF_STA, &config) != ESP_OK) return false;
-    return config.sta.ssid[0] != '\0';
-  }
-
-  void stopScansAndSta(bool eraseCredentials) {
+  void prepareForUserWifiSetupFast() {
+    disableDiagnostics();
     clearSavedNetworkAttempt();
     WiFi.scanDelete();
-    WiFi.disconnect(/*wifioff=*/false, eraseCredentials);
     WiFi.mode(WIFI_STA);
     WiFi.setSleep(false);
-    settleWifi();
-    WiFi.scanDelete();
   }
 
-  void resetRadioForSetup(bool eraseCredentials) {
-    clearSavedNetworkAttempt();
+  void prepareForLeafAccessPoint() {
+    disableDiagnostics();
+    stopScansAndSta(/*eraseCredentials=*/false);
+  }
+
+  void resetUserWifiSettings() {
+    disableDiagnostics();
+    resetRadioForSetup(/*eraseCredentials=*/true);
+    Serial.println("WiFi settings reset");
+  }
+
+  void attemptSavedNetworkConnection() {
+    disableDiagnostics();
     WiFi.scanDelete();
-    WiFi.softAPdisconnect(true);
-    WiFi.disconnect(/*wifioff=*/false, eraseCredentials);
-    WiFi.mode(WIFI_OFF);
-    hardSettleWifi();
     WiFi.mode(WIFI_STA);
     WiFi.setSleep(false);
-    hardSettleWifi();
-    WiFi.scanDelete();
+    if (!hasSavedStationConfig()) {
+      clearSavedNetworkAttempt();
+      return;
+    }
+    WiFi.begin();
+    saved_network_connecting = true;
+    saved_network_connect_started_ms = millis();
   }
-}  // namespace
 
-void disableDiagnosticsUntilReboot() {
-  disableDiagnostics();
-}
-
-bool diagnosticsAllowed() {
-  return !diagnostics_disabled_until_reboot;
-}
-
-void prepareForUserWifiSetup() {
-  disableDiagnostics();
-  resetRadioForSetup(/*eraseCredentials=*/false);
-}
-
-void prepareForUserWifiSetupFast() {
-  disableDiagnostics();
-  clearSavedNetworkAttempt();
-  WiFi.scanDelete();
-  WiFi.mode(WIFI_STA);
-  WiFi.setSleep(false);
-}
-
-void prepareForLeafAccessPoint() {
-  disableDiagnostics();
-  stopScansAndSta(/*eraseCredentials=*/false);
-}
-
-void resetUserWifiSettings() {
-  disableDiagnostics();
-  resetRadioForSetup(/*eraseCredentials=*/true);
-  Serial.println("WiFi settings reset");
-}
-
-void attemptSavedNetworkConnection() {
-  disableDiagnostics();
-  WiFi.scanDelete();
-  WiFi.mode(WIFI_STA);
-  WiFi.setSleep(false);
-  if (!hasSavedStationConfig()) {
+  void disconnectFromNetwork() {
     clearSavedNetworkAttempt();
-    return;
+    WiFi.scanDelete();
+    WiFi.disconnect();
+    WiFi.mode(WIFI_STA);
   }
-  WiFi.begin();
-  saved_network_connecting = true;
-  saved_network_connect_started_ms = millis();
-}
 
-void disconnectFromNetwork() {
-  clearSavedNetworkAttempt();
-  WiFi.scanDelete();
-  WiFi.disconnect();
-  WiFi.mode(WIFI_STA);
-}
-
-bool savedNetworkConnectionInProgress() {
-  updateSavedNetworkAttempt();
-  return saved_network_connecting;
-}
+  bool savedNetworkConnectionInProgress() {
+    updateSavedNetworkAttempt();
+    return saved_network_connecting;
+  }
 
 }  // namespace leaf_wifi

--- a/src/vario/comms/wifi_coordinator.cpp
+++ b/src/vario/comms/wifi_coordinator.cpp
@@ -6,8 +6,11 @@
 namespace leaf_wifi {
 namespace {
   bool diagnostics_disabled_until_reboot = false;
+  bool saved_network_connecting = false;
+  uint32_t saved_network_connect_started_ms = 0;
   constexpr uint32_t WIFI_SETTLE_MS = 150;
   constexpr uint32_t WIFI_HARD_RESET_SETTLE_MS = 500;
+  constexpr uint32_t SAVED_NETWORK_CONNECT_DISPLAY_MS = 6500;
 
   void settleWifi() {
     delay(WIFI_SETTLE_MS);
@@ -24,7 +27,21 @@ namespace {
     diagnostics_disabled_until_reboot = true;
   }
 
+  void clearSavedNetworkAttempt() {
+    saved_network_connecting = false;
+    saved_network_connect_started_ms = 0;
+  }
+
+  void updateSavedNetworkAttempt() {
+    if (!saved_network_connecting) return;
+    if (WiFi.status() == WL_CONNECTED ||
+        millis() - saved_network_connect_started_ms > SAVED_NETWORK_CONNECT_DISPLAY_MS) {
+      clearSavedNetworkAttempt();
+    }
+  }
+
   void stopScansAndSta(bool eraseCredentials) {
+    clearSavedNetworkAttempt();
     WiFi.scanDelete();
     WiFi.disconnect(/*wifioff=*/false, eraseCredentials);
     WiFi.mode(WIFI_STA);
@@ -34,6 +51,7 @@ namespace {
   }
 
   void resetRadioForSetup(bool eraseCredentials) {
+    clearSavedNetworkAttempt();
     WiFi.scanDelete();
     WiFi.softAPdisconnect(true);
     WiFi.disconnect(/*wifioff=*/false, eraseCredentials);
@@ -76,12 +94,20 @@ void attemptSavedNetworkConnection() {
   WiFi.mode(WIFI_STA);
   WiFi.setSleep(false);
   WiFi.begin();
+  saved_network_connecting = true;
+  saved_network_connect_started_ms = millis();
 }
 
 void disconnectFromNetwork() {
+  clearSavedNetworkAttempt();
   WiFi.scanDelete();
   WiFi.disconnect();
   WiFi.mode(WIFI_STA);
+}
+
+bool savedNetworkConnectionInProgress() {
+  updateSavedNetworkAttempt();
+  return saved_network_connecting;
 }
 
 }  // namespace leaf_wifi

--- a/src/vario/comms/wifi_coordinator.cpp
+++ b/src/vario/comms/wifi_coordinator.cpp
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include <WiFi.h>
+#include <esp_wifi.h>
 
 namespace leaf_wifi {
 namespace {
@@ -38,6 +39,12 @@ namespace {
         millis() - saved_network_connect_started_ms > SAVED_NETWORK_CONNECT_DISPLAY_MS) {
       clearSavedNetworkAttempt();
     }
+  }
+
+  bool hasSavedStationConfig() {
+    wifi_config_t config = {};
+    if (esp_wifi_get_config(WIFI_IF_STA, &config) != ESP_OK) return false;
+    return config.sta.ssid[0] != '\0';
   }
 
   void stopScansAndSta(bool eraseCredentials) {
@@ -93,6 +100,10 @@ void attemptSavedNetworkConnection() {
   WiFi.scanDelete();
   WiFi.mode(WIFI_STA);
   WiFi.setSleep(false);
+  if (!hasSavedStationConfig()) {
+    clearSavedNetworkAttempt();
+    return;
+  }
   WiFi.begin();
   saved_network_connecting = true;
   saved_network_connect_started_ms = millis();

--- a/src/vario/comms/wifi_coordinator.h
+++ b/src/vario/comms/wifi_coordinator.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace leaf_wifi {
+
+void disableDiagnosticsUntilReboot();
+bool diagnosticsAllowed();
+
+void prepareForUserWifiSetup();
+void prepareForLeafAccessPoint();
+void resetUserWifiSettings();
+void attemptSavedNetworkConnection();
+void disconnectFromNetwork();
+
+}  // namespace leaf_wifi

--- a/src/vario/comms/wifi_coordinator.h
+++ b/src/vario/comms/wifi_coordinator.h
@@ -6,6 +6,7 @@ void disableDiagnosticsUntilReboot();
 bool diagnosticsAllowed();
 
 void prepareForUserWifiSetup();
+void prepareForUserWifiSetupFast();
 void prepareForLeafAccessPoint();
 void resetUserWifiSettings();
 void attemptSavedNetworkConnection();

--- a/src/vario/comms/wifi_coordinator.h
+++ b/src/vario/comms/wifi_coordinator.h
@@ -10,5 +10,6 @@ void prepareForLeafAccessPoint();
 void resetUserWifiSettings();
 void attemptSavedNetworkConnection();
 void disconnectFromNetwork();
+bool savedNetworkConnectionInProgress();
 
 }  // namespace leaf_wifi

--- a/src/vario/comms/wifi_coordinator.h
+++ b/src/vario/comms/wifi_coordinator.h
@@ -2,15 +2,15 @@
 
 namespace leaf_wifi {
 
-void disableDiagnosticsUntilReboot();
-bool diagnosticsAllowed();
+  void disableDiagnosticsUntilReboot();
+  bool diagnosticsAllowed();
 
-void prepareForUserWifiSetup();
-void prepareForUserWifiSetupFast();
-void prepareForLeafAccessPoint();
-void resetUserWifiSettings();
-void attemptSavedNetworkConnection();
-void disconnectFromNetwork();
-bool savedNetworkConnectionInProgress();
+  void prepareForUserWifiSetup();
+  void prepareForUserWifiSetupFast();
+  void prepareForLeafAccessPoint();
+  void resetUserWifiSettings();
+  void attemptSavedNetworkConnection();
+  void disconnectFromNetwork();
+  bool savedNetworkConnectionInProgress();
 
 }  // namespace leaf_wifi

--- a/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
+++ b/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
@@ -2,6 +2,7 @@
 
 #include <WiFi.h>
 
+#include "comms/wifi_coordinator.h"
 #include "diagnostics/fatal_error.h"
 #include "diagnostics/self_test/selfTest.h"
 #include "power.h"
@@ -41,6 +42,15 @@ bool DiagnosticNetwork::shouldResetWhenSwitchingOn() const {
 bool DiagnosticNetwork::canSleepWhileCharging() const { return shouldResetWhenSwitchingOn(); }
 
 void DiagnosticNetwork::update() {
+  if (!leaf_wifi::diagnosticsAllowed()) {
+    if (!printed_end_state_) {
+      Serial.println("DiagnosticNetwork: disabled by user WiFi action");
+      printed_end_state_ = true;
+    }
+    state_ = State::NoNetworkFound;
+    return;
+  }
+
   if (state_ == State::Ready) {
     maybeLookForNetwork();
   } else if (state_ == State::WifiResetting) {

--- a/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
+++ b/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
@@ -31,7 +31,7 @@ void DiagnosticNetwork::reset(const char* reason) {
   state_ = State::Ready;
   next_scan_attempt_ms_ = millis() + SCAN_RETRY_DELAY_MS;
   WiFi.scanDelete();
-  WiFi.disconnect(true, true);
+  WiFi.disconnect();
 }
 
 bool DiagnosticNetwork::shouldResetWhenSwitchingOn() const {
@@ -121,7 +121,7 @@ void DiagnosticNetwork::maybeLookForNetwork() {
                 WiFi.getMode(), ESP.getFreeHeap());
 
   WiFi.mode(WIFI_STA);
-  WiFi.disconnect(true, true);  // drop old state, clear config
+  WiFi.disconnect();  // drop the active connection without erasing saved user credentials
 
   // Use WifiResetting state to let WiFi settle for 100ms without blocking the loop
   t0_ = millis() + 100;
@@ -181,7 +181,7 @@ void DiagnosticNetwork::checkForDiagnosticNetwork() {
 void DiagnosticNetwork::checkForConnection() {
   uint32_t now = millis();
   if (now - t0_ > CONNECT_TIMEOUT_MS) {
-    WiFi.disconnect(true, true);
+    WiFi.disconnect();
     error_msg_ = "Timeout attempting to connect to diagnostic network";
     state_ = State::Error;
     return;
@@ -192,7 +192,7 @@ void DiagnosticNetwork::checkForConnection() {
     state_ = State::ConnectedToNetwork;
     return;
   } else if (status == WL_CONNECT_FAILED || status == WL_STOPPED) {
-    WiFi.disconnect(true, true);
+    WiFi.disconnect();
     error_msg_ = "WiFi FAILED or STOPPED while connecting to diagnostic network";
     state_ = State::Error;
   }

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -134,7 +134,7 @@ void TaskManager::update() {
   // when re-entering PowerState::On, be sure to start from tasks #1, so baro ADC can be re-prepped
   // before reading
 
-  if (WiFi.status() == WL_CONNECTED) {
+  if (WiFi.status() == WL_CONNECTED || webserver_user_app_active()) {
     webserver_setup();
     webserver_loop();
     factoryDiscovery.update();

--- a/src/vario/ui/display/pages/dialogs/page_qr.h
+++ b/src/vario/ui/display/pages/dialogs/page_qr.h
@@ -5,8 +5,13 @@
 // Provides a simple dialog to display a QR code
 class PageQR : public SimpleSettingsMenuPage {
  public:
+  PageQR() : title("QR"), url("") {}
   PageQR(String title, String url) : title(title), url(url) {}
   const char* get_title() const override { return title.c_str(); }
+  void set(String newTitle, String newUrl) {
+    title = newTitle;
+    url = newUrl;
+  }
   void draw_extra() override;
 
  private:

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -45,6 +45,8 @@ void WifiMenuPage::draw() {
     attemptWifiConnection();
   }
 
+  const bool wifiConnected = WiFi.status() == WL_CONNECTED;
+  const bool wifiSearching = !wifiConnected && leaf_wifi::savedNetworkConnectionInProgress();
   int wifiIcon = wifiIconForCurrentConnection();
 
   u8g2.firstPage();
@@ -56,10 +58,12 @@ void WifiMenuPage::draw() {
     u8g2.setDrawColor(1);
     u8g2.setFont(leaf_6x12);
     u8g2.setCursor(0, 35);
-    if (WiFi.status() == WL_CONNECTED) {
+    if (wifiConnected) {
       u8g2.print("Connected To:");
       u8g2.setCursor(0, 50);
       u8g2.print(WiFi.SSID());
+    } else if (wifiSearching) {
+      u8g2.print("Searching...");
     } else {
       u8g2.print("Not Connected");
     }
@@ -80,7 +84,7 @@ void WifiMenuPage::draw() {
     for (int i = 0; i <= cursor_max; i++) {
       u8g2.setCursor(setting_name_x, menu_items_y[i]);
       if (i == cursor_wifi_connectORupdateFW) {
-        if (WiFi.status() == WL_CONNECTED) {
+        if (wifiConnected) {
           u8g2.print("Update FW");
         } else {
           u8g2.print("Setup Wifi");

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -4,6 +4,7 @@
 
 #include "comms/ble.h"
 #include "comms/ota.h"
+#include "comms/wifi_coordinator.h"
 #include "comms/webserver.h"
 #include "power.h"
 #include "system/version_info.h"
@@ -106,9 +107,9 @@ void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) 
     case cursor_wifi_resetWifiSettings:
       if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::confirm);
-        WiFi.disconnect(true, true);  // erase AP
+        webserver_disable_user_app();
+        leaf_wifi::resetUserWifiSettings();
         wifi_state = WifiState::DISCONNECTED;
-        Serial.println("WiFi settings reset");
       }
       break;
     case cursor_wifi_webApp:
@@ -128,7 +129,7 @@ void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) 
     case cursor_wifi_back: {
       if (state == ButtonEvent::CLICKED || state == ButtonEvent::HELD) {
 #ifndef DEBUG_WIFI
-        WiFi.disconnect();
+        leaf_wifi::disconnectFromNetwork();
         wifi_state = WifiState::DISCONNECTED;
         Serial.println("WiFi disconnected");
 #endif
@@ -154,11 +155,9 @@ void PageMenuSystemWifiSetup::beginWifiSetup() {
 
 void WifiMenuPage::attemptWifiConnection() {
   wifi_state = WifiState::CONNECTING;
-  WiFi.mode(WIFI_STA);
-  WiFi.setSleep(false);
 
-  // This attempts to connect using credentials stored by WiFiManager
-  WiFi.begin();
+  // This attempts to connect using credentials stored by the ESP WiFi stack.
+  leaf_wifi::attemptSavedNetworkConnection();
 }
 
 namespace {

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -311,6 +311,7 @@ void PageMenuSystemWifiWebApp::draw_extra() {
 
 void PageMenuSystemWifiSetup::shown() {
   SimpleSettingsMenuPage::shown();
+  starting_message_started_ms = millis();
   beginWifiSetup();
 }
 
@@ -335,6 +336,23 @@ void PageMenuSystemWifiSetup::draw_extra() {
   u8g2.setCursor(85, 12);
   u8g2.print((char)wifiIcon);
 
+  if (millis() - starting_message_started_ms < STARTING_MESSAGE_MS) {
+    u8g2.setFont(leaf_6x12);
+    u8g2.setCursor(24, 52);
+    u8g2.print("Starting");
+    u8g2.setCursor(12, 69);
+    u8g2.print("Leaf Wifi...");
+
+    u8g2.setFont(leaf_5x8);
+    u8g2.setCursor(8, 104);
+    u8g2.print("Network may take");
+    u8g2.setCursor(15, 116);
+    u8g2.print("10-20 seconds");
+    u8g2.setCursor(8, 128);
+    u8g2.print("to show on phone");
+    return;
+  }
+
   u8g2.setFont(leaf_6x12);
   auto y = 15;
   auto x = 0;
@@ -343,7 +361,7 @@ void PageMenuSystemWifiSetup::draw_extra() {
 
   // Instruction Page
   const char* lines[] = {"Follow these steps", "on Phone or Laptop:", "1.Join Leaf WiFi",   " ",
-                         "2.Click Sign In",   "  Or Visit:",         "192.168.4.1/app/wifi",
+                         "2.Click Sign In",   "  Or Visit:",         "192.168.4.1/wifi",
                          " ",                 "3.Enter Network",     "Select your network",
                          "and enter password", " ",                  "4.Press Save",
                          "This page will close", "when connected..."};

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -45,7 +45,9 @@ void WifiMenuPage::draw() {
     attemptWifiConnection();
   }
 
-  const bool wifiConnected = WiFi.status() == WL_CONNECTED;
+  const String connectedSsid = WiFi.SSID();
+  const bool wifiConnected = WiFi.status() == WL_CONNECTED && !connectedSsid.isEmpty();
+  const bool wifiSettling = WiFi.status() == WL_CONNECTED && connectedSsid.isEmpty();
   const bool wifiSearching = !wifiConnected && leaf_wifi::savedNetworkConnectionInProgress();
   int wifiIcon = wifiIconForCurrentConnection();
 
@@ -61,8 +63,8 @@ void WifiMenuPage::draw() {
     if (wifiConnected) {
       u8g2.print("Connected To:");
       u8g2.setCursor(0, 50);
-      u8g2.print(WiFi.SSID());
-    } else if (wifiSearching) {
+      u8g2.print(connectedSsid);
+    } else if (wifiSearching || wifiSettling) {
       u8g2.print("Searching...");
     } else {
       u8g2.print("Not Connected");

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -221,8 +221,9 @@ void PageMenuSystemWifiWebApp::draw() {
   do {
     display_menuTitle(String(get_title()));
 
+    const auto NETWORK_ACTION_Y = 166;
     const auto BOX_X = 74 - 10;
-    const auto BOX_Y = (cursor_position == CURSOR_BACK ? 190 : 45) - 14;
+    const auto BOX_Y = (cursor_position == CURSOR_BACK ? 190 : NETWORK_ACTION_Y) - 14;
     u8g2.drawRBox(BOX_X, BOX_Y, 34, 16, 2);
 
     u8g2.setFont(leaf_6x12);
@@ -234,10 +235,10 @@ void PageMenuSystemWifiWebApp::draw() {
     u8g2.setDrawColor(1);
 
     u8g2.setFont(leaf_5x8);
-    u8g2.setCursor(2, 45);
+    u8g2.setCursor(2, NETWORK_ACTION_Y);
     u8g2.print(network_labels[0]);
     u8g2.setFont(leaf_6x12);
-    u8g2.setCursor(74, 45);
+    u8g2.setCursor(74, NETWORK_ACTION_Y);
     u8g2.setDrawColor(cursor_position == 0 ? 0 : 1);
     u8g2.print((char)126);
     u8g2.setDrawColor(1);
@@ -290,12 +291,15 @@ void PageMenuSystemWifiWebApp::draw_extra() {
     u8g2.setCursor(85, 40);
     u8g2.print((char)wifiIconForCurrentConnection());
 
-    drawQrCode(webserver_user_app_url().c_str(), 23, 58);
+    u8g2.setFont(leaf_5x8);
+    u8g2.setCursor(2, 58);
+    u8g2.print("Open in browser:");
+    drawQrCode(webserver_user_app_url().c_str(), 23, 64);
 
     String shortUrl = webserver_user_app_url();
     shortUrl.replace("http://", "");
     u8g2.setFont(leaf_5x8);
-    u8g2.setCursor(2, 119);
+    u8g2.setCursor(2, 124);
     u8g2.print(shortUrl);
   } else {
     u8g2.setFont(leaf_5x8);

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -4,6 +4,7 @@
 
 #include "comms/ble.h"
 #include "comms/ota.h"
+#include "comms/webserver.h"
 #include "power.h"
 #include "system/version_info.h"
 #include "ui/audio/sound_effects.h"
@@ -14,10 +15,26 @@
 #include "ui/display/pages.h"
 #include "ui/input/buttons.h"
 #include "ui/settings/settings.h"
+#include "utils/qrcodex.h"
+
+namespace {
+  int wifiIconForCurrentConnection() {
+    int wifiIcon = 65;  // the "full signal" icon
+    if (WiFi.status() == WL_CONNECTED) {
+      const int signalStrength = WiFi.RSSI();
+      if (signalStrength < -70) wifiIcon--;  // decrease one bar
+      if (signalStrength < -85) wifiIcon--;  // decrease another bar
+    } else {
+      wifiIcon++;  // disconnected icon
+    }
+    return wifiIcon;
+  }
+}  // namespace
 
 enum wifi_menu_items_connected {
   cursor_wifi_back,
   cursor_wifi_connectORupdateFW,
+  cursor_wifi_webApp,
   cursor_wifi_resetWifiSettings
 };
 
@@ -27,8 +44,7 @@ void WifiMenuPage::draw() {
     attemptWifiConnection();
   }
 
-  int signalStrength = 0;
-  int wifiIcon = 65;  // the "full signal" icon
+  int wifiIcon = wifiIconForCurrentConnection();
 
   u8g2.firstPage();
   do {
@@ -43,12 +59,8 @@ void WifiMenuPage::draw() {
       u8g2.print("Connected To:");
       u8g2.setCursor(0, 50);
       u8g2.print(WiFi.SSID());
-      signalStrength = WiFi.RSSI();
-      if (signalStrength < -70) wifiIcon--;  // decrease one bar
-      if (signalStrength < -85) wifiIcon--;  // decrease another bar
     } else {
       u8g2.print("Not Connected");
-      wifiIcon++;  // index up to the disconnected icon
     }
     u8g2.setFont(leaf_icons);
     u8g2.setCursor(85, 50);
@@ -58,7 +70,7 @@ void WifiMenuPage::draw() {
     // Menu Items
     uint8_t setting_name_x = 2;
     uint8_t setting_choice_x = 70;
-    uint8_t menu_items_y[] = {190, 90, 105};
+    uint8_t menu_items_y[] = {190, 90, 105, 120};
 
     // first draw cursor selection box
     u8g2.drawRBox(setting_choice_x - 4, menu_items_y[cursor_position] - 14, 30, 16, 2);
@@ -97,6 +109,11 @@ void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) 
         WiFi.disconnect(true, true);  // erase AP
         wifi_state = WifiState::DISCONNECTED;
         Serial.println("WiFi settings reset");
+      }
+      break;
+    case cursor_wifi_webApp:
+      if (state == ButtonEvent::CLICKED) {
+        push_page(&page_wifi_web_app);
       }
       break;
     case cursor_wifi_connectORupdateFW:
@@ -150,6 +167,141 @@ void WifiMenuPage::attemptWifiConnection() {
 
   // This attempts to connect using credentials stored by WiFiManager
   WiFi.begin();
+}
+
+namespace {
+  void drawQrCode(const char* text, uint8_t xOffset, uint8_t yOffset) {
+    static constexpr uint8_t QR_VERSION = 2;
+    static constexpr uint8_t QR_SCALE = 2;
+
+    QRCode qrcode;
+    uint8_t qrcodeData[qrcode_getBufferSize(QR_VERSION)];
+    qrcode_initText(&qrcode, qrcodeData, QR_VERSION, ECC_LOW, text);
+
+    for (uint8_t x = 0; x < qrcode.size; x++) {
+      for (uint8_t y = 0; y < qrcode.size; y++) {
+        if (qrcode_getModule(&qrcode, x, y)) {
+          u8g2.drawBox(xOffset + x * QR_SCALE, yOffset + y * QR_SCALE, QR_SCALE, QR_SCALE);
+        }
+      }
+    }
+  }
+}  // namespace
+
+etl::array<const char*, 1> PageMenuSystemWifiWebApp::network_labels{{"Use LeafWiFi"}};
+
+void PageMenuSystemWifiWebApp::start(bool useLeafWifi) {
+  using_leaf_wifi = useLeafWifi || WiFi.status() != WL_CONNECTED;
+  webserver_enable_user_app(using_leaf_wifi);
+}
+
+void PageMenuSystemWifiWebApp::shown() {
+  start(false);
+  SimpleSettingsMenuPage::shown();
+}
+
+void PageMenuSystemWifiWebApp::closed(bool removed_from_Stack) {
+  if (removed_from_Stack) {
+    webserver_disable_user_app();
+  }
+}
+
+etl::array_view<const char*> PageMenuSystemWifiWebApp::get_labels() const {
+  if (using_leaf_wifi) return etl::array_view<const char*>(emptyMenu);
+  return etl::array_view<const char*>(network_labels);
+}
+
+void PageMenuSystemWifiWebApp::draw() {
+  if (using_leaf_wifi) {
+    SimpleSettingsMenuPage::draw();
+    return;
+  }
+
+  u8g2.firstPage();
+  do {
+    display_menuTitle(String(get_title()));
+
+    const auto BOX_X = 74 - 10;
+    const auto BOX_Y = (cursor_position == CURSOR_BACK ? 190 : 45) - 14;
+    u8g2.drawRBox(BOX_X, BOX_Y, 34, 16, 2);
+
+    u8g2.setFont(leaf_6x12);
+    u8g2.setCursor(2, 190);
+    u8g2.print("Back");
+    u8g2.setCursor(74, 190);
+    u8g2.setDrawColor(cursor_position == CURSOR_BACK ? 0 : 1);
+    u8g2.print((char)124);
+    u8g2.setDrawColor(1);
+
+    u8g2.setFont(leaf_5x8);
+    u8g2.setCursor(2, 45);
+    u8g2.print(network_labels[0]);
+    u8g2.setFont(leaf_6x12);
+    u8g2.setCursor(74, 45);
+    u8g2.setDrawColor(cursor_position == 0 ? 0 : 1);
+    u8g2.print((char)126);
+    u8g2.setDrawColor(1);
+
+    draw_extra();
+  } while (u8g2.nextPage());
+
+  loop();
+}
+
+void PageMenuSystemWifiWebApp::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (cursor_position == CURSOR_BACK && state == ButtonEvent::CLICKED) {
+    pop_page();
+    return;
+  }
+
+  if (state != ButtonEvent::CLICKED) return;
+
+  if (using_leaf_wifi) return;
+
+  if (cursor_position == 0) {
+    start(true);
+    cursor_position = CURSOR_BACK;
+    cursor_max = get_labels().size() - 1;
+  }
+}
+
+void PageMenuSystemWifiWebApp::draw_extra() {
+  u8g2.setFont(leaf_5x8);
+  u8g2.setDrawColor(1);
+
+  if (using_leaf_wifi) {
+    u8g2.setCursor(18, 28);
+    u8g2.print("Join Leaf WiFi");
+    drawQrCode("WIFI:T:nopass;S:Leaf WiFi;;", 23, 34);
+
+    u8g2.setCursor(20, 100);
+    u8g2.print("Open Web App");
+    drawQrCode(webserver_user_app_url().c_str(), 23, 106);
+    return;
+  }
+
+  if (webserver_user_app_active()) {
+    u8g2.setFont(leaf_5x8);
+    u8g2.setCursor(2, 28);
+    u8g2.print("Connected to:");
+    u8g2.setCursor(2, 40);
+    u8g2.print(WiFi.SSID());
+    u8g2.setFont(leaf_icons);
+    u8g2.setCursor(85, 40);
+    u8g2.print((char)wifiIconForCurrentConnection());
+
+    drawQrCode(webserver_user_app_url().c_str(), 23, 58);
+
+    String shortUrl = webserver_user_app_url();
+    shortUrl.replace("http://", "");
+    u8g2.setFont(leaf_5x8);
+    u8g2.setCursor(2, 119);
+    u8g2.print(shortUrl);
+  } else {
+    u8g2.setFont(leaf_5x8);
+    u8g2.setCursor(2, 90);
+    u8g2.print("Web App is off");
+  }
 }
 
 /**************************

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -4,8 +4,8 @@
 
 #include "comms/ble.h"
 #include "comms/ota.h"
-#include "comms/wifi_coordinator.h"
 #include "comms/webserver.h"
+#include "comms/wifi_coordinator.h"
 #include "power.h"
 #include "system/version_info.h"
 #include "ui/audio/sound_effects.h"
@@ -155,9 +155,7 @@ void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) 
   }
 }
 
-void PageMenuSystemWifiSetup::beginWifiSetup() {
-  webserver_enable_wifi_setup();
-}
+void PageMenuSystemWifiSetup::beginWifiSetup() { webserver_enable_wifi_setup(); }
 
 void WifiMenuPage::attemptWifiConnection() {
   wifi_state = WifiState::CONNECTING;
@@ -360,11 +358,10 @@ void PageMenuSystemWifiSetup::draw_extra() {
   u8g2.setCursor(0, y);
 
   // Instruction Page
-  const char* lines[] = {"Follow these steps", "on Phone or Laptop:", "1.Join Leaf WiFi",   " ",
-                         "2.Click Sign In",   "  Or Visit:",         "192.168.4.1/wifi",
-                         " ",                 "3.Enter Network",     "Select your network",
-                         "and enter password", " ",                  "4.Press Save",
-                         "This page will close", "when connected..."};
+  const char* lines[] = {"Follow these steps", "on Phone or Laptop:",  "1.Join Leaf WiFi",   " ",
+                         "2.Click Sign In",    "  Or Visit:",          "192.168.4.1/wifi",   " ",
+                         "3.Enter Network",    "Select your network",  "and enter password", " ",
+                         "4.Press Save",       "This page will close", "when connected..."};
 
   uint8_t lineNum = 0;
 

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -149,15 +149,7 @@ void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) 
 }
 
 void PageMenuSystemWifiSetup::beginWifiSetup() {
-  // TODO: adding these three lines increased reliability of captive portal.  not sure why
-  WiFi.mode(WIFI_AP_STA);
-  WiFi.beginSmartConfig();
-  delay(500);
-
-  WiFi.mode(WIFI_STA);
-  wm.setConfigPortalBlocking(false);
-  wm.autoConnect("Leaf WiFi");
-  wm.setConfigPortalTimeout(60);
+  webserver_enable_wifi_setup();
 }
 
 void WifiMenuPage::attemptWifiConnection() {
@@ -317,13 +309,17 @@ void PageMenuSystemWifiSetup::shown() {
   beginWifiSetup();
 }
 
+void PageMenuSystemWifiSetup::closed(bool removed_from_Stack) {
+  if (removed_from_Stack) {
+    webserver_disable_user_app();
+  }
+}
+
 void PageMenuSystemWifiSetup::loop() {
-  // If we're connected, or portal times out, close the page
-  if (WiFi.status() == WL_CONNECTED || wm.getConfigPortalActive() == false) {
+  if (WiFi.status() == WL_CONNECTED) {
     pop_page();
     return;
   }
-  wm.process();
 }
 
 void PageMenuSystemWifiSetup::draw_extra() {
@@ -341,10 +337,11 @@ void PageMenuSystemWifiSetup::draw_extra() {
   u8g2.setCursor(0, y);
 
   // Instruction Page
-  const char* lines[] = {"Follow these steps", "on Phone or Laptop:",  "1.Join Leaf WiFi",   " ",
-                         "2.Click Sign In",    "  Or Visit:",          "http://192.168.4.1", " ",
-                         "3.Configure WiFi",   "Select your network",  "and enter password", " ",
-                         "4.Press Save",       "This page will close", "when connected..."};
+  const char* lines[] = {"Follow these steps", "on Phone or Laptop:", "1.Join Leaf WiFi",   " ",
+                         "2.Click Sign In",   "  Or Visit:",         "192.168.4.1/app/wifi",
+                         " ",                 "3.Enter Network",     "Select your network",
+                         "and enter password", " ",                  "4.Press Save",
+                         "This page will close", "when connected..."};
 
   uint8_t lineNum = 0;
 

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.h
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.h
@@ -3,7 +3,6 @@
 
 #include <Arduino.h>
 #include <WiFi.h>
-#include <WiFiManager.h>  // https://github.com/tzapu/WiFiManager
 
 #include "etl/array.h"
 #include "etl/array_view.h"
@@ -34,11 +33,11 @@ class PageMenuSystemWifiSetup : public SimpleSettingsMenuPage {
 
   void loop() override;
   void shown() override;
+  void closed(bool removed_from_Stack) override;
   void draw_extra() override;
 
  private:
   int wifiIcon = 62;  // the "empty signal" icon
-  WiFiManager wm;
   void beginWifiSetup(void);
 };
 

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.h
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.h
@@ -9,6 +9,7 @@
 #include "etl/array_view.h"
 #include "etl/vector.h"
 #include "ui/display/menu_page.h"
+#include "ui/display/pages/dialogs/page_qr.h"
 #include "ui/input/buttons.h"
 
 enum class WifiState {
@@ -63,13 +64,36 @@ class PageMenuSystemWifiUpdate : public SimpleSettingsMenuPage {
 };
 
 /////////////////////////////////////////
+// WiFi Web App sub-page
+//  Purpose: Starts a lightweight Leaf-hosted web app
+class PageMenuSystemWifiWebApp : public SimpleSettingsMenuPage {
+ public:
+  const char* get_title() const override { return "Web App"; }
+
+  void draw() override;
+  void shown() override;
+  void closed(bool removed_from_Stack) override;
+  void draw_extra() override;
+  etl::array_view<const char*> get_labels() const override;
+
+ protected:
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
+
+ private:
+  static etl::array<const char*, 1> network_labels;
+  bool using_leaf_wifi = false;
+  PageQR page_qr;
+  void start(bool useLeafWifi);
+};
+
+/////////////////////////////////////////
 // Main Parent Wifi Menu Page
 //
 class WifiMenuPage : public SettingsMenuPage {
  public:
   WifiMenuPage() : page_wifi_update(&wifi_state) {
     cursor_position = 0;
-    cursor_max = 2;
+    cursor_max = 3;
   }
   void draw();
   bool firstOpened = true;
@@ -78,10 +102,11 @@ class WifiMenuPage : public SettingsMenuPage {
   void setting_change(Button dir, ButtonEvent state, uint8_t count);
 
  private:
-  static constexpr char* labels[3] = {"Back", "Setup Wifi", "Reset Wifi"};
+  static constexpr char* labels[4] = {"Back", "Setup Wifi", "Web App", "Reset Wifi"};
   WifiState wifi_state;
   PageMenuSystemWifiSetup page_wifi_setup;
   PageMenuSystemWifiUpdate page_wifi_update;
+  PageMenuSystemWifiWebApp page_wifi_web_app;
   void attemptWifiConnection(void);
 };
 

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.h
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.h
@@ -37,7 +37,9 @@ class PageMenuSystemWifiSetup : public SimpleSettingsMenuPage {
   void draw_extra() override;
 
  private:
+  static constexpr uint32_t STARTING_MESSAGE_MS = 8000;
   int wifiIcon = 62;  // the "empty signal" icon
+  uint32_t starting_message_started_ms = 0;
   void beginWifiSetup(void);
 };
 

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -29,6 +29,13 @@ Preferences leafPrefs;
 namespace {
   constexpr auto FACTORY_FLAGS_NAMESPACE = "factoryFlags";
   constexpr auto FORCE_FORMAT_SD_CARD_KEY = "FORCE_FMT_SD";
+
+  void clearSavedWifiCredentials() {
+    esp_err_t err = esp_wifi_restore();
+    if (err != ESP_OK) {
+      Serial.printf("Failed to erase saved WiFi credentials: %d\n", err);
+    }
+  }
 }  // namespace
 
 bool Settings::init() {
@@ -105,15 +112,7 @@ bool Settings::consumeProductionTestForceFormatSdCard() {
 // Reset Leaf user settings and info to defaults
 void Settings::reset() {
   loadDefaults();
-
-  // Clear any other user-supplied information
-  // Clear WiFi credentials
-  wifi_config_t current_conf;
-  esp_wifi_get_config((wifi_interface_t)ESP_IF_WIFI_STA, &current_conf);
-  memset(current_conf.sta.ssid, 0, sizeof(current_conf.sta.ssid));
-  memset(current_conf.sta.password, 0, sizeof(current_conf.sta.password));
-  esp_wifi_set_config((wifi_interface_t)ESP_IF_WIFI_STA, &current_conf);
-
+  clearSavedWifiCredentials();
   save();
 }
 


### PR DESCRIPTION
## Summary

Adds a Leaf-hosted WiFi/web app flow for setup-time and post-flight device interaction.

- Added a lightweight user web app served by Leaf, with routes for app shell/status and WiFi provisioning.
- Replaced WiFiManager captive portal setup with a custom `/wifi` setup page.
- Added Leaf WiFi menu entry points for Web App and WiFi setup, including QR-code based access.
- Added `wifi_coordinator` to centralize user WiFi setup/reset/AP preparation and prevent diagnostic-network scans from interfering once the user enters WiFi flows.
- Preserved factory commissioning behavior while avoiding accidental WiFi credential erasure during normal diagnostic scans.
- Added robust WiFi credential reset behavior, including saved ESP WiFi credential clearing where appropriate.
- Improved setup reliability with a smaller WiFi setup page, capped network scan list, async scan behavior, and better connection failure handling.
- Added user-facing LCD guidance for Leaf WiFi startup delay and shortened setup URL to `192.168.4.1/wifi`.
- Added dynamic top-level WiFi status display, including saved-network searching state and protection against blank SSID display while connection metadata settles.
- Kept `/app/wifi` as a compatibility alias while making `/wifi` the primary setup route.

## Testing

- Built successfully with:
  - `C:\Users\oxoth\.platformio\penv\Scripts\pio.exe run`
- Hardware-tested WiFi setup flows across repeated cycles:
  - Fresh setup from Leaf WiFi AP
  - Reset WiFi and reconnect
  - Repeated setup/reset/setup attempts
  - Incorrect password handling and retry
  - Saved-network auto-connect status display
  - Web app access over Leaf WiFi and home network
- Confirmed setup page remains responsive after heap/page-size reductions.
- Confirmed bad password no longer causes premature/false failure during transient WiFi states.
- Confirmed Leaf WiFi setup instructions and delay page display on-device.