### PR TITLE
Basic Web App hosted by Leaf

### DIFF
--- a/docs/dev-references/backlog/lcd-preview-renderer.md
+++ b/docs/dev-references/backlog/lcd-preview-renderer.md
@@ -1,0 +1,27 @@
+---
+title: LCD Preview Renderer Backlog
+description: Future host-side pixel-exact renderer for Leaf LCD page layout iteration.
+---
+
+# LCD Preview Renderer Backlog
+
+Display-only UI tweaks currently require building firmware, uploading, booting Leaf, and navigating menus before the layout can be reviewed. A host-side renderer would make iteration much faster, but it needs to be pixel-for-pixel identical to the Leaf LCD output to be useful for final layout decisions.
+
+An initial approximate Python layout renderer was tried and then removed because it was not accurate enough: host-rendered text and placeholder QR codes did not match Leaf's u8g2 fonts, QR output, title rows, footer rows, or exact drawing behavior.
+
+Future work:
+
+- Build a pixel-exact host renderer that runs the actual Leaf page drawing code against a host-side u8g2 framebuffer.
+- Link the real Leaf font arrays from `src/vario/ui/display/fonts.h`.
+- Link the real QR implementation from `src/vario/utils/qrcodex.c`.
+- Link the u8g2 core from `src/libraries/U8g2/src`.
+- Provide small host mocks for Arduino APIs, WiFi state, settings, page stack globals, and any hardware/global objects touched by the page under test.
+- Export the rendered `96x192` native framebuffer as PNG, plus an integer-scaled preview PNG for easier review.
+- Start with `PageMenuSystemWifiWebApp` in Leaf-AP mode, then generalize to other pages once the harness is proven.
+- Ensure the tool uses the same display rotation/orientation as firmware (`96x192` portrait for current Leaf hardware).
+
+Notes from the first attempt:
+
+- A non-exact renderer is not sufficient for design decisions.
+- The Codex Windows environment at the time did not expose a native C/C++ compiler (`cl`, `gcc`, `clang`, `zig`) or a Python FFI/JIT compiler, so the exact u8g2 harness could not be built there.
+- Revisit this when a host compiler is available, or consider a firmware-side debug endpoint that renders the real framebuffer and exports it for review.

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -8,6 +8,7 @@
 #include "comms/factory_discovery.h"
 #include "comms/fanet_radio.h"
 #include "comms/wifi_coordinator.h"
+#include "diagnostics/heap_monitor.h"
 #include "diagnostics/memory_report.h"
 #include "diagnostics/self_test/selfTest.h"
 #include "etl/string_stream.h"
@@ -36,6 +37,15 @@ namespace {
   uint32_t wifi_setup_connect_started_ms = 0;
   String wifi_setup_connect_ssid = "";
   String wifi_setup_connect_error = "";
+  uint32_t user_app_loop_count = 0;
+  uint32_t user_app_handle_count = 0;
+  uint32_t user_app_route_root_count = 0;
+  uint32_t user_app_route_app_count = 0;
+  uint32_t user_app_route_status_count = 0;
+  uint32_t user_app_route_profiles_get_count = 0;
+  uint32_t user_app_route_profiles_put_count = 0;
+  uint32_t user_app_route_not_found_count = 0;
+  uint8_t user_app_max_ap_stations = 0;
 
   enum class SelfTestMode { None, Interactive };
 
@@ -44,6 +54,8 @@ namespace {
   static constexpr size_t PROFILE_FILE_MAX_BYTES = 4096;
   static constexpr const char* PROFILE_TEMP_FILE = "/profiles/profiles.tmp";
   static constexpr const char* PROFILE_BACKUP_FILE = "/profiles/profiles.bak";
+  static constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
+  static constexpr const char* USER_APP_DIAGNOSTICS_FILE = "/diagnostics/webapp_requests.csv";
 
   SelfTestMode last_self_test_mode = SelfTestMode::None;
   bool interactive_self_test_pending = false;
@@ -57,6 +69,57 @@ namespace {
                   static_cast<unsigned long>(wifi_setup_cycle),
                   static_cast<unsigned long>(millis() - wifi_setup_started_ms), event,
                   ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+  }
+
+  void resetUserAppCounters() {
+    user_app_loop_count = 0;
+    user_app_handle_count = 0;
+    user_app_route_root_count = 0;
+    user_app_route_app_count = 0;
+    user_app_route_status_count = 0;
+    user_app_route_profiles_get_count = 0;
+    user_app_route_profiles_put_count = 0;
+    user_app_route_not_found_count = 0;
+    user_app_max_ap_stations = 0;
+  }
+
+  void updateUserAppStationPeak() {
+    const uint8_t station_count = WiFi.softAPgetStationNum();
+    if (station_count > user_app_max_ap_stations) user_app_max_ap_stations = station_count;
+  }
+
+  void dumpUserAppCounters(const char* event) {
+    if (!SD_MMC.exists(DIAGNOSTICS_DIR)) SD_MMC.mkdir(DIAGNOSTICS_DIR);
+
+    const bool existed = SD_MMC.exists(USER_APP_DIAGNOSTICS_FILE);
+    File file = SD_MMC.open(USER_APP_DIAGNOSTICS_FILE, "a", true);
+    if (!file) return;
+
+    if (!existed || file.size() == 0) {
+      file.println("millis,event,enabled,using_leaf_wifi,user_server_started,main_server_started,"
+                   "ap_stations,max_ap_stations,wifi_status,free_heap,max_alloc_heap,loop_count,"
+                   "handle_count,root,app,status,profiles_get,profiles_put,not_found,ap_ip");
+    }
+
+    updateUserAppStationPeak();
+    const String ap_ip = WiFi.softAPIP().toString();
+    file.printf("%lu,%s,%u,%u,%u,%u,%u,%u,%d,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%s\n",
+                static_cast<unsigned long>(millis()), event ? event : "",
+                user_app_enabled ? 1 : 0, user_app_using_leaf_wifi ? 1 : 0,
+                user_server_started ? 1 : 0, webserver_started ? 1 : 0,
+                static_cast<unsigned int>(WiFi.softAPgetStationNum()),
+                static_cast<unsigned int>(user_app_max_ap_stations),
+                static_cast<int>(WiFi.status()), static_cast<unsigned long>(ESP.getFreeHeap()),
+                static_cast<unsigned long>(ESP.getMaxAllocHeap()),
+                static_cast<unsigned long>(user_app_loop_count),
+                static_cast<unsigned long>(user_app_handle_count),
+                static_cast<unsigned long>(user_app_route_root_count),
+                static_cast<unsigned long>(user_app_route_app_count),
+                static_cast<unsigned long>(user_app_route_status_count),
+                static_cast<unsigned long>(user_app_route_profiles_get_count),
+                static_cast<unsigned long>(user_app_route_profiles_put_count),
+                static_cast<unsigned long>(user_app_route_not_found_count), ap_ip.c_str());
+    file.close();
   }
 
   const char* selfTestModeName(SelfTestMode mode) {
@@ -750,14 +813,28 @@ loadStatus();loadProfiles();
     if (user_server_started) return;
 
     if (!user_server_routes_configured) {
-      user_server.on("/", HTTP_GET,
-                     []() { sendRedirect(user_server, user_app_provisioning ? "/wifi" : "/app"); });
-      user_server.on("/app", HTTP_GET, []() { sendUserAppShell(user_server); });
+      user_server.on("/", HTTP_GET, []() {
+        user_app_route_root_count++;
+        sendRedirect(user_server, user_app_provisioning ? "/wifi" : "/app");
+      });
+      user_server.on("/app", HTTP_GET, []() {
+        user_app_route_app_count++;
+        sendUserAppShell(user_server);
+      });
       user_server.on("/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
       user_server.on("/app/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
-      user_server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(user_server); });
-      user_server.on("/api/profiles", HTTP_GET, []() { sendProfiles(user_server); });
-      user_server.on("/api/profiles", HTTP_PUT, []() { saveProfiles(user_server); });
+      user_server.on("/api/user/status", HTTP_GET, []() {
+        user_app_route_status_count++;
+        sendUserStatus(user_server);
+      });
+      user_server.on("/api/profiles", HTTP_GET, []() {
+        user_app_route_profiles_get_count++;
+        sendProfiles(user_server);
+      });
+      user_server.on("/api/profiles", HTTP_PUT, []() {
+        user_app_route_profiles_put_count++;
+        saveProfiles(user_server);
+      });
       user_server.on("/api/wifi/status", HTTP_GET,
                      []() { user_server.send(200, "application/json", wifiStatusJson()); });
       user_server.on("/api/wifi/networks", HTTP_GET, []() { sendWifiNetworks(user_server); });
@@ -772,6 +849,7 @@ loadStatus();loadProfiles();
       user_server.on("/ncsi.txt", HTTP_GET,
                      []() { sendNoCaptivePortalResponse(user_server, "Microsoft NCSI"); });
       user_server.onNotFound([]() {
+        user_app_route_not_found_count++;
         if (handleCaptivePortalRequest(user_server)) return;
         user_server.send(404, "text/plain", "Not found");
       });
@@ -1059,8 +1137,11 @@ void webserver_loop() {
   if (WiFi.status() == WL_CONNECTED || user_app_enabled) {
     server.handleClient();
     if (user_app_enabled) {
+      user_app_loop_count++;
+      updateUserAppStationPeak();
       if (user_app_provisioning) updateWifiNetworkScan();
       if (user_app_provisioning) dns_server.processNextRequest();
+      user_app_handle_count++;
       user_server.handleClient();
     }
     updatePendingInteractiveSelfTest();
@@ -1068,20 +1149,28 @@ void webserver_loop() {
 }
 
 void webserver_enable_user_app(bool useLeafWifi) {
+  heap_monitor::clear();
+  resetUserAppCounters();
+  heap_monitor::record("enable-start");
   if (useLeafWifi || WiFi.status() != WL_CONNECTED) {
     leaf_wifi::prepareForLeafAccessPoint();
+    heap_monitor::record("after-prepare-ap");
     WiFi.mode(WIFI_AP);
     WiFi.setSleep(false);
     WiFi.softAP("Leaf WiFi");
+    heap_monitor::record("after-softap");
     user_app_using_leaf_wifi = true;
   } else {
     user_app_using_leaf_wifi = false;
+    heap_monitor::record("using-sta");
   }
 
   user_app_enabled = true;
   user_app_provisioning = false;
   setupUserAppServer();
+  heap_monitor::record("after-user-server");
   webserver_setup();
+  heap_monitor::record("enabled");
 }
 
 void webserver_enable_wifi_setup() {
@@ -1109,6 +1198,8 @@ void webserver_enable_wifi_setup() {
 }
 
 void webserver_disable_user_app() {
+  heap_monitor::record("disable-start");
+  dumpUserAppCounters("disable-start");
   user_app_enabled = false;
   if (user_app_provisioning) dns_server.stop();
   user_app_provisioning = false;
@@ -1121,12 +1212,17 @@ void webserver_disable_user_app() {
   if (user_server_started) {
     user_server.stop();
     user_server_started = false;
+    heap_monitor::record("after-user-stop");
   }
   if (user_app_using_leaf_wifi) {
     WiFi.softAPdisconnect(true);
     WiFi.mode(WIFI_STA);
+    heap_monitor::record("after-ap-stop");
   }
   user_app_using_leaf_wifi = false;
+  heap_monitor::record("disabled");
+  dumpUserAppCounters("disabled");
+  heap_monitor::dumpToSd();
 }
 
 bool webserver_user_app_active() { return user_app_enabled; }

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -12,6 +12,7 @@
 #include "diagnostics/self_test/selfTest.h"
 #include "etl/string_stream.h"
 #include "power.h"
+#include "profiles/profile_store.h"
 #include "storage/sd_card.h"
 #include "system/version_info.h"
 #include "ui/display/display.h"
@@ -40,6 +41,9 @@ namespace {
 
   static constexpr uint32_t SELF_TEST_POWER_ON_DELAY_MS = 10000;
   static constexpr uint32_t WIFI_SETUP_CONNECT_TIMEOUT_MS = 12000;
+  static constexpr size_t PROFILE_FILE_MAX_BYTES = 4096;
+  static constexpr const char* PROFILE_TEMP_FILE = "/profiles/profiles.tmp";
+  static constexpr const char* PROFILE_BACKUP_FILE = "/profiles/profiles.bak";
 
   SelfTestMode last_self_test_mode = SelfTestMode::None;
   bool interactive_self_test_pending = false;
@@ -421,6 +425,106 @@ namespace {
     return json;
   }
 
+  const char* emptyProfilesJson() {
+    return "{\"schema\":\"leaf.profiles\",\"schema_version\":\"v0.1.0\","
+           "\"active_pilot_id\":null,\"active_glider_id\":null,\"pilots\":[],\"gliders\":[]}";
+  }
+
+  void sendProfiles(WebServer& target) {
+    if (!user_app_enabled) {
+      target.send(404, "application/json", "{\"detail\":\"Leaf Web App is not active.\"}");
+      return;
+    }
+
+    if (!sdcard.isMounted()) {
+      target.send(404, "application/json", "{\"detail\":\"SD card is not mounted.\"}");
+      return;
+    }
+
+    if (!SD_MMC.exists(ProfileStore::filePath())) {
+      sendNoStoreHeaders(target);
+      target.send(200, "application/json", emptyProfilesJson());
+      return;
+    }
+
+    File file = SD_MMC.open(ProfileStore::filePath(), "r");
+    if (!file) {
+      target.send(500, "application/json",
+                  "{\"detail\":\"Profiles file could not be opened.\"}");
+      return;
+    }
+
+    sendNoStoreHeaders(target);
+    target.streamFile(file, "application/json");
+    file.close();
+  }
+
+  bool profilesRequestLooksValid(const String& body) {
+    if (body.length() == 0 || body.length() > PROFILE_FILE_MAX_BYTES) return false;
+    if (extractJsonStringValue(body, "schema") != "leaf.profiles") return false;
+    if (body.indexOf("\"pilots\"") < 0 || body.indexOf("\"gliders\"") < 0) return false;
+    return true;
+  }
+
+  bool writeProfilesBody(const String& body) {
+    if (!SD_MMC.exists(ProfileStore::directoryPath()) && !SD_MMC.mkdir(ProfileStore::directoryPath())) {
+      return false;
+    }
+
+    if (SD_MMC.exists(PROFILE_TEMP_FILE)) SD_MMC.remove(PROFILE_TEMP_FILE);
+    if (SD_MMC.exists(PROFILE_BACKUP_FILE)) SD_MMC.remove(PROFILE_BACKUP_FILE);
+
+    File file = SD_MMC.open(PROFILE_TEMP_FILE, "w", true);
+    if (!file) return false;
+
+    const size_t written = file.print(body);
+    file.close();
+    if (written != body.length()) {
+      SD_MMC.remove(PROFILE_TEMP_FILE);
+      return false;
+    }
+
+    const bool hadExisting = SD_MMC.exists(ProfileStore::filePath());
+    if (hadExisting && !SD_MMC.rename(ProfileStore::filePath(), PROFILE_BACKUP_FILE)) {
+      SD_MMC.remove(PROFILE_TEMP_FILE);
+      return false;
+    }
+
+    if (!SD_MMC.rename(PROFILE_TEMP_FILE, ProfileStore::filePath())) {
+      if (hadExisting) SD_MMC.rename(PROFILE_BACKUP_FILE, ProfileStore::filePath());
+      SD_MMC.remove(PROFILE_TEMP_FILE);
+      return false;
+    }
+
+    if (hadExisting) SD_MMC.remove(PROFILE_BACKUP_FILE);
+    return true;
+  }
+
+  void saveProfiles(WebServer& target) {
+    if (!user_app_enabled) {
+      target.send(404, "application/json", "{\"detail\":\"Leaf Web App is not active.\"}");
+      return;
+    }
+
+    if (!sdcard.isMounted()) {
+      target.send(404, "application/json", "{\"detail\":\"SD card is not mounted.\"}");
+      return;
+    }
+
+    const String body = target.arg("plain");
+    if (!profilesRequestLooksValid(body)) {
+      target.send(400, "application/json", "{\"detail\":\"Invalid profiles JSON.\"}");
+      return;
+    }
+
+    if (!writeProfilesBody(body)) {
+      target.send(500, "application/json", "{\"saved\":false}");
+      return;
+    }
+
+    target.send(200, "application/json", "{\"saved\":true}");
+  }
+
   void sendRedirect(WebServer& target, const char* location) {
     sendNoStoreHeaders(target);
     target.sendHeader("Location", location, true);
@@ -448,120 +552,56 @@ namespace {
       return;
     }
 
-    target.send(200, "text/html", R"(
-      <!DOCTYPE html>
-      <html lang="en">
-        <head>
-          <meta charset="utf-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1">
-          <title>Leaf Web App</title>
-          <style>
-            :root {
-              color-scheme: light;
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-              line-height: 1.35;
-            }
-            body {
-              margin: 0;
-              background: #f5f7f2;
-              color: #172016;
-            }
-            header {
-              background: #172016;
-              color: white;
-              padding: 20px;
-            }
-            main {
-              max-width: 720px;
-              margin: 0 auto;
-              padding: 20px;
-            }
-            h1 {
-              font-size: 28px;
-              margin: 0;
-            }
-            h2 {
-              font-size: 18px;
-              margin: 0 0 8px;
-            }
-            section {
-              border-bottom: 1px solid #d9dfd3;
-              padding: 18px 0;
-            }
-            label {
-              display: block;
-              font-size: 14px;
-              font-weight: 650;
-              margin: 14px 0 6px;
-            }
-            input, select, button {
-              box-sizing: border-box;
-              width: 100%;
-              border: 1px solid #bac3b4;
-              border-radius: 6px;
-              font: inherit;
-              padding: 12px;
-            }
-            button {
-              background: #172016;
-              color: white;
-              font-weight: 700;
-              margin-top: 16px;
-            }
-            .status {
-              display: grid;
-              gap: 6px;
-              font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
-              font-size: 14px;
-            }
-            .muted {
-              color: #596256;
-            }
-          </style>
-        </head>
-        <body>
-          <header>
-            <h1>Leaf Web App</h1>
-          </header>
-          <main>
-            <section>
-              <h2>Status</h2>
-              <div class="status" id="status">Loading...</div>
-            </section>
-            <section>
-              <h2>Settings</h2>
-              <p class="muted">Settings tools will be added here.</p>
-            </section>
-            <section>
-              <h2>Flight Logs</h2>
-              <p class="muted">Logbook tools will be added here.</p>
-            </section>
-            <section>
-              <h2>Waypoints & Routes</h2>
-              <p class="muted">Navigation file tools will be added here.</p>
-            </section>
-          </main>
-          <script>
-            async function loadStatus() {
-              const target = document.getElementById('status');
-              try {
-                const response = await fetch('/api/user/status');
-                const status = await response.json();
-                target.innerHTML = [
-                  `mode: ${status.mode}`,
-                  `ssid: ${status.ssid || '(none)'}`,
-                  `ip: ${status.ip_address || '(none)'}`,
-                  `firmware: ${status.firmware_version}`
-                ].join('<br>');
-              } catch (error) {
-                target.textContent = 'Unable to read status.';
-              }
-            }
-            loadStatus();
-          </script>
-        </body>
-      </html>
-    )");
+    target.send(200, "text/html", R"leafapp(<!doctype html><html lang=en><head><meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf</title><style>:root{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#172016;background:#f5f7f2;line-height:1.35}body{margin:0}header{background:#172016;color:white;padding:18px 20px}main{max-width:640px;margin:auto;padding:16px 18px}h1{font-size:24px;margin:0}h2{font-size:18px;margin:0 0 10px}section{border-bottom:1px solid #d9dfd3;padding:18px 0}.grid{display:grid;gap:10px}.row{display:flex;gap:8px}.row>*{flex:1}.row>.small{flex:0 0 94px}label{display:block;font-size:13px;font-weight:650;margin:10px 0 4px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:11px;border:1px solid #bac3b4;border-radius:6px;background:white}button{background:#172016;color:white;font-weight:700}.secondary{background:white;color:#172016}.danger{background:#5d1717;color:white}.muted{color:#596256}.status{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:13px;white-space:pre-wrap}.msg{min-height:20px;margin-top:10px}</style></head><body><header><h1>Leaf</h1></header><main><section><h2>Status</h2><div class=status id=status>Loading...</div></section><section><h2>Pilots</h2><label>Active pilot</label><select id=pilotList></select><label>Name</label><input id=pilotName maxlength=48 autocomplete=name><div class=row><button id=pilotSave>Save</button><button class=secondary id=pilotNew>New</button><button class="small danger" id=pilotDelete>Delete</button></div></section><section><h2>Gliders</h2><label>Active glider</label><select id=gliderList></select><div class=row><div><label>Brand</label><input id=gliderBrand maxlength=32></div><div><label>Model</label><input id=gliderModel maxlength=48></div></div><div class=row><div><label>Size</label><input id=gliderSize maxlength=16></div><div><label>Display name</label><input id=gliderDisplay maxlength=64></div></div><div class=row><button id=gliderSave>Save</button><button class=secondary id=gliderNew>New</button><button class="small danger" id=gliderDelete>Delete</button></div><p class="muted msg" id=msg></p></section></main><script>
+let profiles={schema:'leaf.profiles',schema_version:'v0.1.0',active_pilot_id:null,active_glider_id:null,pilots:[],gliders:[]};
+const $=id=>document.getElementById(id);
+function id(){return Math.floor(Math.random()*0xffffffff).toString(16).padStart(8,'0')}
+function clean(v){v=(v||'').trim();return v?v:null}
+function pilotLabel(p){return p.name||'Unnamed pilot'}
+function gliderLabel(g){return g.display_name||[g.brand,g.model,g.size].filter(Boolean).join(' ')||'Unnamed glider'}
+function selectedPilot(){return profiles.pilots.find(p=>p.id==profiles.active_pilot_id)}
+function selectedGlider(){return profiles.gliders.find(g=>g.id==profiles.active_glider_id)}
+function setMsg(t){$('msg').textContent=t||''}
+function render(){
+  let pl=$('pilotList');pl.textContent='';
+  profiles.pilots.forEach(p=>{let o=document.createElement('option');o.value=p.id;o.textContent=pilotLabel(p);pl.appendChild(o)});
+  if(profiles.active_pilot_id)pl.value=profiles.active_pilot_id;
+  let p=selectedPilot();$('pilotName').value=p?p.name||'':'';
+  let gl=$('gliderList');gl.textContent='';
+  profiles.gliders.forEach(g=>{let o=document.createElement('option');o.value=g.id;o.textContent=gliderLabel(g);gl.appendChild(o)});
+  if(profiles.active_glider_id)gl.value=profiles.active_glider_id;
+  let g=selectedGlider();$('gliderBrand').value=g?g.brand||'':'';$('gliderModel').value=g?g.model||'':'';$('gliderSize').value=g?g.size||'':'';$('gliderDisplay').value=g?g.display_name||'':'';
+}
+function normalize(){
+  profiles.schema='leaf.profiles';profiles.schema_version='v0.1.0';
+  profiles.pilots=(profiles.pilots||[]).filter(p=>p&&p.id&&p.name);
+  profiles.gliders=(profiles.gliders||[]).filter(g=>g&&g.id&&g.model);
+  if(!profiles.pilots.find(p=>p.id==profiles.active_pilot_id))profiles.active_pilot_id=profiles.pilots.length==1?profiles.pilots[0].id:null;
+  if(!profiles.gliders.find(g=>g.id==profiles.active_glider_id))profiles.active_glider_id=profiles.gliders.length==1?profiles.gliders[0].id:null;
+}
+async function save(note){
+  normalize();
+  let r=await fetch('/api/profiles',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(profiles)});
+  if(!r.ok)throw new Error();
+  setMsg(note||'Saved.');
+  render();
+}
+async function loadStatus(){
+  try{let s=await(await fetch('/api/user/status')).json();$('status').textContent=`mode: ${s.mode}\nssid: ${s.ssid||'(none)'}\nip: ${s.ip_address||'(none)'}\nfirmware: ${s.firmware_version}`}catch(e){$('status').textContent='Unable to read status.'}
+}
+async function loadProfiles(){
+  try{profiles=await(await fetch('/api/profiles')).json();normalize();render();setMsg('')}catch(e){setMsg('Unable to read profiles.')}
+}
+$('pilotList').onchange=()=>{profiles.active_pilot_id=$('pilotList').value;render();save('Active pilot saved.').catch(()=>setMsg('Unable to save.'))};
+$('gliderList').onchange=()=>{profiles.active_glider_id=$('gliderList').value;render();save('Active glider saved.').catch(()=>setMsg('Unable to save.'))};
+$('pilotNew').onclick=()=>{$('pilotList').value='';profiles.active_pilot_id=null;$('pilotName').value='';$('pilotName').focus();setMsg('Enter pilot name, then Save.')};
+$('gliderNew').onclick=()=>{$('gliderList').value='';profiles.active_glider_id=null;['gliderBrand','gliderModel','gliderSize','gliderDisplay'].forEach(x=>$(x).value='');$('gliderModel').focus();setMsg('Enter glider details, then Save.')};
+$('pilotSave').onclick=()=>{let name=clean($('pilotName').value);if(!name){setMsg('Pilot name is required.');return}let p=selectedPilot();if(!p){p={id:id(),name:''};profiles.pilots.push(p);profiles.active_pilot_id=p.id}p.name=name;save('Pilot saved.').catch(()=>setMsg('Unable to save pilot.'))};
+$('gliderSave').onclick=()=>{let model=clean($('gliderModel').value);if(!model){setMsg('Glider model is required.');return}let g=selectedGlider();if(!g){g={id:id(),model:''};profiles.gliders.push(g);profiles.active_glider_id=g.id}g.brand=clean($('gliderBrand').value);g.model=model;g.size=clean($('gliderSize').value);g.display_name=clean($('gliderDisplay').value);save('Glider saved.').catch(()=>setMsg('Unable to save glider.'))};
+$('pilotDelete').onclick=()=>{let p=selectedPilot();if(!p)return;profiles.pilots=profiles.pilots.filter(x=>x.id!=p.id);profiles.active_pilot_id=null;save('Pilot deleted.').catch(()=>setMsg('Unable to delete pilot.'))};
+$('gliderDelete').onclick=()=>{let g=selectedGlider();if(!g)return;profiles.gliders=profiles.gliders.filter(x=>x.id!=g.id);profiles.active_glider_id=null;save('Glider deleted.').catch(()=>setMsg('Unable to delete glider.'))};
+loadStatus();loadProfiles();
+</script></body></html>)leafapp");
   }
 
   void sendWifiSetupPage(WebServer& target) {
@@ -716,6 +756,8 @@ namespace {
       user_server.on("/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
       user_server.on("/app/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
       user_server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(user_server); });
+      user_server.on("/api/profiles", HTTP_GET, []() { sendProfiles(user_server); });
+      user_server.on("/api/profiles", HTTP_PUT, []() { saveProfiles(user_server); });
       user_server.on("/api/wifi/status", HTTP_GET,
                      []() { user_server.send(200, "application/json", wifiStatusJson()); });
       user_server.on("/api/wifi/networks", HTTP_GET, []() { sendWifiNetworks(user_server); });
@@ -912,6 +954,8 @@ void webserver_setup() {
   server.on("/app", HTTP_GET, []() { sendUserAppShell(server); });
 
   server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(server); });
+  server.on("/api/profiles", HTTP_GET, []() { sendProfiles(server); });
+  server.on("/api/profiles", HTTP_PUT, []() { saveProfiles(server); });
 
   server.on("/mac-address", HTTP_GET, []() {
     String json = "{\"mac_address\":\"";

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -911,6 +911,7 @@ void writeScreenshotBuffer(const char* buffer) {
 }
 
 void webserver_setup() {
+  if (!settings.dev_mode) return;
   if (debug_routes_configured) return;
 
   user_server.on("/app/debug", HTTP_GET, []() {

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -101,17 +101,18 @@ namespace {
     if (!file) return;
 
     if (!existed || file.size() == 0) {
-      file.println("millis,event,enabled,using_leaf_wifi,user_server_started,debug_routes_configured,"
-                   "ap_stations,max_ap_stations,wifi_status,free_heap,max_alloc_heap,loop_count,"
-                   "handle_count,root,app,status,profiles_get,profiles_put,not_found,ap_ip");
+      file.println(
+          "millis,event,enabled,using_leaf_wifi,user_server_started,debug_routes_configured,"
+          "ap_stations,max_ap_stations,wifi_status,free_heap,max_alloc_heap,loop_count,"
+          "handle_count,root,app,status,profiles_get,profiles_put,not_found,ap_ip");
     }
 
     updateUserAppStationPeak();
     const String ap_ip = WiFi.softAPIP().toString();
     file.printf("%lu,%s,%u,%u,%u,%u,%u,%u,%d,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%s\n",
-                static_cast<unsigned long>(millis()), event ? event : "",
-                user_app_enabled ? 1 : 0, user_app_using_leaf_wifi ? 1 : 0,
-                user_server_started ? 1 : 0, debug_routes_configured ? 1 : 0,
+                static_cast<unsigned long>(millis()), event ? event : "", user_app_enabled ? 1 : 0,
+                user_app_using_leaf_wifi ? 1 : 0, user_server_started ? 1 : 0,
+                debug_routes_configured ? 1 : 0,
                 static_cast<unsigned int>(WiFi.softAPgetStationNum()),
                 static_cast<unsigned int>(user_app_max_ap_stations),
                 static_cast<int>(WiFi.status()), static_cast<unsigned long>(ESP.getFreeHeap()),
@@ -614,8 +615,7 @@ namespace {
 
     File file = SD_MMC.open(ProfileStore::filePath(), "r");
     if (!file) {
-      target.send(500, "application/json",
-                  "{\"detail\":\"Profiles file could not be opened.\"}");
+      target.send(500, "application/json", "{\"detail\":\"Profiles file could not be opened.\"}");
       return;
     }
 
@@ -632,7 +632,8 @@ namespace {
   }
 
   bool writeProfilesBody(const String& body) {
-    if (!SD_MMC.exists(ProfileStore::directoryPath()) && !SD_MMC.mkdir(ProfileStore::directoryPath())) {
+    if (!SD_MMC.exists(ProfileStore::directoryPath()) &&
+        !SD_MMC.mkdir(ProfileStore::directoryPath())) {
       return false;
     }
 
@@ -717,7 +718,9 @@ namespace {
       return;
     }
 
-    target.send(200, "text/html", R"leafapp(<!doctype html><html lang=en><head><meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf</title><style>:root{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#172016;background:#f5f7f2;line-height:1.35}body{margin:0}header{background:#172016;color:white;padding:18px 20px}main{max-width:640px;margin:auto;padding:16px 18px}h1{font-size:24px;margin:0}h2{font-size:18px;margin:0 0 10px}section{border-bottom:1px solid #d9dfd3;padding:18px 0}.grid{display:grid;gap:10px}.row{display:flex;gap:8px}.row>*{flex:1}.row>.small{flex:0 0 94px}label{display:block;font-size:13px;font-weight:650;margin:10px 0 4px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:11px;border:1px solid #bac3b4;border-radius:6px;background:white}button{background:#172016;color:white;font-weight:700}.secondary{background:white;color:#172016}.danger{background:#5d1717;color:white}.muted{color:#596256}.status{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:13px;white-space:pre-wrap}.msg{min-height:20px;margin-top:10px}</style></head><body><header><h1>Leaf</h1></header><main><section><h2>Status</h2><div class=status id=status>Loading...</div></section><section><h2>Pilots</h2><label>Active pilot</label><select id=pilotList></select><label>Name</label><input id=pilotName maxlength=48 autocomplete=name><div class=row><button id=pilotSave>Save</button><button class=secondary id=pilotNew>New</button><button class="small danger" id=pilotDelete>Delete</button></div></section><section><h2>Gliders</h2><label>Active glider</label><select id=gliderList></select><div class=row><div><label>Brand</label><input id=gliderBrand maxlength=32></div><div><label>Model</label><input id=gliderModel maxlength=48></div></div><div class=row><div><label>Size</label><input id=gliderSize maxlength=16></div><div><label>Display name</label><input id=gliderDisplay maxlength=64></div></div><div class=row><button id=gliderSave>Save</button><button class=secondary id=gliderNew>New</button><button class="small danger" id=gliderDelete>Delete</button></div><p class="muted msg" id=msg></p></section></main><script>
+    target.send(
+        200, "text/html",
+        R"leafapp(<!doctype html><html lang=en><head><meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf</title><style>:root{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#172016;background:#f5f7f2;line-height:1.35}body{margin:0}header{background:#172016;color:white;padding:18px 20px}main{max-width:640px;margin:auto;padding:16px 18px}h1{font-size:24px;margin:0}h2{font-size:18px;margin:0 0 10px}section{border-bottom:1px solid #d9dfd3;padding:18px 0}.grid{display:grid;gap:10px}.row{display:flex;gap:8px}.row>*{flex:1}.row>.small{flex:0 0 94px}label{display:block;font-size:13px;font-weight:650;margin:10px 0 4px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:11px;border:1px solid #bac3b4;border-radius:6px;background:white}button{background:#172016;color:white;font-weight:700}.secondary{background:white;color:#172016}.danger{background:#5d1717;color:white}.muted{color:#596256}.status{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:13px;white-space:pre-wrap}.msg{min-height:20px;margin-top:10px}</style></head><body><header><h1>Leaf</h1></header><main><section><h2>Status</h2><div class=status id=status>Loading...</div></section><section><h2>Pilots</h2><label>Active pilot</label><select id=pilotList></select><label>Name</label><input id=pilotName maxlength=48 autocomplete=name><div class=row><button id=pilotSave>Save</button><button class=secondary id=pilotNew>New</button><button class="small danger" id=pilotDelete>Delete</button></div></section><section><h2>Gliders</h2><label>Active glider</label><select id=gliderList></select><div class=row><div><label>Brand</label><input id=gliderBrand maxlength=32></div><div><label>Model</label><input id=gliderModel maxlength=48></div></div><div class=row><div><label>Size</label><input id=gliderSize maxlength=16></div><div><label>Display name</label><input id=gliderDisplay maxlength=64></div></div><div class=row><button id=gliderSave>Save</button><button class=secondary id=gliderNew>New</button><button class="small danger" id=gliderDelete>Delete</button></div><p class="muted msg" id=msg></p></section></main><script>
 let profiles={schema:'leaf.profiles',schema_version:'v0.1.0',active_pilot_id:null,active_glider_id:null,pilots:[],gliders:[]};
 const $=id=>document.getElementById(id);
 function id(){return Math.floor(Math.random()*0xffffffff).toString(16).padStart(8,'0')}
@@ -1001,7 +1004,7 @@ void webserver_setup() {
         </body>
       </html>
     )");
-    });
+  });
 
   user_server.on("/api/debug/raw-xbm", HTTP_GET, []() {
     send_buffer = "";
@@ -1015,46 +1018,46 @@ void webserver_setup() {
     auto& radio = fanetRadio;
     auto protocol = radio.protocol;
 
-      // Lock the radio while we poke around their private parts
-      LockGuard lock(radio.x_fanet_manager_mutex);
-      auto& radioStats = protocol->stats();
-      // UnsafeManager* manager = (UnsafeManager*)radio.manager;
-      auto ms = millis();
+    // Lock the radio while we poke around their private parts
+    LockGuard lock(radio.x_fanet_manager_mutex);
+    auto& radioStats = protocol->stats();
+    // UnsafeManager* manager = (UnsafeManager*)radio.manager;
+    auto ms = millis();
 
-      ss << "<!DOCTYPE html>\n"
-         << "<html>\n"
-         << "<script>\n"
-         << "setTimeout(() => location.reload(), 1000);\n"
-         << "</script>\n"
-         << "<body><pre>\n"
+    ss << "<!DOCTYPE html>\n"
+       << "<html>\n"
+       << "<script>\n"
+       << "setTimeout(() => location.reload(), 1000);\n"
+       << "</script>\n"
+       << "<body><pre>\n"
 
-         << "Current Time: " << ms << endl
-         << endl
-         << "-- STATS -- " << endl
-         << "State: " << fanetRadio.getState().c_str() << "\n"
-         << "rx: " << radioStats.rx << "\n"
-         << "txSuccess: " << radioStats.txSuccess << "\n"
-         << "txFailed: " << radioStats.txFailed << "\n"
-         << "processed: " << radioStats.processed << "\n"
-         << "forwarded: " << radioStats.forwarded << "\n"
-         << "fwdMinRssiDrp: " << radioStats.fwdMinRssiDrp << "\n"
-         << "fwdNeighborDrp: " << radioStats.fwdNeighborDrp << "\n"
-         << "fwdDbBoostWeak: " << radioStats.fwdDbBoostWeak << "\n"
-         << "fwdDbBoostDrop: " << radioStats.fwdDbBoostDrop << "\n"
-         << "rxFromUsDrp: " << radioStats.rxFromUsDrp << "\n"
-         << "txAck: " << radioStats.txAck << "\n"
-         << "neighbors: " << radioStats.neighborTableSize << "\n"
-         << "-- Manager --" << endl
-         << "Manager Queue Length: " << protocol->txPoolSize() << endl
-         << "Next allowed tracking time: "
-         << (radio.m_nextAllowedTrackingTimeMs ? (long long)radio.m_nextAllowedTrackingTimeMs - ms
-                                               : 0) /
-                1000.0f
-         << "s" << endl
-         << endl
+       << "Current Time: " << ms << endl
+       << endl
+       << "-- STATS -- " << endl
+       << "State: " << fanetRadio.getState().c_str() << "\n"
+       << "rx: " << radioStats.rx << "\n"
+       << "txSuccess: " << radioStats.txSuccess << "\n"
+       << "txFailed: " << radioStats.txFailed << "\n"
+       << "processed: " << radioStats.processed << "\n"
+       << "forwarded: " << radioStats.forwarded << "\n"
+       << "fwdMinRssiDrp: " << radioStats.fwdMinRssiDrp << "\n"
+       << "fwdNeighborDrp: " << radioStats.fwdNeighborDrp << "\n"
+       << "fwdDbBoostWeak: " << radioStats.fwdDbBoostWeak << "\n"
+       << "fwdDbBoostDrop: " << radioStats.fwdDbBoostDrop << "\n"
+       << "rxFromUsDrp: " << radioStats.rxFromUsDrp << "\n"
+       << "txAck: " << radioStats.txAck << "\n"
+       << "neighbors: " << radioStats.neighborTableSize << "\n"
+       << "-- Manager --" << endl
+       << "Manager Queue Length: " << protocol->txPoolSize() << endl
+       << "Next allowed tracking time: "
+       << (radio.m_nextAllowedTrackingTimeMs ? (long long)radio.m_nextAllowedTrackingTimeMs - ms
+                                             : 0) /
+              1000.0f
+       << "s" << endl
+       << endl
 
-         << "</pre></body>\n"
-         << "</html>\n";
+       << "</pre></body>\n"
+       << "</html>\n";
 
     user_server.send(200, "text/html", str.c_str());
   });
@@ -1121,7 +1124,7 @@ void webserver_setup() {
         </body>
         </html>
     )");
-    });
+  });
 
   user_server.on("/api/debug/mass-storage", HTTP_GET, []() {
     // Serial.end();
@@ -1187,7 +1190,8 @@ void webserver_setup() {
 
   user_server.on("/api/debug/sd-card/format", HTTP_POST, []() {
     if (selfTest.updateNeeded() || interactive_self_test_pending) {
-      user_server.send(409, "application/json", "{\"detail\":\"Self test is running or pending.\"}");
+      user_server.send(409, "application/json",
+                       "{\"detail\":\"Self test is running or pending.\"}");
       return;
     }
 

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -5,6 +5,7 @@
 #include <WebServer.h>
 #include <WiFi.h>
 #include <ctype.h>
+#include "comms/ble.h"
 #include "comms/factory_discovery.h"
 #include "comms/fanet_radio.h"
 #include "comms/wifi_coordinator.h"
@@ -30,6 +31,10 @@ namespace {
   bool user_app_enabled = false;
   bool user_app_using_leaf_wifi = false;
   bool user_app_provisioning = false;
+  bool user_app_services_paused = false;
+  bool user_app_restart_ble = false;
+  bool user_app_restart_fanet = false;
+  FanetRadioRegion user_app_fanet_region = FanetRadioRegion::OFF;
   String wifi_setup_networks_json = "{\"scanning\":false,\"networks\":[]}";
   bool wifi_setup_scan_running = false;
   bool wifi_setup_connecting = false;
@@ -418,6 +423,42 @@ namespace {
     url += userAppAddress();
     url += "/app";
     return url;
+  }
+
+  void pauseServicesForUserApp() {
+    if (user_app_services_paused) return;
+
+    user_app_restart_ble = settings.system_bluetoothOn;
+    if (user_app_restart_ble) {
+      BLE::get().stop();
+    }
+
+    user_app_restart_fanet = fanetRadio.getState() == FanetRadioState::RUNNING;
+    user_app_fanet_region = settings.fanet_region;
+    if (user_app_restart_fanet) {
+      fanetRadio.end();
+    }
+
+    user_app_services_paused = true;
+  }
+
+  void resumeServicesAfterUserApp() {
+    if (!user_app_services_paused) return;
+
+    if (user_app_restart_fanet && settings.fanet_region != FanetRadioRegion::OFF) {
+      fanetRadio.begin(settings.fanet_region);
+    } else if (user_app_restart_fanet && user_app_fanet_region != FanetRadioRegion::OFF) {
+      fanetRadio.begin(user_app_fanet_region);
+    }
+
+    if (user_app_restart_ble && settings.system_bluetoothOn) {
+      BLE::get().start();
+    }
+
+    user_app_restart_ble = false;
+    user_app_restart_fanet = false;
+    user_app_fanet_region = FanetRadioRegion::OFF;
+    user_app_services_paused = false;
   }
 
   bool stationConnectionReady() {
@@ -897,7 +938,7 @@ void webserver_setup() {
         </body>
       </html>
     )");
-  });
+    });
 
   user_server.on("/api/debug/raw-xbm", HTTP_GET, []() {
     send_buffer = "";
@@ -911,46 +952,46 @@ void webserver_setup() {
     auto& radio = fanetRadio;
     auto protocol = radio.protocol;
 
-    // Lock the radio while we poke around their private parts
-    LockGuard lock(radio.x_fanet_manager_mutex);
-    auto& radioStats = protocol->stats();
-    // UnsafeManager* manager = (UnsafeManager*)radio.manager;
-    auto ms = millis();
+      // Lock the radio while we poke around their private parts
+      LockGuard lock(radio.x_fanet_manager_mutex);
+      auto& radioStats = protocol->stats();
+      // UnsafeManager* manager = (UnsafeManager*)radio.manager;
+      auto ms = millis();
 
-    ss << "<!DOCTYPE html>\n"
-       << "<html>\n"
-       << "<script>\n"
-       << "setTimeout(() => location.reload(), 1000);\n"
-       << "</script>\n"
-       << "<body><pre>\n"
+      ss << "<!DOCTYPE html>\n"
+         << "<html>\n"
+         << "<script>\n"
+         << "setTimeout(() => location.reload(), 1000);\n"
+         << "</script>\n"
+         << "<body><pre>\n"
 
-       << "Current Time: " << ms << endl
-       << endl
-       << "-- STATS -- " << endl
-       << "State: " << fanetRadio.getState().c_str() << "\n"
-       << "rx: " << radioStats.rx << "\n"
-       << "txSuccess: " << radioStats.txSuccess << "\n"
-       << "txFailed: " << radioStats.txFailed << "\n"
-       << "processed: " << radioStats.processed << "\n"
-       << "forwarded: " << radioStats.forwarded << "\n"
-       << "fwdMinRssiDrp: " << radioStats.fwdMinRssiDrp << "\n"
-       << "fwdNeighborDrp: " << radioStats.fwdNeighborDrp << "\n"
-       << "fwdDbBoostWeak: " << radioStats.fwdDbBoostWeak << "\n"
-       << "fwdDbBoostDrop: " << radioStats.fwdDbBoostDrop << "\n"
-       << "rxFromUsDrp: " << radioStats.rxFromUsDrp << "\n"
-       << "txAck: " << radioStats.txAck << "\n"
-       << "neighbors: " << radioStats.neighborTableSize << "\n"
-       << "-- Manager --" << endl
-       << "Manager Queue Length: " << protocol->txPoolSize() << endl
-       << "Next allowed tracking time: "
-       << (radio.m_nextAllowedTrackingTimeMs ? (long long)radio.m_nextAllowedTrackingTimeMs - ms
-                                             : 0) /
-              1000.0f
-       << "s" << endl
-       << endl
+         << "Current Time: " << ms << endl
+         << endl
+         << "-- STATS -- " << endl
+         << "State: " << fanetRadio.getState().c_str() << "\n"
+         << "rx: " << radioStats.rx << "\n"
+         << "txSuccess: " << radioStats.txSuccess << "\n"
+         << "txFailed: " << radioStats.txFailed << "\n"
+         << "processed: " << radioStats.processed << "\n"
+         << "forwarded: " << radioStats.forwarded << "\n"
+         << "fwdMinRssiDrp: " << radioStats.fwdMinRssiDrp << "\n"
+         << "fwdNeighborDrp: " << radioStats.fwdNeighborDrp << "\n"
+         << "fwdDbBoostWeak: " << radioStats.fwdDbBoostWeak << "\n"
+         << "fwdDbBoostDrop: " << radioStats.fwdDbBoostDrop << "\n"
+         << "rxFromUsDrp: " << radioStats.rxFromUsDrp << "\n"
+         << "txAck: " << radioStats.txAck << "\n"
+         << "neighbors: " << radioStats.neighborTableSize << "\n"
+         << "-- Manager --" << endl
+         << "Manager Queue Length: " << protocol->txPoolSize() << endl
+         << "Next allowed tracking time: "
+         << (radio.m_nextAllowedTrackingTimeMs ? (long long)radio.m_nextAllowedTrackingTimeMs - ms
+                                               : 0) /
+                1000.0f
+         << "s" << endl
+         << endl
 
-       << "</pre></body>\n"
-       << "</html>\n";
+         << "</pre></body>\n"
+         << "</html>\n";
 
     user_server.send(200, "text/html", str.c_str());
   });
@@ -1017,7 +1058,7 @@ void webserver_setup() {
         </body>
         </html>
     )");
-  });
+    });
 
   user_server.on("/api/debug/mass-storage", HTTP_GET, []() {
     // Serial.end();
@@ -1137,6 +1178,8 @@ void webserver_loop() {
 }
 
 void webserver_enable_user_app(bool useLeafWifi) {
+  pauseServicesForUserApp();
+
   heap_monitor::clear();
   resetUserAppCounters();
   heap_monitor::record("enable-start");
@@ -1162,6 +1205,8 @@ void webserver_enable_user_app(bool useLeafWifi) {
 }
 
 void webserver_enable_wifi_setup() {
+  pauseServicesForUserApp();
+
   wifi_setup_cycle++;
   wifi_setup_started_ms = millis();
   logWifiSetupTiming("start");
@@ -1211,6 +1256,7 @@ void webserver_disable_user_app() {
   heap_monitor::record("disabled");
   dumpUserAppCounters("disabled");
   heap_monitor::dumpToSd();
+  resumeServicesAfterUserApp();
 }
 
 bool webserver_user_app_active() { return user_app_enabled; }

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -32,6 +32,7 @@ namespace {
   bool user_app_using_leaf_wifi = false;
   bool user_app_provisioning = false;
   bool user_app_services_paused = false;
+  bool user_app_dns_started = false;
   bool user_app_restart_ble = false;
   bool user_app_restart_fanet = false;
   FanetRadioRegion user_app_fanet_region = FanetRadioRegion::OFF;
@@ -425,6 +426,67 @@ namespace {
     return url;
   }
 
+  String deviceHexDigits() {
+    String hex = settings.getMacAddress();
+    hex.replace(":", "");
+    hex.toUpperCase();
+    if (hex.length() < 4) return "LEAF";
+    return hex;
+  }
+
+  String leafApSsid() {
+    const String hex = deviceHexDigits();
+    String ssid = "Leaf-";
+    ssid += hex.substring(hex.length() - 4);
+    return ssid;
+  }
+
+  uint8_t hexNibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    return 0;
+  }
+
+  String leafApPassword() {
+    static constexpr const char* words[] = {"sunset", "breeze", "updraft", "skyward"};
+    const String hex = deviceHexDigits();
+    const uint8_t a = hexNibble(hex.length() > 1 ? hex[hex.length() - 2] : '2');
+    const uint8_t b = hexNibble(hex.length() > 0 ? hex[hex.length() - 1] : '3');
+
+    String password = words[(a + b) % (sizeof(words) / sizeof(words[0]))];
+    password += static_cast<char>('2' + (a % 8));
+    password += static_cast<char>('2' + (b % 8));
+    return password;
+  }
+
+  void startLeafAp() {
+    const String ssid = leafApSsid();
+    const String password = leafApPassword();
+    WiFi.softAP(ssid.c_str(), password.c_str());
+  }
+
+  void startLeafApDns() {
+    if (user_app_dns_started) return;
+    dns_server.start(53, "*", WiFi.softAPIP());
+    user_app_dns_started = true;
+  }
+
+  void stopLeafApDns() {
+    if (!user_app_dns_started) return;
+    dns_server.stop();
+    user_app_dns_started = false;
+  }
+
+  String leafApWifiQr() {
+    String qr = "WIFI:T:WPA;S:";
+    qr += leafApSsid();
+    qr += ";P:";
+    qr += leafApPassword();
+    qr += ";;";
+    return qr;
+  }
+
   void pauseServicesForUserApp() {
     if (user_app_services_paused) return;
 
@@ -481,7 +543,7 @@ namespace {
     WiFi.disconnect(false, true);
     WiFi.mode(WIFI_AP_STA);
     WiFi.setSleep(false);
-    WiFi.softAP("Leaf WiFi");
+    startLeafAp();
   }
 
   String wifiStatusJson() {
@@ -635,8 +697,8 @@ namespace {
   }
 
   bool handleCaptivePortalRequest(WebServer& target) {
-    if (!user_app_provisioning) return false;
-    sendRedirect(target, "/wifi");
+    if (!user_app_using_leaf_wifi) return false;
+    sendRedirect(target, user_app_provisioning ? "/wifi" : "/app");
     return true;
   }
 
@@ -715,7 +777,7 @@ loadStatus();loadProfiles();
 
     sendNoStoreHeaders(target);
     static constexpr char WIFI_SETUP_PAGE[] =
-        R"leafhtml(<!doctype html><html><head><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf WiFi</title><style>body{margin:0;background:#f5f7f2;color:#172016;font:16px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}h1{margin:0;padding:18px 20px;background:#172016;color:white;font-size:24px}main{padding:20px;max-width:560px;margin:auto}label{display:block;font-weight:650;margin:14px 0 6px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:12px;border:1px solid #bac3b4;border-radius:6px}button{margin-top:16px;background:#172016;color:white;font-weight:700}.status{border-bottom:1px solid #d9dfd3;color:#596256;padding-bottom:14px}.row{display:flex;gap:10px}.row input{flex:1}.show{display:flex;align-items:center;gap:6px;width:auto;white-space:nowrap}.show input{width:auto}</style><script>async function init(){let s=document.getElementById('s'),l=document.getElementById('l'),n=document.getElementById('n'),p=document.getElementById('p'),w=document.getElementById('w'),f=document.getElementById('f');l.onchange=()=>{if(l.value)n.value=l.value};w.onchange=()=>p.type=w.checked?'text':'password';async function nets(){try{let d=await(await fetch('/api/wifi/networks')).json();if(d.scanning){s.textContent='Scanning for networks...';setTimeout(nets,1500);return}l.innerHTML='<option value="">Select network...</option>';d.networks.forEach(x=>{let o=document.createElement('option');o.value=x.ssid;o.textContent=x.ssid+' ('+x.rssi+' dBm)';l.appendChild(o)});s.textContent=d.networks.length?'Choose a network or type one manually.':'No networks found. Type the network name manually.'}catch(e){s.textContent='Unable to read network list. Type the network name manually.'}}async function poll(){try{let d=await(await fetch('/api/wifi/status')).json();if(d.connected){s.textContent='Connected to '+d.ssid+'. Open '+d.ip_address+':81/app';return}if(d.error){s.textContent='Unable to connect. Check password and try again.';return}s.textContent=d.target_ssid?'Trying to connect to '+d.target_ssid+'...':'Trying to connect...';setTimeout(poll,1500)}catch(e){s.textContent='Trying to connect...';setTimeout(poll,2000)}}f.onsubmit=async e=>{e.preventDefault();let ssid=n.value.trim();if(!ssid){s.textContent='Enter a network name.';return}s.textContent='Saving credentials...';try{await fetch('/api/wifi/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:ssid,password:p.value})});poll()}catch(x){s.textContent='Unable to save network details. Try again.'}};nets()}</script></head><body onload=init()><h1>Leaf WiFi Setup</h1><main><p class=status id=s>Loading...</p><form id=f><label>Network</label><select id=l><option>Select network...</option></select><input id=n autocomplete=off placeholder="Type network name"><label>Password</label><div class=row><input id=p type=password autocomplete=current-password><label class=show><input id=w type=checkbox>Show</label></div><button>Save and Connect</button></form></main></body></html>)leafhtml";
+        R"leafhtml(<!doctype html><html><head><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf WiFi</title><style>body{margin:0;background:#f5f7f2;color:#172016;font:16px -apple-system,BlinkMacSystemFont,Segoe UI,sans-serif}h1{margin:0;padding:18px 20px;background:#172016;color:white;font-size:24px}main{padding:20px;max-width:560px;margin:auto}label{display:block;font-weight:650;margin:14px 0 6px}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:12px;border:1px solid #bac3b4;border-radius:6px}button{margin-top:16px;background:#172016;color:white;font-weight:700}.status{border-bottom:1px solid #d9dfd3;color:#596256;padding-bottom:14px}.row{display:flex;gap:10px}.row input{flex:1}.show{display:flex;align-items:center;gap:6px;width:auto;white-space:nowrap}.show input{width:auto}</style><script>async function init(){let s=document.getElementById('s'),l=document.getElementById('l'),n=document.getElementById('n'),p=document.getElementById('p'),w=document.getElementById('w'),f=document.getElementById('f');l.onchange=()=>{if(l.value)n.value=l.value};w.onchange=()=>p.type=w.checked?'text':'password';async function nets(){try{let d=await(await fetch('/api/wifi/networks')).json();if(d.scanning){s.textContent='Scanning for networks...';setTimeout(nets,1500);return}l.innerHTML='<option value="">Select network...</option>';d.networks.forEach(x=>{let o=document.createElement('option');o.value=x.ssid;o.textContent=x.ssid+' ('+x.rssi+' dBm)';l.appendChild(o)});s.textContent=d.networks.length?'Choose a network or type one manually.':'No networks found. Type the network name manually.'}catch(e){s.textContent='Unable to read network list. Type the network name manually.'}}async function poll(){try{let d=await(await fetch('/api/wifi/status')).json();if(d.connected){s.textContent='Connected to '+d.ssid+'. Open http://'+d.ip_address+'/app';return}if(d.error){s.textContent='Unable to connect. Check password and try again.';return}s.textContent=d.target_ssid?'Trying to connect to '+d.target_ssid+'...':'Trying to connect...';setTimeout(poll,1500)}catch(e){s.textContent='Trying to connect...';setTimeout(poll,2000)}}f.onsubmit=async e=>{e.preventDefault();let ssid=n.value.trim();if(!ssid){s.textContent='Enter a network name.';return}s.textContent='Saving credentials...';try{await fetch('/api/wifi/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:ssid,password:p.value})});poll()}catch(x){s.textContent='Unable to save network details. Try again.'}};nets()}</script></head><body onload=init()><h1>Leaf WiFi Setup</h1><main><p class=status id=s>Loading...</p><form id=f><label>Network</label><select id=l><option>Select network...</option></select><input id=n autocomplete=off placeholder="Type network name"><label>Password</label><div class=row><input id=p type=password autocomplete=current-password><label class=show><input id=w type=checkbox>Show</label></div><button>Save and Connect</button></form></main></body></html>)leafhtml";
     target.send(200, "text/html", WIFI_SETUP_PAGE);
   }
 
@@ -728,7 +790,7 @@ loadStatus();loadProfiles();
     String json = "{\"active\":true,\"mode\":\"";
     json += userAppMode();
     json += "\",\"ssid\":\"";
-    json += jsonEscape(user_app_using_leaf_wifi ? "Leaf WiFi" : WiFi.SSID());
+    json += jsonEscape(user_app_using_leaf_wifi ? leafApSsid() : WiFi.SSID());
     json += "\",\"ip_address\":\"";
     json += userAppAddress();
     json += "\",\"url\":\"";
@@ -1170,7 +1232,7 @@ void webserver_loop() {
       user_app_loop_count++;
       updateUserAppStationPeak();
       if (user_app_provisioning) updateWifiNetworkScan();
-      if (user_app_provisioning) dns_server.processNextRequest();
+      if (user_app_dns_started) dns_server.processNextRequest();
       user_app_handle_count++;
       user_server.handleClient();
     }
@@ -1189,7 +1251,8 @@ void webserver_enable_user_app(bool useLeafWifi) {
     heap_monitor::record("after-prepare-ap");
     WiFi.mode(WIFI_AP);
     WiFi.setSleep(false);
-    WiFi.softAP("Leaf WiFi");
+    startLeafAp();
+    startLeafApDns();
     heap_monitor::record("after-softap");
     user_app_using_leaf_wifi = true;
   } else {
@@ -1215,14 +1278,14 @@ void webserver_enable_wifi_setup() {
   logWifiSetupTiming("after-fast-prepare");
   WiFi.mode(WIFI_AP_STA);
   WiFi.setSleep(false);
-  WiFi.softAP("Leaf WiFi");
+  startLeafAp();
   logWifiSetupTiming("after-softAP");
   user_app_enabled = true;
   user_app_using_leaf_wifi = true;
   user_app_provisioning = true;
   setupUserAppServer();
   logWifiSetupTiming("after-user-server");
-  dns_server.start(53, "*", WiFi.softAPIP());
+  startLeafApDns();
   logWifiSetupTiming("after-dns");
   webserver_setup();
   logWifiSetupTiming("after-main-server");
@@ -1235,7 +1298,7 @@ void webserver_disable_user_app() {
   heap_monitor::record("disable-start");
   dumpUserAppCounters("disable-start");
   user_app_enabled = false;
-  if (user_app_provisioning) dns_server.stop();
+  stopLeafApDns();
   user_app_provisioning = false;
   if (wifi_setup_scan_running) WiFi.scanDelete();
   wifi_setup_scan_running = false;
@@ -1263,3 +1326,9 @@ void webserver_disable_user_app() {
 bool webserver_user_app_active() { return user_app_enabled; }
 
 String webserver_user_app_url() { return userAppUrl(); }
+
+String webserver_leaf_ap_ssid() { return leafApSsid(); }
+
+String webserver_leaf_ap_password() { return leafApPassword(); }
+
+String webserver_leaf_ap_wifi_qr() { return leafApWifiQr(); }

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -21,13 +21,12 @@
 #include "utils/lock_guard.h"
 
 namespace {
-  ::WebServer server;
   ::WebServer user_server(80);
   DNSServer dns_server;
   String send_buffer = "";
-  bool webserver_started = false;
   bool user_server_started = false;
   bool user_server_routes_configured = false;
+  bool debug_routes_configured = false;
   bool user_app_enabled = false;
   bool user_app_using_leaf_wifi = false;
   bool user_app_provisioning = false;
@@ -96,7 +95,7 @@ namespace {
     if (!file) return;
 
     if (!existed || file.size() == 0) {
-      file.println("millis,event,enabled,using_leaf_wifi,user_server_started,main_server_started,"
+      file.println("millis,event,enabled,using_leaf_wifi,user_server_started,debug_routes_configured,"
                    "ap_stations,max_ap_stations,wifi_status,free_heap,max_alloc_heap,loop_count,"
                    "handle_count,root,app,status,profiles_get,profiles_put,not_found,ap_ip");
     }
@@ -106,7 +105,7 @@ namespace {
     file.printf("%lu,%s,%u,%u,%u,%u,%u,%u,%d,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%s\n",
                 static_cast<unsigned long>(millis()), event ? event : "",
                 user_app_enabled ? 1 : 0, user_app_using_leaf_wifi ? 1 : 0,
-                user_server_started ? 1 : 0, webserver_started ? 1 : 0,
+                user_server_started ? 1 : 0, debug_routes_configured ? 1 : 0,
                 static_cast<unsigned int>(WiFi.softAPgetStationNum()),
                 static_cast<unsigned int>(user_app_max_ap_stations),
                 static_cast<int>(WiFi.status()), static_cast<unsigned long>(ESP.getFreeHeap()),
@@ -207,37 +206,37 @@ namespace {
     return latest_file_name;
   }
 
-  void sendLatestSelfTestDetails() {
+  void sendLatestSelfTestDetails(WebServer& target) {
     if (!sdcard.isMounted()) {
-      server.send(404, "application/json", "{\"detail\":\"SD card is not mounted.\"}");
+      target.send(404, "application/json", "{\"detail\":\"SD card is not mounted.\"}");
       return;
     }
 
     String file_name = latestSelfTestDetailsFileName();
     if (file_name.isEmpty()) {
-      server.send(404, "application/json", "{\"detail\":\"No self test details file found.\"}");
+      target.send(404, "application/json", "{\"detail\":\"No self test details file found.\"}");
       return;
     }
 
     File file = SD_MMC.open(file_name, "r");
     if (!file) {
-      server.send(500, "application/json",
+      target.send(500, "application/json",
                   "{\"detail\":\"Self test details file could not be opened.\"}");
       return;
     }
 
-    server.streamFile(file, "text/plain");
+    target.streamFile(file, "text/plain");
     file.close();
   }
 
-  void clearSelfTestDetailsFiles() {
+  void clearSelfTestDetailsFiles(WebServer& target) {
     if (!sdcard.isMounted()) {
-      server.send(404, "application/json", "{\"detail\":\"SD card is not mounted.\"}");
+      target.send(404, "application/json", "{\"detail\":\"SD card is not mounted.\"}");
       return;
     }
 
     if (selfTest.updateNeeded()) {
-      server.send(409, "application/json", "{\"detail\":\"Self test is still running.\"}");
+      target.send(409, "application/json", "{\"detail\":\"Self test is still running.\"}");
       return;
     }
 
@@ -262,14 +261,14 @@ namespace {
       json += ",\"failed_count\":";
       json += failed_count;
       json += "}";
-      server.send(500, "application/json", json);
+      target.send(500, "application/json", json);
       return;
     }
 
     String json = "{\"cleared\":true,\"deleted_count\":";
     json += deleted_count;
     json += "}";
-    server.send(200, "application/json", json);
+    target.send(200, "application/json", json);
   }
 
   void beginInteractiveSelfTest() {
@@ -856,6 +855,7 @@ loadStatus();loadProfiles();
       user_server_routes_configured = true;
     }
 
+    webserver_setup();
     user_server.begin();
     user_server_started = true;
     Serial.printf("Leaf Web App started: %s\n", userAppUrl().c_str());
@@ -870,44 +870,42 @@ void writeScreenshotBuffer(const char* buffer) {
 }
 
 void webserver_setup() {
-  if (WiFi.status() != WL_CONNECTED && !user_app_enabled) return;
+  if (debug_routes_configured) return;
 
-  if (webserver_started) return;
-
-  server.on("/", HTTP_GET, []() {
-    server.send(200, "text/html", R"(
+  user_server.on("/app/debug", HTTP_GET, []() {
+    user_server.send(200, "text/html", R"(
       <!DOCTYPE html>
       <html>
         <head>
-          <title>ESP32 Vario</title>
+          <title>Leaf Debug</title>
           <style>
             body { font-family: Arial, sans-serif; margin: 2em auto; max-width: 800px; }
           </style>
         </head>
         <body>
-          <h1>ESP32 Vario Webserver</h1>
+          <h1>Leaf Debug</h1>
           <ul>
-            <li><a href="/screenshot" target="_blank">Download Screenshot</a></li>
-            <li><a href="/mass_storage" target="_blank">Start Mass Storage</a></li>
-            <li><a href="#" onclick="fetch('/self-test/interactive', {method: 'POST'}); return false;">Start Interactive Self Test</a></li>
-            <li><a href="#" onclick="fetch('/settings/factory-reset', {method: 'POST'}); return false;">Factory Reset Settings</a></li>
-            <li><a href="/mac-address" target="_blank">MAC Address</a></li>
-            <li><a href="/firmware-version" target="_blank">Firmware Version</a></li>
-            <li><a href="/fanet" target="_blank">FANet Message Stats</a></li>
-            <li><a href="/memory" target="_blank">Memory Usage Stats</a></li>
+            <li><a href="/app/debug/screenshot" target="_blank">Download Screenshot</a></li>
+            <li><a href="/api/debug/mass-storage" target="_blank">Start Mass Storage</a></li>
+            <li><a href="#" onclick="fetch('/api/debug/self-test/interactive', {method: 'POST'}); return false;">Start Interactive Self Test</a></li>
+            <li><a href="#" onclick="fetch('/api/debug/settings/factory-reset', {method: 'POST'}); return false;">Factory Reset Settings</a></li>
+            <li><a href="/api/debug/mac-address" target="_blank">MAC Address</a></li>
+            <li><a href="/api/debug/firmware-version" target="_blank">Firmware Version</a></li>
+            <li><a href="/app/debug/fanet" target="_blank">FANet Message Stats</a></li>
+            <li><a href="/app/debug/memory" target="_blank">Memory Usage Stats</a></li>
           </ul>
         </body>
       </html>
     )");
   });
 
-  server.on("/raw-xbm", HTTP_GET, []() {
+  user_server.on("/api/debug/raw-xbm", HTTP_GET, []() {
     send_buffer = "";
     u8g2_WriteBufferXBM(u8g2.getU8g2(), writeScreenshotBuffer);
-    server.send(200, "image/x-xbitmap", send_buffer);
+    user_server.send(200, "image/x-xbitmap", send_buffer);
   });
 
-  server.on("/fanet", HTTP_GET, []() {
+  user_server.on("/app/debug/fanet", HTTP_GET, []() {
     etl::string<1024> str;
     etl::string_stream ss(str);
     auto& radio = fanetRadio;
@@ -954,11 +952,11 @@ void webserver_setup() {
        << "</pre></body>\n"
        << "</html>\n";
 
-    server.send(200, "text/html", str.c_str());
+    user_server.send(200, "text/html", str.c_str());
   });
 
-  server.on("/screenshot", HTTP_GET, []() {
-    server.send(200, "text/html", R"(
+  user_server.on("/app/debug/screenshot", HTTP_GET, []() {
+    user_server.send(200, "text/html", R"(
         <!DOCTYPE html>
         <html>
         <head>
@@ -1005,7 +1003,7 @@ void webserver_setup() {
         }
 
 
-        fetch('/raw-xbm')
+        fetch('/api/debug/raw-xbm')
           .then(response => response.text())
           .then(xbmData => {
             drawXBM(xbmData, 'screenshotCanvas');
@@ -1021,56 +1019,51 @@ void webserver_setup() {
     )");
   });
 
-  server.on("/mass_storage", HTTP_GET, []() {
+  user_server.on("/api/debug/mass-storage", HTTP_GET, []() {
     // Serial.end();
     sdcard.setupMassStorage();
-    server.send(200, "text/html", "OK!");
+    user_server.send(200, "text/html", "OK!");
   });
 
-  server.on("/memory", HTTP_GET, []() { server.send(200, "text/plain", getMemoryUsage()); });
+  user_server.on("/app/debug/memory", HTTP_GET,
+                 []() { user_server.send(200, "text/plain", getMemoryUsage()); });
 
-  server.on("/app", HTTP_GET, []() { sendUserAppShell(server); });
-
-  server.on("/api/user/status", HTTP_GET, []() { sendUserStatus(server); });
-  server.on("/api/profiles", HTTP_GET, []() { sendProfiles(server); });
-  server.on("/api/profiles", HTTP_PUT, []() { saveProfiles(server); });
-
-  server.on("/mac-address", HTTP_GET, []() {
+  user_server.on("/api/debug/mac-address", HTTP_GET, []() {
     String json = "{\"mac_address\":\"";
     json += settings.getMacAddress();
     json += "\"}";
-    server.send(200, "application/json", json);
+    user_server.send(200, "application/json", json);
   });
 
-  server.on("/firmware-version", HTTP_GET, []() {
+  user_server.on("/api/debug/firmware-version", HTTP_GET, []() {
     String json = "{\"firmware_version\":\"";
     json += LeafVersionInfo::firmwareVersion();
     json += "\"}";
-    server.send(200, "application/json", json);
+    user_server.send(200, "application/json", json);
   });
 
-  server.on("/discovery", HTTP_GET, []() {
+  user_server.on("/api/debug/discovery", HTTP_GET, []() {
     factoryDiscovery.update();
-    server.send(200, "application/json", factoryDiscovery.statusJson());
+    user_server.send(200, "application/json", factoryDiscovery.statusJson());
   });
 
-  server.on("/settings/factory-reset", HTTP_POST, []() {
+  user_server.on("/api/debug/settings/factory-reset", HTTP_POST, []() {
     const bool forceFormatSdCard =
-        extractJsonBoolValue(server.arg("plain"), "force_format_sd_card", false);
+        extractJsonBoolValue(user_server.arg("plain"), "force_format_sd_card", false);
     settings.factoryResetVario();
     settings.setProductionTestForceFormatSdCard(forceFormatSdCard);
-    server.send(200, "application/json", "{\"reset_requested\":true}");
+    user_server.send(200, "application/json", "{\"reset_requested\":true}");
     delay(250);
     ESP.restart();
   });
 
-  server.on("/settings/fanet-address", HTTP_POST, []() {
-    String fanet_address = extractJsonStringValue(server.arg("plain"), "fanet_address");
+  user_server.on("/api/debug/settings/fanet-address", HTTP_POST, []() {
+    String fanet_address = extractJsonStringValue(user_server.arg("plain"), "fanet_address");
     fanet_address.trim();
     fanet_address.toUpperCase();
     if (!isValidFanetAddress(fanet_address)) {
-      server.send(400, "application/json",
-                  "{\"detail\":\"fanet_address must be a 6-character hexadecimal string.\"}");
+      user_server.send(400, "application/json",
+                       "{\"detail\":\"fanet_address must be a 6-character hexadecimal string.\"}");
       return;
     }
 
@@ -1080,62 +1073,57 @@ void webserver_setup() {
     String json = "{\"fanet_address\":\"";
     json += settings.fanet_address;
     json += "\",\"saved\":true}";
-    server.send(200, "application/json", json);
+    user_server.send(200, "application/json", json);
   });
 
-  server.on("/self-test/interactive", HTTP_POST, []() {
+  user_server.on("/api/debug/self-test/interactive", HTTP_POST, []() {
     requestInteractiveSelfTest();
-    server.send(200, "application/json", selfTestSnapshotJson());
+    user_server.send(200, "application/json", selfTestSnapshotJson());
   });
 
-  server.on("/sd-card/format", HTTP_POST, []() {
+  user_server.on("/api/debug/sd-card/format", HTTP_POST, []() {
     if (selfTest.updateNeeded() || interactive_self_test_pending) {
-      server.send(409, "application/json", "{\"detail\":\"Self test is running or pending.\"}");
+      user_server.send(409, "application/json", "{\"detail\":\"Self test is running or pending.\"}");
       return;
     }
 
     if (!sdcard.isCardPresent()) {
-      server.send(404, "application/json", "{\"detail\":\"SD card is not present.\"}");
+      user_server.send(404, "application/json", "{\"detail\":\"SD card is not present.\"}");
       return;
     }
 
     if (!sdcard.format()) {
-      server.send(500, "application/json", "{\"formatted\":false}");
+      user_server.send(500, "application/json", "{\"formatted\":false}");
       return;
     }
 
     if (!sdcard.setLabel()) {
-      server.send(500, "application/json", "{\"formatted\":true,\"label_set\":false}");
+      user_server.send(500, "application/json", "{\"formatted\":true,\"label_set\":false}");
       return;
     }
 
-    server.send(200, "application/json", "{\"formatted\":true,\"label_set\":true}");
+    user_server.send(200, "application/json", "{\"formatted\":true,\"label_set\":true}");
   });
 
-  server.on("/self-test/details", HTTP_GET, []() { sendLatestSelfTestDetails(); });
+  user_server.on("/api/debug/self-test/details", HTTP_GET,
+                 []() { sendLatestSelfTestDetails(user_server); });
 
-  server.on("/self-test/results", HTTP_DELETE, []() { clearSelfTestDetailsFiles(); });
+  user_server.on("/api/debug/self-test/results", HTTP_DELETE,
+                 []() { clearSelfTestDetailsFiles(user_server); });
 
-  server.on("/self-test", HTTP_GET,
-            []() { server.send(200, "application/json", selfTestSnapshotJson()); });
+  user_server.on("/api/debug/self-test", HTTP_GET,
+                 []() { user_server.send(200, "application/json", selfTestSnapshotJson()); });
 
-  server.on("/commissioning/complete", HTTP_POST, []() {
+  user_server.on("/api/debug/commissioning/complete", HTTP_POST, []() {
     selfTest.confirmCommissioningComplete();
-    server.send(200, "application/json", "{\"commissioning_complete\":true}");
+    user_server.send(200, "application/json", "{\"commissioning_complete\":true}");
   });
 
-  // Give it a chance to settle so the startup message has a valid IP address.
-  delay(250);
-  // The captive portal belongs on port 80 for setting up WiFi. Keep this
-  // webserver on port 81.
-  server.begin(81);
-  webserver_started = true;
-  Serial.printf("Webserver started: http://%s:81/\n", WiFi.localIP().toString());
+  debug_routes_configured = true;
 }
 
 void webserver_loop() {
   if (WiFi.status() == WL_CONNECTED || user_app_enabled) {
-    server.handleClient();
     if (user_app_enabled) {
       user_app_loop_count++;
       updateUserAppStationPeak();

--- a/src/vario/comms/webserver.h
+++ b/src/vario/comms/webserver.h
@@ -9,3 +9,6 @@ void webserver_enable_wifi_setup();
 void webserver_disable_user_app();
 bool webserver_user_app_active();
 String webserver_user_app_url();
+String webserver_leaf_ap_ssid();
+String webserver_leaf_ap_password();
+String webserver_leaf_ap_wifi_qr();

--- a/src/vario/diagnostics/heap_monitor.cpp
+++ b/src/vario/diagnostics/heap_monitor.cpp
@@ -9,88 +9,89 @@
 #include "freertos/task.h"
 
 namespace heap_monitor {
-namespace {
-constexpr size_t SAMPLE_COUNT = 32;
-constexpr size_t EVENT_LENGTH = 28;
-constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
+  namespace {
+    constexpr size_t SAMPLE_COUNT = 32;
+    constexpr size_t EVENT_LENGTH = 28;
+    constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
 
-struct Sample {
-  uint32_t millis;
-  char event[EVENT_LENGTH];
-  uint32_t freeHeap;
-  uint32_t minFreeHeap;
-  uint32_t largestFreeBlock;
-  uint32_t maxAllocHeap;
-  uint32_t stackHighWater;
-};
+    struct Sample {
+      uint32_t millis;
+      char event[EVENT_LENGTH];
+      uint32_t freeHeap;
+      uint32_t minFreeHeap;
+      uint32_t largestFreeBlock;
+      uint32_t maxAllocHeap;
+      uint32_t stackHighWater;
+    };
 
-Sample samples[SAMPLE_COUNT];
-size_t nextSample = 0;
-size_t sampleTotal = 0;
+    Sample samples[SAMPLE_COUNT];
+    size_t nextSample = 0;
+    size_t sampleTotal = 0;
 
-void copyEvent(char* dest, const char* event) {
-  if (!event) event = "";
-  size_t i = 0;
-  for (; i + 1 < EVENT_LENGTH && event[i] != '\0'; i++) {
-    dest[i] = event[i];
+    void copyEvent(char* dest, const char* event) {
+      if (!event) event = "";
+      size_t i = 0;
+      for (; i + 1 < EVENT_LENGTH && event[i] != '\0'; i++) {
+        dest[i] = event[i];
+      }
+      dest[i] = '\0';
+    }
+
+    bool ensureDiagnosticsDirectory() {
+      if (SD_MMC.exists(DIAGNOSTICS_DIR)) return true;
+      return SD_MMC.mkdir(DIAGNOSTICS_DIR);
+    }
+
+    void writeHeaderIfNeeded(File& file, const char* path) {
+      if (SD_MMC.exists(path) && file.size() > 0) return;
+      file.println(
+          "millis,event,free_heap,min_free_heap,largest_free_block,max_alloc_heap,"
+          "stack_high_water");
+    }
+
+  }  // namespace
+
+  void record(const char* event) {
+    Sample& sample = samples[nextSample];
+    sample.millis = millis();
+    copyEvent(sample.event, event);
+    sample.freeHeap = esp_get_free_heap_size();
+    sample.minFreeHeap = esp_get_minimum_free_heap_size();
+    sample.largestFreeBlock = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+    sample.maxAllocHeap = ESP.getMaxAllocHeap();
+    sample.stackHighWater = uxTaskGetStackHighWaterMark(NULL);
+
+    nextSample = (nextSample + 1) % SAMPLE_COUNT;
+    if (sampleTotal < SAMPLE_COUNT) sampleTotal++;
   }
-  dest[i] = '\0';
-}
 
-bool ensureDiagnosticsDirectory() {
-  if (SD_MMC.exists(DIAGNOSTICS_DIR)) return true;
-  return SD_MMC.mkdir(DIAGNOSTICS_DIR);
-}
+  bool dumpToSd(const char* path) {
+    if (!path || path[0] == '\0') return false;
+    if (!ensureDiagnosticsDirectory()) return false;
 
-void writeHeaderIfNeeded(File& file, const char* path) {
-  if (SD_MMC.exists(path) && file.size() > 0) return;
-  file.println("millis,event,free_heap,min_free_heap,largest_free_block,max_alloc_heap,"
-               "stack_high_water");
-}
+    const bool existed = SD_MMC.exists(path);
+    File file = SD_MMC.open(path, "a", true);
+    if (!file) return false;
 
-}  // namespace
+    if (!existed || file.size() == 0) writeHeaderIfNeeded(file, path);
 
-void record(const char* event) {
-  Sample& sample = samples[nextSample];
-  sample.millis = millis();
-  copyEvent(sample.event, event);
-  sample.freeHeap = esp_get_free_heap_size();
-  sample.minFreeHeap = esp_get_minimum_free_heap_size();
-  sample.largestFreeBlock = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
-  sample.maxAllocHeap = ESP.getMaxAllocHeap();
-  sample.stackHighWater = uxTaskGetStackHighWaterMark(NULL);
-
-  nextSample = (nextSample + 1) % SAMPLE_COUNT;
-  if (sampleTotal < SAMPLE_COUNT) sampleTotal++;
-}
-
-bool dumpToSd(const char* path) {
-  if (!path || path[0] == '\0') return false;
-  if (!ensureDiagnosticsDirectory()) return false;
-
-  const bool existed = SD_MMC.exists(path);
-  File file = SD_MMC.open(path, "a", true);
-  if (!file) return false;
-
-  if (!existed || file.size() == 0) writeHeaderIfNeeded(file, path);
-
-  const size_t start = sampleTotal < SAMPLE_COUNT ? 0 : nextSample;
-  for (size_t i = 0; i < sampleTotal; i++) {
-    const Sample& sample = samples[(start + i) % SAMPLE_COUNT];
-    file.printf("%lu,%s,%lu,%lu,%lu,%lu,%lu\n", static_cast<unsigned long>(sample.millis),
-                sample.event, static_cast<unsigned long>(sample.freeHeap),
-                static_cast<unsigned long>(sample.minFreeHeap),
-                static_cast<unsigned long>(sample.largestFreeBlock),
-                static_cast<unsigned long>(sample.maxAllocHeap),
-                static_cast<unsigned long>(sample.stackHighWater));
+    const size_t start = sampleTotal < SAMPLE_COUNT ? 0 : nextSample;
+    for (size_t i = 0; i < sampleTotal; i++) {
+      const Sample& sample = samples[(start + i) % SAMPLE_COUNT];
+      file.printf("%lu,%s,%lu,%lu,%lu,%lu,%lu\n", static_cast<unsigned long>(sample.millis),
+                  sample.event, static_cast<unsigned long>(sample.freeHeap),
+                  static_cast<unsigned long>(sample.minFreeHeap),
+                  static_cast<unsigned long>(sample.largestFreeBlock),
+                  static_cast<unsigned long>(sample.maxAllocHeap),
+                  static_cast<unsigned long>(sample.stackHighWater));
+    }
+    file.close();
+    return true;
   }
-  file.close();
-  return true;
-}
 
-void clear() {
-  nextSample = 0;
-  sampleTotal = 0;
-}
+  void clear() {
+    nextSample = 0;
+    sampleTotal = 0;
+  }
 
 }  // namespace heap_monitor

--- a/src/vario/diagnostics/heap_monitor.cpp
+++ b/src/vario/diagnostics/heap_monitor.cpp
@@ -1,0 +1,96 @@
+#include "heap_monitor.h"
+
+#include <Arduino.h>
+#include <SD_MMC.h>
+
+#include "esp_heap_caps.h"
+#include "esp_system.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+namespace heap_monitor {
+namespace {
+constexpr size_t SAMPLE_COUNT = 32;
+constexpr size_t EVENT_LENGTH = 28;
+constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
+
+struct Sample {
+  uint32_t millis;
+  char event[EVENT_LENGTH];
+  uint32_t freeHeap;
+  uint32_t minFreeHeap;
+  uint32_t largestFreeBlock;
+  uint32_t maxAllocHeap;
+  uint32_t stackHighWater;
+};
+
+Sample samples[SAMPLE_COUNT];
+size_t nextSample = 0;
+size_t sampleTotal = 0;
+
+void copyEvent(char* dest, const char* event) {
+  if (!event) event = "";
+  size_t i = 0;
+  for (; i + 1 < EVENT_LENGTH && event[i] != '\0'; i++) {
+    dest[i] = event[i];
+  }
+  dest[i] = '\0';
+}
+
+bool ensureDiagnosticsDirectory() {
+  if (SD_MMC.exists(DIAGNOSTICS_DIR)) return true;
+  return SD_MMC.mkdir(DIAGNOSTICS_DIR);
+}
+
+void writeHeaderIfNeeded(File& file, const char* path) {
+  if (SD_MMC.exists(path) && file.size() > 0) return;
+  file.println("millis,event,free_heap,min_free_heap,largest_free_block,max_alloc_heap,"
+               "stack_high_water");
+}
+
+}  // namespace
+
+void record(const char* event) {
+  Sample& sample = samples[nextSample];
+  sample.millis = millis();
+  copyEvent(sample.event, event);
+  sample.freeHeap = esp_get_free_heap_size();
+  sample.minFreeHeap = esp_get_minimum_free_heap_size();
+  sample.largestFreeBlock = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+  sample.maxAllocHeap = ESP.getMaxAllocHeap();
+  sample.stackHighWater = uxTaskGetStackHighWaterMark(NULL);
+
+  nextSample = (nextSample + 1) % SAMPLE_COUNT;
+  if (sampleTotal < SAMPLE_COUNT) sampleTotal++;
+}
+
+bool dumpToSd(const char* path) {
+  if (!path || path[0] == '\0') return false;
+  if (!ensureDiagnosticsDirectory()) return false;
+
+  const bool existed = SD_MMC.exists(path);
+  File file = SD_MMC.open(path, "a", true);
+  if (!file) return false;
+
+  if (!existed || file.size() == 0) writeHeaderIfNeeded(file, path);
+
+  const size_t start = sampleTotal < SAMPLE_COUNT ? 0 : nextSample;
+  for (size_t i = 0; i < sampleTotal; i++) {
+    const Sample& sample = samples[(start + i) % SAMPLE_COUNT];
+    file.printf("%lu,%s,%lu,%lu,%lu,%lu,%lu\n", static_cast<unsigned long>(sample.millis),
+                sample.event, static_cast<unsigned long>(sample.freeHeap),
+                static_cast<unsigned long>(sample.minFreeHeap),
+                static_cast<unsigned long>(sample.largestFreeBlock),
+                static_cast<unsigned long>(sample.maxAllocHeap),
+                static_cast<unsigned long>(sample.stackHighWater));
+  }
+  file.close();
+  return true;
+}
+
+void clear() {
+  nextSample = 0;
+  sampleTotal = 0;
+}
+
+}  // namespace heap_monitor

--- a/src/vario/diagnostics/heap_monitor.h
+++ b/src/vario/diagnostics/heap_monitor.h
@@ -2,8 +2,8 @@
 
 namespace heap_monitor {
 
-void record(const char* event);
-bool dumpToSd(const char* path = "/diagnostics/heap_monitor.csv");
-void clear();
+  void record(const char* event);
+  bool dumpToSd(const char* path = "/diagnostics/heap_monitor.csv");
+  void clear();
 
 }  // namespace heap_monitor

--- a/src/vario/diagnostics/heap_monitor.h
+++ b/src/vario/diagnostics/heap_monitor.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace heap_monitor {
+
+void record(const char* event);
+bool dumpToSd(const char* path = "/diagnostics/heap_monitor.csv");
+void clear();
+
+}  // namespace heap_monitor

--- a/src/vario/instruments/gps.cpp
+++ b/src/vario/instruments/gps.cpp
@@ -263,9 +263,9 @@ void LeafGPS::updateSatList(const NMEAString& nmea) {
         parseNmeaIntField(nmea, field + 2, azimuthValue)) {
       parseNmeaIntField(nmea, field + 3, snrValue);
 
-      sats[no - 1].elevation = elevationValue;
-      sats[no - 1].azimuth = azimuthValue;
-      sats[no - 1].snr = snrValue;
+      sats[no - 1].elevation = constrain(elevationValue, 0, 90);
+      sats[no - 1].azimuth = constrain(azimuthValue, 0, 359);
+      sats[no - 1].snr = constrain(snrValue, 0, 99);
       sats[no - 1].active = true;
     }
   }
@@ -294,9 +294,9 @@ void LeafGPS::testSats() {
       int no = atoi(satNumber[i].value());
       // Serial.print(F("SatNumber is ")); Serial.println(no);
       if (no >= 1 && no <= MAX_SATELLITES) {
-        sats[no - 1].elevation = atoi(elevation[i].value());
-        sats[no - 1].azimuth = atoi(azimuth[i].value());
-        sats[no - 1].snr = atoi(snr[i].value());
+        sats[no - 1].elevation = constrain(atoi(elevation[i].value()), 0, 90);
+        sats[no - 1].azimuth = constrain(atoi(azimuth[i].value()), 0, 359);
+        sats[no - 1].snr = constrain(atoi(snr[i].value()), 0, 99);
         sats[no - 1].active = true;
       }
     }

--- a/src/vario/instruments/gps.h
+++ b/src/vario/instruments/gps.h
@@ -29,10 +29,10 @@
 // GPS Satellites
 #define MAX_SATELLITES 80
 struct GPSSatInfo {
-  bool active;
-  int elevation;
-  int azimuth;
-  int snr;
+  bool active = false;
+  uint8_t elevation = 0;
+  uint16_t azimuth = 0;
+  uint8_t snr = 0;
 };
 struct GPSFixInfo {
   // float latError;

--- a/src/vario/logbook/igc.cpp
+++ b/src/vario/logbook/igc.cpp
@@ -7,6 +7,7 @@
 #include "FS.h"
 #include "instruments/baro.h"
 #include "instruments/gps.h"
+#include "profiles/profile_store.h"
 #include "system/version_info.h"
 #include "time.h"
 #include "ui/settings/settings.h"
@@ -83,8 +84,7 @@ bool Igc::startFlight() {
 
   logger.pilot = "Unknown";
   logger.glider_type = "Unknown";
-  // Overwrite from file if set in the Pilot descriptor
-  setPilotFromFile();
+  setPilotFromProfiles();
 
   logger.firmware_version = LeafVersionInfo::firmwareVersion();
   logger.hardware_version = "Leaf1";
@@ -115,13 +115,15 @@ void Igc::end(const FlightStats stats, bool showSummary) {
   Flight::end(stats, showSummary);
 }
 
-void Igc::setPilotFromFile() {
-  auto pilotFile = SD_MMC.open("/pilot.json", "r");
-  if (!pilotFile) {
-    return;  // No pilot JSON file
+void Igc::setPilotFromProfiles() {
+  PilotProfile pilot;
+  if (ProfileStore::activePilot(pilot)) {
+    logger.pilot = pilot.name;
   }
-  JsonDocument doc;
-  deserializeJson(doc, pilotFile);
-  logger.pilot = (String)doc["pilot"];
-  logger.glider_type = (String)doc["glider_type"];
+
+  GliderProfile glider;
+  if (ProfileStore::activeGlider(glider)) {
+    const String displayName = glider.resolvedDisplayName();
+    if (!displayName.isEmpty()) logger.glider_type = displayName;
+  }
 }

--- a/src/vario/logbook/igc.h
+++ b/src/vario/logbook/igc.h
@@ -17,5 +17,5 @@ class Igc : public Flight {
 
  private:
   IgcLogger logger;
-  void setPilotFromFile();
+  void setPilotFromProfiles();
 };

--- a/src/vario/logbook/logbook.yaml
+++ b/src/vario/logbook/logbook.yaml
@@ -275,6 +275,9 @@ components:
       type: object
       additionalProperties: true
       properties:
+        id:
+          type: string
+          nullable: true
         name:
           type: string
           nullable: true
@@ -282,6 +285,9 @@ components:
       type: object
       additionalProperties: true
       properties:
+        id:
+          type: string
+          nullable: true
         brand:
           type: string
           nullable: true
@@ -289,6 +295,9 @@ components:
           type: string
           nullable: true
         size:
+          type: string
+          nullable: true
+        display_name:
           type: string
           nullable: true
     SiteInfo:

--- a/src/vario/logbook/logbook_entry.cpp
+++ b/src/vario/logbook/logbook_entry.cpp
@@ -6,6 +6,7 @@
 #include <time.h>
 
 #include "instruments/gps.h"
+#include "profiles/profile_store.h"
 #include "system/version_info.h"
 #include "ui/settings/settings.h"
 
@@ -61,6 +62,8 @@ bool LogbookEntryFile::begin(const FlightStats& stats) {
   }
   path_ = pathForStem(startTimeValid_ ? timestampFileStem() : unsyncedFileStem());
   startTemperatureC_ = stats.temperature;
+  ProfileStore::activePilot(pilot_);
+  ProfileStore::activeGlider(glider_);
 
   return true;
 }
@@ -129,6 +132,8 @@ void LogbookEntryFile::reset() {
   firstFixDurationSeconds_ = 0;
   startTemperatureC_ = 0;
   firstFixTemperatureC_ = 0;
+  pilot_ = PilotProfile();
+  glider_ = GliderProfile();
 }
 
 bool LogbookEntryFile::deleteFiles(const String& logbookPath, const String& trackPath) {
@@ -271,11 +276,30 @@ bool LogbookEntryFile::writeJson(const FlightStats& stats, bool finalEntry,
   device["hardware_version"] = LeafVersionInfo::hardwareVariant();
   device["mac_address"] = settings.macAddress;
 
-  doc["pilot"].to<JsonObject>()["name"] = nullptr;
+  JsonObject pilot = doc["pilot"].to<JsonObject>();
+  if (pilot_.valid()) {
+    pilot["id"] = pilot_.id;
+    pilot["name"] = pilot_.name;
+  } else {
+    pilot["id"] = nullptr;
+    pilot["name"] = nullptr;
+  }
+
   JsonObject glider = doc["glider"].to<JsonObject>();
-  glider["brand"] = nullptr;
-  glider["model"] = nullptr;
-  glider["size"] = nullptr;
+  if (glider_.valid()) {
+    glider["id"] = glider_.id;
+    glider["brand"] = glider_.brand.isEmpty() ? nullptr : glider_.brand.c_str();
+    glider["model"] = glider_.model;
+    glider["size"] = glider_.size.isEmpty() ? nullptr : glider_.size.c_str();
+    String displayName = glider_.resolvedDisplayName();
+    glider["display_name"] = displayName.isEmpty() ? nullptr : displayName.c_str();
+  } else {
+    glider["id"] = nullptr;
+    glider["brand"] = nullptr;
+    glider["model"] = nullptr;
+    glider["size"] = nullptr;
+    glider["display_name"] = nullptr;
+  }
   JsonObject site = doc["site"].to<JsonObject>();
   site["launch_name"] = nullptr;
   site["landing_name"] = nullptr;

--- a/src/vario/logbook/logbook_entry.h
+++ b/src/vario/logbook/logbook_entry.h
@@ -2,6 +2,7 @@
 
 #include "Arduino.h"
 #include "logbook/flight_stats.h"
+#include "profiles/profile_store.h"
 
 class LogbookEntryFile {
  public:
@@ -41,4 +42,6 @@ class LogbookEntryFile {
   unsigned long firstFixDurationSeconds_ = 0;
   float startTemperatureC_ = 0;
   float firstFixTemperatureC_ = 0;
+  PilotProfile pilot_;
+  GliderProfile glider_;
 };

--- a/src/vario/navigation/gpx.cpp
+++ b/src/vario/navigation/gpx.cpp
@@ -47,12 +47,12 @@ bool Navigator::addWaypoint(const Waypoint& waypoint) {
   return true;
 }
 
-WaypointID Navigator::findWaypointByName(const String& name) const {
-  if (name == "") {
+WaypointID Navigator::findWaypointByName(const char* name) const {
+  if (name == nullptr || name[0] == '\0') {
     return WaypointID::None;
   }
   for (uint8_t i = 1; i <= totalWaypoints; i++) {
-    if (waypoints[i].name == name) {
+    if (strncmp(waypoints[i].name, name, maxGpxNameLength) == 0) {
       return WaypointID(i);
     }
   }
@@ -94,7 +94,7 @@ void Navigator::update() {
   if (hasActivePoint()) {
     // update distance remaining, then sequence to next point if distance is small enough
     pointDistanceRemaining = gps.distanceBetween(gps.location.lat(), gps.location.lng(),
-                                                 activePoint.lat, activePoint.lon);
+                                                 activePoint.latitude(), activePoint.longitude());
     if (pointDistanceRemaining < waypointRadius && !reachedGoal_)
       sequenceWaypoint();  //  (this will also update distance to the new point)
 
@@ -106,8 +106,8 @@ void Navigator::update() {
     }
 
     // get degress to active point
-    courseToActive_ =
-        gps.courseTo(gps.location.lat(), gps.location.lng(), activePoint.lat, activePoint.lon);
+    courseToActive_ = gps.courseTo(gps.location.lat(), gps.location.lng(), activePoint.latitude(),
+                                   activePoint.longitude());
     turnToActive = courseToActive_ - gps.course.deg();
     if (turnToActive > 180)
       turnToActive -= 360;
@@ -116,8 +116,8 @@ void Navigator::update() {
 
     // if there's a next point, get course to that as well
     if (nextPointIndex_) {
-      courseToNext_ =
-          gps.courseTo(gps.location.lat(), gps.location.lng(), nextPoint_.lat, nextPoint_.lon);
+      courseToNext_ = gps.courseTo(gps.location.lat(), gps.location.lng(), nextPoint_.latitude(),
+                                   nextPoint_.longitude());
       turnToNext_ = courseToNext_ - gps.course.deg();
       if (turnToNext_ > 180)
         turnToNext_ -= 360;
@@ -163,8 +163,8 @@ bool Navigator::activatePoint(WaypointID pointIndex) {
 
   speaker.playSound(fx::enter);
 
-  double newDistance =
-      gps.distanceBetween(gps.location.lat(), gps.location.lng(), activePoint.lat, activePoint.lon);
+  double newDistance = gps.distanceBetween(gps.location.lat(), gps.location.lng(),
+                                           activePoint.latitude(), activePoint.longitude());
 
   segmentDistance = newDistance;
   totalDistanceRemaining_ = newDistance;
@@ -197,17 +197,18 @@ bool Navigator::activateRoute(RouteID routeIndex) {
     if (routes[activeRouteIndex].totalPoints >= 2) {
       for (int i = 1; i < routes[activeRouteIndex].totalPoints; i++) {
         totalDistanceRemaining_ +=
-            gps.distanceBetween(routePoint(activeRouteIndex, RouteIndex(i)).lat,
-                                routePoint(activeRouteIndex, RouteIndex(i)).lon,
-                                routePoint(activeRouteIndex, RouteIndex(i + 1)).lat,
-                                routePoint(activeRouteIndex, RouteIndex(i + 1)).lon);
+            gps.distanceBetween(routePoint(activeRouteIndex, RouteIndex(i)).latitude(),
+                                routePoint(activeRouteIndex, RouteIndex(i)).longitude(),
+                                routePoint(activeRouteIndex, RouteIndex(i + 1)).latitude(),
+                                routePoint(activeRouteIndex, RouteIndex(i + 1)).longitude());
       }
       // otherwise our Route only has 1 point, so the Route distance is from where we are now to
       // that one point
     } else if (routes[activeRouteIndex].totalPoints == 1) {
-      totalDistanceRemaining_ = gps.distanceBetween(
-          gps.location.lat(), gps.location.lng(), routePoint(activeRouteIndex, RouteIndex(1)).lat,
-          routePoint(activeRouteIndex, RouteIndex(1)).lon);
+      totalDistanceRemaining_ =
+          gps.distanceBetween(gps.location.lat(), gps.location.lng(),
+                              routePoint(activeRouteIndex, RouteIndex(1)).latitude(),
+                              routePoint(activeRouteIndex, RouteIndex(1)).longitude());
     }
   }
   return navigating;
@@ -235,7 +236,7 @@ bool Navigator::sequenceWaypoint() {
     Serial.print(" new point:");
     Serial.print(activePoint.name);
     Serial.print(" new lat: ");
-    Serial.print(activePoint.lat);
+    Serial.print(activePoint.latitude());
 
     if (activeRoutePointIndex + 1 <
         routes[activeRouteIndex]
@@ -253,14 +254,14 @@ bool Navigator::sequenceWaypoint() {
     if (activeRoutePointIndex == 1) {
       segmentDistance =
           gps.distanceBetween(gps.location.lat(), gps.location.lng(),
-                              routePoint(activeRouteIndex, activeRoutePointIndex).lat,
-                              routePoint(activeRouteIndex, activeRoutePointIndex).lon);
+                              routePoint(activeRouteIndex, activeRoutePointIndex).latitude(),
+                              routePoint(activeRouteIndex, activeRoutePointIndex).longitude());
     } else {
       segmentDistance =
-          gps.distanceBetween(routePoint(activeRouteIndex, activeRoutePointIndex - 1).lat,
-                              routePoint(activeRouteIndex, activeRoutePointIndex - 1).lon,
-                              routePoint(activeRouteIndex, activeRoutePointIndex).lat,
-                              routePoint(activeRouteIndex, activeRoutePointIndex).lon);
+          gps.distanceBetween(routePoint(activeRouteIndex, activeRoutePointIndex - 1).latitude(),
+                              routePoint(activeRouteIndex, activeRoutePointIndex - 1).longitude(),
+                              routePoint(activeRouteIndex, activeRoutePointIndex).latitude(),
+                              routePoint(activeRouteIndex, activeRoutePointIndex).longitude());
     }
 
   } else {  // otherwise, we made it to our destination!
@@ -288,8 +289,6 @@ void Navigator::cancelNav() {
 
 bool Navigator::hasActivePoint() { return activeWaypointIndex || activeRoutePointIndex; }
 
-Navigator parse_result;
-
 bool gpx_readFile(fs::FS& fs, String fileName) {
   FileReader file_reader(fs, fileName);
   if (file_reader.error() != "") {
@@ -298,45 +297,44 @@ bool gpx_readFile(fs::FS& fs, String fileName) {
     return false;
   }
   GPXParser parser(&file_reader);
-  bool success = parser.parse(&parse_result);
+  bool success = parser.parse(&navigator);
   if (success) {
     Serial.println("gpx_readFile was successful:");
     Serial.print("  ");
-    Serial.print(parse_result.totalWaypoints);
+    Serial.print(navigator.totalWaypoints);
     Serial.println(" waypoints");
-    for (uint8_t wp = 1; wp <= parse_result.totalWaypoints; wp++) {
+    for (uint8_t wp = 1; wp <= navigator.totalWaypoints; wp++) {
       Serial.print("    ");
-      Serial.print(parse_result.waypoint(WaypointID(wp)).name);
+      Serial.print(navigator.waypoint(WaypointID(wp)).name);
       Serial.print(" @ ");
-      Serial.print(parse_result.waypoint(WaypointID(wp)).lat);
+      Serial.print(navigator.waypoint(WaypointID(wp)).latitude());
       Serial.print(", ");
-      Serial.print(parse_result.waypoint(WaypointID(wp)).lon);
+      Serial.print(navigator.waypoint(WaypointID(wp)).longitude());
       Serial.print(", ");
-      Serial.print(parse_result.waypoint(WaypointID(wp)).ele);
+      Serial.print(navigator.waypoint(WaypointID(wp)).ele);
       Serial.println("m");
     }
     Serial.print("  ");
-    Serial.print(parse_result.totalRoutes);
+    Serial.print(navigator.totalRoutes);
     Serial.println(" routes");
-    for (uint8_t r = 1; r <= parse_result.totalRoutes; r++) {
+    for (uint8_t r = 1; r <= navigator.totalRoutes; r++) {
       Serial.print("    ");
-      Serial.print(parse_result.routes[r].name);
+      Serial.print(navigator.routes[r].name);
       Serial.print(" (");
-      Serial.print(parse_result.routes[r].totalPoints);
+      Serial.print(navigator.routes[r].totalPoints);
       Serial.println(" points)");
-      for (uint8_t wp = 1; wp <= parse_result.routes[r].totalPoints; wp++) {
+      for (uint8_t wp = 1; wp <= navigator.routes[r].totalPoints; wp++) {
         Serial.print("      ");
-        Serial.print(parse_result.routePoint(RouteID(r), RouteIndex(wp)).name);
+        Serial.print(navigator.routePoint(RouteID(r), RouteIndex(wp)).name);
         Serial.print(" @ ");
-        Serial.print(parse_result.routePoint(RouteID(r), RouteIndex(wp)).lat);
+        Serial.print(navigator.routePoint(RouteID(r), RouteIndex(wp)).latitude());
         Serial.print(", ");
-        Serial.print(parse_result.routePoint(RouteID(r), RouteIndex(wp)).lon);
+        Serial.print(navigator.routePoint(RouteID(r), RouteIndex(wp)).longitude());
         Serial.print(", ");
-        Serial.print(parse_result.routePoint(RouteID(r), RouteIndex(wp)).ele);
+        Serial.print(navigator.routePoint(RouteID(r), RouteIndex(wp)).ele);
         Serial.println("m");
       }
     }
-    navigator = parse_result;
     Serial.print("Navigator loaded ");
     Serial.print(navigator.totalWaypoints);
     Serial.print(" waypoints and ");
@@ -359,26 +357,26 @@ bool gpx_readFile(fs::FS& fs, String fileName) {
 void Navigator::loadRoutes() {
   totalRoutes = 4;
 
-  routes[1].name = "R: TheCircuit";
+  routes[1].setName("R: TheCircuit");
   addRoutePoint(&routes[1], WaypointID(1));
   addRoutePoint(&routes[1], WaypointID(7));
   addRoutePoint(&routes[1], WaypointID(8));
   addRoutePoint(&routes[1], WaypointID(1));
   addRoutePoint(&routes[1], WaypointID(2));
 
-  routes[2].name = "R: Scenic";
+  routes[2].setName("R: Scenic");
   addRoutePoint(&routes[2], WaypointID(1));
   addRoutePoint(&routes[2], WaypointID(3));
   addRoutePoint(&routes[2], WaypointID(4));
   addRoutePoint(&routes[2], WaypointID(5));
   addRoutePoint(&routes[2], WaypointID(2));
 
-  routes[3].name = "R: Downhill";
+  routes[3].setName("R: Downhill");
   addRoutePoint(&routes[3], WaypointID(1));
   addRoutePoint(&routes[3], WaypointID(5));
   addRoutePoint(&routes[3], WaypointID(2));
 
-  routes[4].name = "R: MiniTri";
+  routes[4].setName("R: MiniTri");
   addRoutePoint(&routes[4], WaypointID(1));
   addRoutePoint(&routes[4], WaypointID(4));
   addRoutePoint(&routes[4], WaypointID(5));
@@ -388,12 +386,37 @@ void Navigator::loadRoutes() {
 void Navigator::loadWaypoints() {
   clear();
 
-  addWaypoint(Waypoint{.name = "Marshall", .lat = 34.21016, .lon = -117.30274, .ele = 1223});
-  addWaypoint(Waypoint{.name = "Marshall_LZ", .lat = 34.19318, .lon = -117.32334, .ele = 521});
-  addWaypoint(Waypoint{.name = "Cloud", .lat = 34.21065, .lon = -117.31298, .ele = 1169});
-  addWaypoint(Waypoint{.name = "Regionals", .lat = 34.20958, .lon = -117.31982, .ele = 1033});
-  addWaypoint(Waypoint{.name = "750", .lat = 34.19991, .lon = -117.31688, .ele = 767});
-  addWaypoint(Waypoint{.name = "Crestline", .lat = 34.23604, .lon = -117.31321, .ele = 1611});
-  addWaypoint(Waypoint{.name = "Billboard", .lat = 34.23531, .lon = -117.32608, .ele = 1572});
-  addWaypoint(Waypoint{.name = "Pine_Mt", .lat = 34.23762, .lon = -117.35115, .ele = 1553});
+  Waypoint waypoint;
+  waypoint.setName("Marshall");
+  waypoint.setCoordinates(34.21016, -117.30274);
+  waypoint.ele = 1223;
+  addWaypoint(waypoint);
+  waypoint.setName("Marshall_LZ");
+  waypoint.setCoordinates(34.19318, -117.32334);
+  waypoint.ele = 521;
+  addWaypoint(waypoint);
+  waypoint.setName("Cloud");
+  waypoint.setCoordinates(34.21065, -117.31298);
+  waypoint.ele = 1169;
+  addWaypoint(waypoint);
+  waypoint.setName("Regionals");
+  waypoint.setCoordinates(34.20958, -117.31982);
+  waypoint.ele = 1033;
+  addWaypoint(waypoint);
+  waypoint.setName("750");
+  waypoint.setCoordinates(34.19991, -117.31688);
+  waypoint.ele = 767;
+  addWaypoint(waypoint);
+  waypoint.setName("Crestline");
+  waypoint.setCoordinates(34.23604, -117.31321);
+  waypoint.ele = 1611;
+  addWaypoint(waypoint);
+  waypoint.setName("Billboard");
+  waypoint.setCoordinates(34.23531, -117.32608);
+  waypoint.ele = 1572;
+  addWaypoint(waypoint);
+  waypoint.setName("Pine_Mt");
+  waypoint.setCoordinates(34.23762, -117.35115);
+  waypoint.ele = 1553;
+  addWaypoint(waypoint);
 }

--- a/src/vario/navigation/gpx.h
+++ b/src/vario/navigation/gpx.h
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include <FS.h>
+#include <string.h>
 
 #include "navigation/nav_ids.h"
 
@@ -12,19 +13,45 @@
 #define maxRoutes 10
 #define maxNavPoints 100
 #define maxRoutePointRefs 75
+#define maxGpxNameLength 24
+
+inline int32_t gpxDegreesToE7(double degrees) {
+  return static_cast<int32_t>(degrees * 10000000.0 + (degrees >= 0 ? 0.5 : -0.5));
+}
+
+inline double gpxE7ToDegrees(int32_t degreesE7) { return degreesE7 / 10000000.0; }
 
 struct Waypoint {
-  String name;
-  double lat;
-  double lon;
-  float ele;
+  char name[maxGpxNameLength + 1] = "";
+  int32_t latE7 = 0;
+  int32_t lonE7 = 0;
+  float ele = 0;
+
+  void setName(const char* value) {
+    strncpy(name, value ? value : "", maxGpxNameLength);
+    name[maxGpxNameLength] = '\0';
+  }
+
+  void setLatitude(double latitude) { latE7 = gpxDegreesToE7(latitude); }
+  void setLongitude(double longitude) { lonE7 = gpxDegreesToE7(longitude); }
+  void setCoordinates(double latitude, double longitude) {
+    setLatitude(latitude);
+    setLongitude(longitude);
+  }
+  double latitude() const { return gpxE7ToDegrees(latE7); }
+  double longitude() const { return gpxE7ToDegrees(lonE7); }
 };
 
 // Route definition and memory allocation
 struct Route {
-  String name;
+  char name[maxGpxNameLength + 1] = "";
   uint8_t firstRoutePointIndex = 0;
   uint8_t totalPoints = 0;
+
+  void setName(const char* value) {
+    strncpy(name, value ? value : "", maxGpxNameLength);
+    name[maxGpxNameLength] = '\0';
+  }
 };
 
 // Navigator class for managing nav info (used largely for display purposes)
@@ -43,7 +70,7 @@ class Navigator {
   void clear();
   bool addWaypoint(const Waypoint& waypoint);
   WaypointID addOrFindWaypoint(const Waypoint& waypoint);
-  WaypointID findWaypointByName(const String& name) const;
+  WaypointID findWaypointByName(const char* name) const;
   bool addRoutePoint(Route* route, WaypointID waypointIndex);
   const Waypoint& waypoint(WaypointID pointIndex) const;
   const Waypoint& routePoint(RouteID routeIndex, RouteIndex pointIndex) const;

--- a/src/vario/navigation/gpx_parser.cpp
+++ b/src/vario/navigation/gpx_parser.cpp
@@ -218,9 +218,9 @@ bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name, bool requ
                              bool openingTagSelfClosing) {
   char key[MAX_VALUE_LENGTH + 1];
   char value[MAX_VALUE_LENGTH + 1];
-  waypoint->name = "";
-  waypoint->lat = 0;
-  waypoint->lon = 0;
+  waypoint->setName("");
+  waypoint->latE7 = 0;
+  waypoint->lonE7 = 0;
   waypoint->ele = 0;
 
   // Read attributes of opening tag (until tag is closed)
@@ -251,10 +251,10 @@ bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name, bool requ
         return false;
       }
       if (equalsIgnoreCase(key, "lat")) {
-        waypoint->lat = atof(value);
+        waypoint->setLatitude(atof(value));
         found_lat = true;
       } else if (equalsIgnoreCase(key, "lon")) {
-        waypoint->lon = atof(value);
+        waypoint->setLongitude(atof(value));
         found_lon = true;
       }
     }
@@ -312,7 +312,7 @@ bool GPXParser::readWaypoint(Waypoint* waypoint, const char* tag_name, bool requ
         _error += " while reading value of name tag in waypoint";
         return false;
       }
-      waypoint->name = String(value);
+      waypoint->setName(value);
       ReadTagNameResult closing_outcome = readTagName(key);
       if (closing_outcome == ReadTagNameResult::Error) {
         _error += " while reading name of tag that should be a closing name tag in waypoint";
@@ -446,6 +446,7 @@ bool GPXParser::readFullTagName(char* key) {
 }
 
 bool GPXParser::readRoute(Navigator* result, Route* route, bool storePoints) {
+  route->setName("");
   route->firstRoutePointIndex = 0;
   route->totalPoints = 0;
 
@@ -516,7 +517,7 @@ bool GPXParser::readRoute(Navigator* result, Route* route, bool storePoints) {
         _error += " while reading route name";
         return false;
       }
-      route->name = String(value);
+      route->setName(value);
       ReadTagNameResult closing_outcome = readTagName(key);
       if (closing_outcome == ReadTagNameResult::Error) {
         _error += " while reading closing name tag in route";

--- a/src/vario/profiles/profile_store.cpp
+++ b/src/vario/profiles/profile_store.cpp
@@ -4,56 +4,56 @@
 #include <SD_MMC.h>
 
 namespace {
-String optionalString(JsonVariantConst value) {
-  if (value.isNull()) return "";
-  return value.as<String>();
-}
-
-String joinGliderName(const String& brand, const String& model, const String& size) {
-  String name;
-  if (!brand.isEmpty()) name += brand;
-  if (!model.isEmpty()) {
-    if (!name.isEmpty()) name += " ";
-    name += model;
+  String optionalString(JsonVariantConst value) {
+    if (value.isNull()) return "";
+    return value.as<String>();
   }
-  if (!size.isEmpty()) {
-    if (!name.isEmpty()) name += " ";
-    name += size;
+
+  String joinGliderName(const String& brand, const String& model, const String& size) {
+    String name;
+    if (!brand.isEmpty()) name += brand;
+    if (!model.isEmpty()) {
+      if (!name.isEmpty()) name += " ";
+      name += model;
+    }
+    if (!size.isEmpty()) {
+      if (!name.isEmpty()) name += " ";
+      name += size;
+    }
+    return name;
   }
-  return name;
-}
 
-PilotProfile pilotFromJson(JsonObjectConst obj) {
-  PilotProfile pilot;
-  pilot.id = optionalString(obj["id"]);
-  pilot.name = optionalString(obj["name"]);
-  return pilot;
-}
-
-GliderProfile gliderFromJson(JsonObjectConst obj) {
-  GliderProfile glider;
-  glider.id = optionalString(obj["id"]);
-  glider.brand = optionalString(obj["brand"]);
-  glider.model = optionalString(obj["model"]);
-  if (glider.model.isEmpty()) {
-    glider.model = optionalString(obj["name"]);
+  PilotProfile pilotFromJson(JsonObjectConst obj) {
+    PilotProfile pilot;
+    pilot.id = optionalString(obj["id"]);
+    pilot.name = optionalString(obj["name"]);
+    return pilot;
   }
-  glider.size = optionalString(obj["size"]);
-  glider.displayName = optionalString(obj["display_name"]);
-  return glider;
-}
 
-bool loadProfiles(JsonDocument& doc) {
-  File file = SD_MMC.open(ProfileStore::filePath(), "r");
-  if (!file) return false;
+  GliderProfile gliderFromJson(JsonObjectConst obj) {
+    GliderProfile glider;
+    glider.id = optionalString(obj["id"]);
+    glider.brand = optionalString(obj["brand"]);
+    glider.model = optionalString(obj["model"]);
+    if (glider.model.isEmpty()) {
+      glider.model = optionalString(obj["name"]);
+    }
+    glider.size = optionalString(obj["size"]);
+    glider.displayName = optionalString(obj["display_name"]);
+    return glider;
+  }
 
-  DeserializationError error = deserializeJson(doc, file);
-  file.close();
-  if (error) return false;
+  bool loadProfiles(JsonDocument& doc) {
+    File file = SD_MMC.open(ProfileStore::filePath(), "r");
+    if (!file) return false;
 
-  const char* schema = doc["schema"] | "";
-  return strcmp(schema, "leaf.profiles") == 0;
-}
+    DeserializationError error = deserializeJson(doc, file);
+    file.close();
+    if (error) return false;
+
+    const char* schema = doc["schema"] | "";
+    return strcmp(schema, "leaf.profiles") == 0;
+  }
 }  // namespace
 
 String GliderProfile::resolvedDisplayName() const {

--- a/src/vario/profiles/profile_store.cpp
+++ b/src/vario/profiles/profile_store.cpp
@@ -1,0 +1,128 @@
+#include "profile_store.h"
+
+#include <ArduinoJson.h>
+#include <SD_MMC.h>
+
+namespace {
+String optionalString(JsonVariantConst value) {
+  if (value.isNull()) return "";
+  return value.as<String>();
+}
+
+String joinGliderName(const String& brand, const String& model, const String& size) {
+  String name;
+  if (!brand.isEmpty()) name += brand;
+  if (!model.isEmpty()) {
+    if (!name.isEmpty()) name += " ";
+    name += model;
+  }
+  if (!size.isEmpty()) {
+    if (!name.isEmpty()) name += " ";
+    name += size;
+  }
+  return name;
+}
+
+PilotProfile pilotFromJson(JsonObjectConst obj) {
+  PilotProfile pilot;
+  pilot.id = optionalString(obj["id"]);
+  pilot.name = optionalString(obj["name"]);
+  return pilot;
+}
+
+GliderProfile gliderFromJson(JsonObjectConst obj) {
+  GliderProfile glider;
+  glider.id = optionalString(obj["id"]);
+  glider.brand = optionalString(obj["brand"]);
+  glider.model = optionalString(obj["model"]);
+  if (glider.model.isEmpty()) {
+    glider.model = optionalString(obj["name"]);
+  }
+  glider.size = optionalString(obj["size"]);
+  glider.displayName = optionalString(obj["display_name"]);
+  return glider;
+}
+
+bool loadProfiles(JsonDocument& doc) {
+  File file = SD_MMC.open(ProfileStore::filePath(), "r");
+  if (!file) return false;
+
+  DeserializationError error = deserializeJson(doc, file);
+  file.close();
+  if (error) return false;
+
+  const char* schema = doc["schema"] | "";
+  return strcmp(schema, "leaf.profiles") == 0;
+}
+}  // namespace
+
+String GliderProfile::resolvedDisplayName() const {
+  if (!displayName.isEmpty()) return displayName;
+  return joinGliderName(brand, model, size);
+}
+
+bool ProfileStore::activePilot(PilotProfile& pilot) {
+  pilot = PilotProfile();
+
+  JsonDocument doc;
+  if (!loadProfiles(doc)) return false;
+
+  JsonArrayConst pilots = doc["pilots"].as<JsonArrayConst>();
+  if (pilots.isNull()) return false;
+
+  const String activeId = optionalString(doc["active_pilot_id"]);
+  PilotProfile onlyPilot;
+  uint16_t validPilotCount = 0;
+
+  for (JsonObjectConst item : pilots) {
+    PilotProfile candidate = pilotFromJson(item);
+    if (!candidate.valid()) continue;
+
+    validPilotCount++;
+    onlyPilot = candidate;
+    if (!activeId.isEmpty() && candidate.id == activeId) {
+      pilot = candidate;
+      return true;
+    }
+  }
+
+  if (activeId.isEmpty() && validPilotCount == 1) {
+    pilot = onlyPilot;
+    return true;
+  }
+
+  return false;
+}
+
+bool ProfileStore::activeGlider(GliderProfile& glider) {
+  glider = GliderProfile();
+
+  JsonDocument doc;
+  if (!loadProfiles(doc)) return false;
+
+  JsonArrayConst gliders = doc["gliders"].as<JsonArrayConst>();
+  if (gliders.isNull()) return false;
+
+  const String activeId = optionalString(doc["active_glider_id"]);
+  GliderProfile onlyGlider;
+  uint16_t validGliderCount = 0;
+
+  for (JsonObjectConst item : gliders) {
+    GliderProfile candidate = gliderFromJson(item);
+    if (!candidate.valid()) continue;
+
+    validGliderCount++;
+    onlyGlider = candidate;
+    if (!activeId.isEmpty() && candidate.id == activeId) {
+      glider = candidate;
+      return true;
+    }
+  }
+
+  if (activeId.isEmpty() && validGliderCount == 1) {
+    glider = onlyGlider;
+    return true;
+  }
+
+  return false;
+}

--- a/src/vario/profiles/profile_store.h
+++ b/src/vario/profiles/profile_store.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Arduino.h>
+
+struct PilotProfile {
+  String id;
+  String name;
+
+  bool valid() const { return !id.isEmpty() && !name.isEmpty(); }
+};
+
+struct GliderProfile {
+  String id;
+  String brand;
+  String model;
+  String size;
+  String displayName;
+
+  bool valid() const { return !id.isEmpty() && !model.isEmpty(); }
+  String resolvedDisplayName() const;
+};
+
+class ProfileStore {
+ public:
+  static constexpr const char* directoryPath() { return "/profiles"; }
+  static constexpr const char* filePath() { return "/profiles/profiles.json"; }
+
+  static bool activePilot(PilotProfile& pilot);
+  static bool activeGlider(GliderProfile& glider);
+};

--- a/src/vario/profiles/profiles.yaml
+++ b/src/vario/profiles/profiles.yaml
@@ -1,0 +1,91 @@
+openapi: 3.0.2
+info:
+  title: Leaf profiles
+  version: v0.1.0
+  description: >
+    Canonical schema for pilot and glider profiles stored on the Leaf SD card
+    at /profiles/profiles.json. Flight logbook entries snapshot selected
+    profile fields when a flight starts so historical flights remain stable if
+    profiles are edited later.
+paths:
+  /profiles:
+    get:
+      summary: Read the profiles file.
+      responses:
+        "200":
+          description: Profile settings.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Profiles"
+components:
+  schemas:
+    Profiles:
+      type: object
+      additionalProperties: true
+      required:
+        - schema
+        - schema_version
+        - pilots
+        - gliders
+      properties:
+        schema:
+          type: string
+          enum:
+            - leaf.profiles
+        schema_version:
+          type: string
+          example: v0.1.0
+        active_pilot_id:
+          type: string
+          nullable: true
+          description: Pilot used for the next flight. If null and exactly one valid pilot exists, that pilot is treated as active.
+        active_glider_id:
+          type: string
+          nullable: true
+          description: Glider used for the next flight. If null and exactly one valid glider exists, that glider is treated as active.
+        pilots:
+          type: array
+          items:
+            $ref: "#/components/schemas/PilotProfile"
+        gliders:
+          type: array
+          items:
+            $ref: "#/components/schemas/GliderProfile"
+    PilotProfile:
+      type: object
+      additionalProperties: true
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          pattern: "^[0-9a-fA-F]{6,16}$"
+        name:
+          type: string
+          minLength: 1
+    GliderProfile:
+      type: object
+      additionalProperties: true
+      required:
+        - id
+        - model
+      properties:
+        id:
+          type: string
+          pattern: "^[0-9a-fA-F]{6,16}$"
+        brand:
+          type: string
+          nullable: true
+        model:
+          type: string
+          minLength: 1
+          description: Minimum required glider display field.
+        size:
+          type: string
+          nullable: true
+        display_name:
+          type: string
+          nullable: true
+          description: Optional preferred display label. If missing, firmware derives one from brand, model, and size.

--- a/src/vario/ui/display/pages/menu/page_menu_system.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_system.cpp
@@ -244,10 +244,10 @@ void SystemMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count
         about_page.show();
       } else if (state == ButtonEvent::INCREMENTED && count == 4) {
         // toggle developer mode
-        settings.toggleBoolOnOff(&settings.dev_menu);
+        settings.toggleBoolOnOff(&settings.dev_mode);
 
         // ..and if dev mode is now off, restore default dev settings
-        if (!settings.dev_menu) {
+        if (!settings.dev_mode) {
           settings.dev_startLogAtBoot = false;
           settings.dev_startDisconnected = false;
           settings.disp_showDebugPage = false;

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -165,25 +165,33 @@ void WifiMenuPage::attemptWifiConnection() {
 }
 
 namespace {
-  void drawQrCode(const char* text, uint8_t xOffset, uint8_t yOffset) {
-    static constexpr uint8_t QR_VERSION = 2;
-    static constexpr uint8_t QR_SCALE = 2;
+  void drawQrCodeScaled(const char* text, uint8_t xOffset, uint8_t yOffset, uint8_t version,
+                        uint8_t scale) {
+    static constexpr uint8_t QR_MAX_VERSION = 3;
 
     QRCode qrcode;
-    uint8_t qrcodeData[qrcode_getBufferSize(QR_VERSION)];
-    qrcode_initText(&qrcode, qrcodeData, QR_VERSION, ECC_LOW, text);
+    uint8_t qrcodeData[qrcode_getBufferSize(QR_MAX_VERSION)];
+    qrcode_initText(&qrcode, qrcodeData, version, ECC_LOW, text);
 
     for (uint8_t x = 0; x < qrcode.size; x++) {
       for (uint8_t y = 0; y < qrcode.size; y++) {
         if (qrcode_getModule(&qrcode, x, y)) {
-          u8g2.drawBox(xOffset + x * QR_SCALE, yOffset + y * QR_SCALE, QR_SCALE, QR_SCALE);
+          u8g2.drawBox(xOffset + x * scale, yOffset + y * scale, scale, scale);
         }
       }
     }
   }
+
+  void drawQrCode(const char* text, uint8_t xOffset, uint8_t yOffset) {
+    drawQrCodeScaled(text, xOffset, yOffset, 3, 2);
+  }
+
+  void drawSmallQrCode(const char* text, uint8_t xOffset, uint8_t yOffset) {
+    drawQrCodeScaled(text, xOffset, yOffset, 2, 2);
+  }
 }  // namespace
 
-etl::array<const char*, 1> PageMenuSystemWifiWebApp::network_labels{{"Use LeafWiFi"}};
+etl::array<const char*, 1> PageMenuSystemWifiWebApp::network_labels{{"Use Leaf AP"}};
 
 void PageMenuSystemWifiWebApp::start(bool useLeafWifi) {
   using_leaf_wifi = useLeafWifi || WiFi.status() != WL_CONNECTED;
@@ -266,13 +274,21 @@ void PageMenuSystemWifiWebApp::draw_extra() {
   u8g2.setDrawColor(1);
 
   if (using_leaf_wifi) {
-    u8g2.setCursor(18, 28);
-    u8g2.print("Join Leaf WiFi");
-    drawQrCode("WIFI:T:nopass;S:Leaf WiFi;;", 23, 34);
+    u8g2.setCursor(1, 25);
+    u8g2.print("Join Wifi: ");
+    u8g2.print(webserver_leaf_ap_ssid());
+    u8g2.setCursor(1, 35);
+    u8g2.print("Password: ");
+    u8g2.print(webserver_leaf_ap_password());
+    drawQrCode(webserver_leaf_ap_wifi_qr().c_str(), 19, 41);
 
-    u8g2.setCursor(20, 100);
-    u8g2.print("Open Web App");
-    drawQrCode(webserver_user_app_url().c_str(), 23, 106);
+    u8g2.setCursor(17, 106);
+    u8g2.print("Open Web App:");
+    drawSmallQrCode(webserver_user_app_url().c_str(), 23, 112);
+    u8g2.setCursor(8, 171);
+    String shortUrl = webserver_user_app_url();
+    shortUrl.replace("http://", "");
+    u8g2.print(shortUrl);
     return;
   }
 
@@ -339,7 +355,7 @@ void PageMenuSystemWifiSetup::draw_extra() {
     u8g2.setCursor(24, 52);
     u8g2.print("Starting");
     u8g2.setCursor(12, 69);
-    u8g2.print("Leaf Wifi...");
+    u8g2.print("Leaf WiFi...");
 
     u8g2.setFont(leaf_5x8);
     u8g2.setCursor(8, 104);
@@ -351,39 +367,39 @@ void PageMenuSystemWifiSetup::draw_extra() {
     return;
   }
 
+  u8g2.setFont(leaf_5x8);
+  u8g2.setCursor(0, 28);
+  u8g2.print("Follow these steps");
+  u8g2.setCursor(0, 39);
+  u8g2.print("on Phone or Laptop:");
+
   u8g2.setFont(leaf_6x12);
-  auto y = 15;
-  auto x = 0;
-  const auto OFFSET = 4;  // default new paragraph spacing
-  u8g2.setCursor(0, y);
+  u8g2.setCursor(0, 58);
+  u8g2.print("1.Join:");
+  u8g2.setFont(leaf_5x8);
+  u8g2.setCursor(5, 70);
+  u8g2.print(webserver_leaf_ap_ssid());
+  u8g2.setCursor(5, 82);
+  u8g2.print("Pass ");
+  u8g2.print(webserver_leaf_ap_password());
 
-  // Instruction Page
-  const char* lines[] = {"Follow these steps", "on Phone or Laptop:",  "1.Join Leaf WiFi",   " ",
-                         "2.Click Sign In",    "  Or Visit:",          "192.168.4.1/wifi",   " ",
-                         "3.Enter Network",    "Select your network",  "and enter password", " ",
-                         "4.Press Save",       "This page will close", "when connected..."};
+  u8g2.setFont(leaf_6x12);
+  u8g2.setCursor(0, 103);
+  u8g2.print("2.Sign In");
+  u8g2.setFont(leaf_5x8);
+  u8g2.setCursor(5, 115);
+  u8g2.print("Or Visit:");
+  u8g2.setCursor(5, 127);
+  u8g2.print("192.168.4.1/wifi");
 
-  uint8_t lineNum = 0;
-
-  for (auto line : lines) {
-    u8g2.setCursor(0, y);
-    if (lineNum == 2 || lineNum == 4 || lineNum == 8 || lineNum == 12) {
-      y += 14;
-      x = 0;
-      u8g2.setFont(leaf_6x12);
-    } else if (lineNum == 0 || lineNum == 1 || lineNum == 5 || lineNum == 6 || lineNum == 9 ||
-               lineNum == 10 || lineNum == 13 || lineNum == 14) {
-      y += 11;
-      x = 5;
-      u8g2.setFont(leaf_5x8);
-    } else {
-      y += OFFSET;
-      u8g2.setFont(leaf_5x8);
-    }
-    u8g2.setCursor(x, y);
-    u8g2.print(line);
-    lineNum++;
-  }
+  u8g2.setFont(leaf_6x12);
+  u8g2.setCursor(0, 148);
+  u8g2.print("3.Enter Network");
+  u8g2.setFont(leaf_5x8);
+  u8g2.setCursor(5, 160);
+  u8g2.print("Select network");
+  u8g2.setCursor(5, 172);
+  u8g2.print("and enter password");
 
   u8g2.drawHLine(0, 174, 96);
 }

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -310,7 +310,7 @@ void PageMenuSystemWifiWebApp::draw_extra() {
     String shortUrl = webserver_user_app_url();
     shortUrl.replace("http://", "");
     u8g2.setFont(leaf_5x8);
-    u8g2.setCursor(2, 124);
+    u8g2.setCursor(2, 134);
     u8g2.print(shortUrl);
   } else {
     u8g2.setFont(leaf_5x8);

--- a/src/vario/ui/display/pages/primary/page_charging.cpp
+++ b/src/vario/ui/display/pages/primary/page_charging.cpp
@@ -49,7 +49,7 @@ void chargingPage_draw() {
     u8g2.print("mV");
     u8g2.setDrawColor(1);
 
-    if (settings.dev_menu) {
+    if (settings.dev_mode) {
       // If Developer Mode enabled, show Input Current max limit
       u8g2.setFont(leaf_6x12);
       u8g2.setCursor(10, 157);
@@ -101,7 +101,7 @@ void chargingPage_button(Button button, ButtonEvent state, uint8_t count) {
         case ButtonEvent::CLICKED:
           break;
         case ButtonEvent::HELD:
-          if (settings.dev_menu) {
+          if (settings.dev_mode) {
             power.increaseInputCurrent();
             speaker.playSound(fx::enter);
           }
@@ -113,7 +113,7 @@ void chargingPage_button(Button button, ButtonEvent state, uint8_t count) {
         case ButtonEvent::CLICKED:
           break;
         case ButtonEvent::HELD:
-          if (settings.dev_menu) {
+          if (settings.dev_mode) {
             power.decreaseInputCurrent();
             speaker.playSound(fx::exit);
           }

--- a/src/vario/ui/display/pages/primary/page_menu_main.cpp
+++ b/src/vario/ui/display/pages/primary/page_menu_main.cpp
@@ -105,7 +105,7 @@ void MainMenuPage::draw_main_menu() {
     // then draw all the menu items
     for (int i = 0; i <= cursor_max; i++) {
       // hide developer menu if not in dev mode
-      if (i == cursor_developer && !settings.dev_menu) {
+      if (i == cursor_developer && !settings.dev_mode) {
         continue;  // skip drawing this menu item
       }
 
@@ -226,7 +226,7 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonEvent state, uint8_t
     case Button::UP:
       if (state == ButtonEvent::CLICKED) {
         cursor_prev();
-        if (cursor_position == cursor_developer && !settings.dev_menu) {
+        if (cursor_position == cursor_developer && !settings.dev_mode) {
           cursor_prev();  // skip developer menu if not in dev mode
         }
         if (cursor_position == cursor_fanet) {
@@ -256,7 +256,7 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonEvent state, uint8_t
 #endif
         }
 
-        if (cursor_position == cursor_developer && !settings.dev_menu) {
+        if (cursor_position == cursor_developer && !settings.dev_mode) {
           cursor_next();  // skip developer menu if not in dev mode
         }
         redraw = true;

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -339,7 +339,7 @@ void navigatePage_draw() {
       }
     } else {
       if (navigator.navigating)
-        u8g2.print(navigator.activePoint.name.c_str());
+        u8g2.print(navigator.activePoint.name);
       else
         u8g2.print(defaultWaypointString);
       u8g2.setFont(leaf_6x12);

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -173,7 +173,7 @@ void Settings::loadDefaults() {
   system_showWarning = DEF_SHOW_WARNING;
 
   // Developer Options
-  dev_menu = DEF_DEV_MENU;
+  dev_mode = DEF_DEV_MODE;
   dev_startLogAtBoot = DEF_DEV_START_LOG_AT_BOOT;
   dev_startDisconnected = DEF_DEV_START_DISCONNECTED;
   dev_fanetFwd = DEF_DEV_FANET_FWD;
@@ -244,7 +244,7 @@ void Settings::retrieve() {
   productionTest = leafPrefs.getBool("PRODUCTION_TEST", DEF_PRODUCTIONTEST);
 
   // Developer Options
-  dev_menu = leafPrefs.getBool("DEVELOPER_MENU");
+  dev_mode = leafPrefs.getBool("DEV_MODE", leafPrefs.getBool("DEVELOPER_MENU", DEF_DEV_MODE));
   dev_startLogAtBoot = leafPrefs.getBool("DEV_STARTLOG");
   dev_startDisconnected = leafPrefs.getBool("DEV_STARTDISCON");
   dev_fanetFwd = leafPrefs.getBool("DEV_FANET_FWD", DEF_DEV_FANET_FWD);
@@ -321,7 +321,7 @@ void Settings::save() {
   leafPrefs.putBool("PRODUCTION_TEST", productionTest);
   leafPrefs.putString("MAC_ADDRESS", macAddress);
   // Developer Options
-  leafPrefs.putBool("DEVELOPER_MENU", dev_menu);
+  leafPrefs.putBool("DEV_MODE", dev_mode);
   leafPrefs.putBool("DEV_STARTLOG", dev_startLogAtBoot);
   leafPrefs.putBool("DEV_STARTDISCON", dev_startDisconnected);
   leafPrefs.putBool("DEV_FANET_FWD", dev_fanetFwd);

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -73,7 +73,7 @@ typedef uint8_t SettingLogFormat;
 #define DEF_PRODUCTIONTEST 0  // default that we have not yet run the production self test
 
 // Developer Settings
-#define DEF_DEV_MENU 0                // default hide the dev menu
+#define DEF_DEV_MODE 0                // default hide developer-mode features
 #define DEF_DEV_START_LOG_AT_BOOT 0   // default do not start log at boot
 #define DEF_DEV_START_DISCONNECTED 0  // default do not disconnect hardware at boot
 #define DEF_DEV_FANET_FWD 0           //  DO rebroadcast Fanet packets (turn off for range testing)
@@ -159,7 +159,7 @@ setting | samples | time avg
   bool productionTest;  // flag that we've run the initial selfTest during production assembly
 
   // developer options
-  bool dev_menu;
+  bool dev_mode;
   bool dev_startLogAtBoot;
   bool dev_startDisconnected;
   bool dev_fanetFwd;


### PR DESCRIPTION
## Summary

- Adds a lightweight Leaf Web App for editing pilot and glider profiles from a phone or laptop.
- Moves debug web tools into the main web app server and removes the separate port `81` debug server.
- Improves Web App connection reliability by using a per-device WPA2 Leaf AP, DNS capture, and captive-portal redirects.
- Adds heap/request diagnostics for web app sessions and reduces normal-mode web route memory pressure.
- Adds profile metadata into logbook JSON and IGC headers.

## Changes

- Added `profiles/profiles.json` support with a new profile store:
  - pilots with `id` and `name`
  - gliders with `id`, `brand`, `model`, `size`, and `display_name`
  - active pilot/glider selection
  - auto-fallback to empty/null profile data when no profile file exists

- Added Web App profile editing:
  - view current firmware/status
  - create/edit/delete pilots
  - create/edit/delete gliders
  - select active pilot and active glider
  - save profile changes back to SD card

- Integrated profiles with flight logs:
  - logbook JSON now includes selected pilot/glider IDs and display fields
  - IGC headers use selected pilot name and glider display name when available
  - IGC falls back to `Unknown` when no profile exists

- Consolidated web serving:
  - removed the separate debug web server on port `81`
  - moved debug tools under main web app paths such as `/app/debug` and `/api/debug/...`
  - gates debug route registration behind `settings.dev_mode` to reduce normal web app memory use

- Improved Leaf-hosted Web App WiFi:
  - Leaf AP now uses per-device SSID format like `Leaf-6004`
  - Leaf AP now uses a stable simple WPA2 password like `sunset26`
  - Web App screen shows SSID, password, WiFi QR, app URL, and fallback app QR
  - normal Web App mode now runs DNS capture, not just WiFi setup mode
  - captive/unknown requests redirect to `/app` in Web App mode and `/wifi` in setup mode

- Added web app diagnostics:
  - heap snapshots for web app enable/disable lifecycle
  - request/session counters written to SD diagnostics CSV
  - AP station peak tracking
  - kept diagnostics lightweight enough for ongoing web app development

- Added memory hardening related to web app mode:
  - pauses BLE/FANet during user web app sessions to free RAM
  - restores paused services after web app shutdown
  - reduces debug route registration in normal mode
  
- Reduced ram/heap consumption generally
  - GPX waypoints now stored as int_32 Lat/LonE7 instead of doubles
  - GPX waypoint names are char[24] max, instead of strings 
  - Sat info array uses smaller int types where appropriate

- Added backlog note for a future pixel-exact LCD preview renderer:
  - documents why the approximate renderer was removed
  - captures the need for a host compiler/u8g2 framebuffer harness

## Validation

- Built successfully with:

```powershell
C:\Users\oxoth\.platformio\penv\Scripts\pio.exe run -e leaf_3_2_6_release
```

- On-device testing confirmed:
  - profile creation/edit/delete works from the Web App
  - profile data is written to `profiles/profiles.json`
  - logbook JSON includes selected pilot/glider
  - IGC headers use selected pilot/glider where available
  - WPA2 Leaf AP can be joined repeatedly
  - DNS/captive portal flow opens the Web App automatically on phone across repeated sessions  -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   - 