### PR TITLE
Webserver UI

### DIFF
--- a/mock/webapp/index.html
+++ b/mock/webapp/index.html
@@ -56,6 +56,44 @@
     .sync-status{color:#e2e7dc;font-size:12px;font-weight:650;text-align:center}
     .sync-status strong{display:block;color:white;font-size:13px}
     .msg{min-height:20px;margin-top:10px}
+    .log-pager{display:flex;align-items:center;justify-content:center;gap:12px;margin-bottom:14px}
+    .log-pager button{width:40px;height:34px;padding:4px 8px;font-size:21px;line-height:1}
+    .log-count{min-width:72px;color:white;text-align:center;font-weight:800}
+    .metric-grid{display:grid;grid-template-columns:1fr 1fr;gap:9px}
+    .metric{background:#4d4d4d;border-radius:7px;padding:8px 10px;color:white}
+    .metric span{display:block;color:#dfe5d9;font-size:12px;font-weight:650;margin-bottom:2px}
+    .metric strong{display:block;font-size:16px}
+    .metric.wide{grid-column:1/-1}
+    .flight-card{color:white}
+    .flight-meta{display:flex;justify-content:space-between;gap:12px;font-weight:800;margin-bottom:10px}
+    .flight-meta span:last-child{text-align:right}
+    .alt-chart{position:relative;height:150px;border-radius:7px;background:#4d4d4d;overflow:hidden;margin:12px 0 16px}
+    .alt-title{position:absolute;left:0;right:0;top:50%;transform:translateY(-50%);text-align:center;color:#dfe5d9;font-size:16px;font-weight:800;letter-spacing:.04em}
+    .alt-point{position:absolute;min-width:58px;transform:translate(-50%,-50%);text-align:center}
+    .alt-point strong{display:block;background:var(--leaf);color:#0b0d0b;border-radius:6px;padding:6px 8px;font-size:16px}
+    .alt-point span{display:block;color:white;font-size:11px;font-weight:700;margin-bottom:2px}
+    .flight-detail-grid{display:grid;grid-template-columns:116px 1fr;gap:16px;margin:0 0 16px}
+    .climb-box{display:grid;grid-template-rows:1fr auto 1fr;justify-items:center;min-height:140px;background:#4d4d4d;border-radius:7px;padding:10px 8px;box-sizing:border-box}
+    .climb-box div{display:flex;align-items:center;justify-content:center}
+    .climb-box .mid{color:#dfe5d9;font-weight:800}
+    .climb-value{border-radius:6px;padding:6px 8px;font-weight:800;min-width:72px;text-align:center}
+    .climb-up{align-self:start}
+    .climb-up .climb-value{background:var(--leaf);color:#0b0d0b}
+    .climb-down{align-self:end}
+    .climb-down .climb-value{background:#0b0d0b;color:white}
+    .detail-list{display:grid;gap:7px}
+    .detail-row{display:flex;justify-content:space-between;gap:10px;border-bottom:1px solid #777;padding-bottom:5px}
+    .detail-row span{color:#dfe5d9}
+    .detail-row strong{text-align:right}
+    .track-link{color:var(--leaf);font-weight:800;word-break:break-all}
+    .track-block{margin-top:6px}
+    .flight-id{color:#dfe5d9;font-size:12px;text-align:right;margin-top:6px}
+    .delete-log{margin-top:14px;display:flex;justify-content:flex-end}
+    .delete-log button{width:auto;padding:8px 12px;font-size:14px}
+    .delete-confirm{margin-top:14px;background:#4d4d4d;border-radius:7px;padding:10px}
+    .delete-confirm p{margin:0 0 10px;color:white;font-weight:600;text-align:center}
+    .delete-confirm .row{gap:14px}
+    .cancel-delete{background:var(--leaf);border-color:var(--leaf);color:#0b0d0b}
   </style>
 </head>
 <body>
@@ -74,7 +112,7 @@
         </div>
       </section>
       <section>
-        <h2>Logbook Profiles</h2>
+        <h2>Profiles</h2>
         <label>Active pilot</label>
         <select id="activePilotList"></select>
         <label>Active glider</label>
@@ -86,7 +124,13 @@
       </section>
       <section>
         <h2>Logbook</h2>
-        <p class="muted">Flight log tools will go here.</p>
+        <div class="metric-grid" id="logbookOverview">
+          <div class="metric wide"><span>Flights</span><strong>Loading...</strong></div>
+        </div>
+        <div class="actions">
+          <p class="muted msg" id="logbookMsg"></p>
+          <button class="secondary" id="openLogbook">Open Logbook</button>
+        </div>
       </section>
     </div>
     <div id="profilesView" class="view">
@@ -139,6 +183,21 @@
         <p class="muted msg" id="gliderMsg"></p>
       </section>
     </div>
+    <div id="logbookView" class="view">
+      <div class="subbar">
+        <button class="back" id="backLogbookMain" aria-label="Back">&#x276e;</button>
+        <h2>Logbook</h2>
+      </div>
+      <section>
+        <h2>Flight Details</h2>
+        <div class="log-pager">
+          <button class="secondary" id="logPrev" aria-label="Previous flight">&#x276e;</button>
+          <div class="log-count" id="logCount">--/--</div>
+          <button class="secondary" id="logNext" aria-label="Next flight">&#x276f;</button>
+        </div>
+        <div class="log-summary" id="logSummary"></div>
+      </section>
+    </div>
   </main>
 
   <script>
@@ -171,6 +230,17 @@
       ]
     };
 
+    const mockLogs = [
+      {file:'2026-06-26_11-20-11_6a118bb5.json',flight_id:'6a118bb5',start:{time_local:'2026-06-26T11:20:11'},metrics:{duration_seconds:121,max_altitude_m:41.2,min_altitude_m:29.11,max_altitude_above_launch_m:0,max_climb_rate_mps:0.26,max_sink_rate_mps:-0.16,max_ground_speed_mps:0.581322,average_ground_speed_mps:0.089284,path_distance_m:10.80333},track:{saved:true,path:'tracks/2026-06-26-XLF-000-02.igc'}},
+      {file:'2026-06-26_11-38-48_2dd3a567.json',flight_id:'2dd3a567',start:{time_local:'2026-06-26T11:38:48'},metrics:{duration_seconds:80,max_altitude_m:24.22,min_altitude_m:24.22,max_altitude_above_launch_m:0,max_climb_rate_mps:0.09,max_sink_rate_mps:-0.22,max_ground_speed_mps:0.154333,average_ground_speed_mps:0.025856,path_distance_m:1.656511},track:{saved:true,path:'tracks/2026-06-26-XLF-000-03.igc'}},
+      {file:'2026-06-26_11-55-20_7375661d.json',flight_id:'7375661d',start:{time_local:'2026-06-26T11:55:20'},metrics:{duration_seconds:40,max_altitude_m:0,min_altitude_m:0,max_altitude_above_launch_m:0,max_climb_rate_mps:0.11,max_sink_rate_mps:-0.11,max_ground_speed_mps:2.196678,average_ground_speed_mps:0.135299,path_distance_m:5.411955},track:{saved:false,path:null}},
+      {file:'2026-06-26_12-13-02_37243116.json',flight_id:'37243116',start:{time_local:'2026-06-26T12:13:02'},metrics:{duration_seconds:82,max_altitude_m:24.17,min_altitude_m:24.17,max_altitude_above_launch_m:0,max_climb_rate_mps:0.25,max_sink_rate_mps:-0.13,max_ground_speed_mps:0.159478,average_ground_speed_mps:0.006776,path_distance_m:0.5556},track:{saved:false,path:null}},
+      {file:'2026-06-26_13-59-18_b7d7f6e8.json',flight_id:'b7d7f6e8',start:{time_local:'2026-06-26T13:59:18'},metrics:{duration_seconds:165,max_altitude_m:44.35,min_altitude_m:0,max_altitude_above_launch_m:0,max_climb_rate_mps:1.49,max_sink_rate_mps:-0.88,max_ground_speed_mps:1.0649,average_ground_speed_mps:0.111245,path_distance_m:18.35538},track:{saved:false,path:null}},
+      {file:'2026-06-26_14-53-13_68278e6a.json',flight_id:'68278e6a',start:{time_local:'2026-06-26T14:53:13'},metrics:{duration_seconds:10,max_altitude_m:24.81,min_altitude_m:24.29,max_altitude_above_launch_m:0.52,max_climb_rate_mps:1.01,max_sink_rate_mps:-0.65,max_ground_speed_mps:0.6945,average_ground_speed_mps:0.466601,path_distance_m:4.666012},track:{saved:true,path:'tracks/2026-06-26-XLF-000-04.igc'}},
+      {file:'2026-06-26_14-53-49_013725e8.json',flight_id:'013725e8',start:{time_local:'2026-06-26T14:53:49'},metrics:{duration_seconds:6,max_altitude_m:24.29,min_altitude_m:24.29,max_altitude_above_launch_m:0,max_climb_rate_mps:0.68,max_sink_rate_mps:-0.62,max_ground_speed_mps:0.920856,average_ground_speed_mps:0.596756,path_distance_m:3.580533},track:{saved:true,path:'tracks/2026-06-26-XLF-000-05.igc'}},
+      {file:'2026-06-26_14-55-34_31c02d5d.json',flight_id:'31c02d5d',start:{time_local:'2026-06-26T14:55:34'},metrics:{duration_seconds:6,max_altitude_m:24.29,min_altitude_m:24.29,max_altitude_above_launch_m:0,max_climb_rate_mps:0.11,max_sink_rate_mps:-0.17,max_ground_speed_mps:0.010289,average_ground_speed_mps:0,path_distance_m:0},track:{saved:true,path:'tracks/2026-06-26-XLF-000-06.igc'}}
+    ];
+
     function mockProfiles() {
       try {
         return JSON.parse(localStorage.getItem('leaf.mock.profiles')) || defaultProfiles;
@@ -196,6 +266,17 @@
         saveMockProfiles(JSON.parse(options.body));
         return new Response(JSON.stringify({ saved: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
+      if (path === '/api/logbook') {
+        let loaded=[];
+        for (let item of mockLogs) {
+          try {
+            let r=await realFetch('logbook%20json%20files/'+item.file);
+            if(r.ok)loaded.push(await r.json());
+          } catch (e) {}
+        }
+        if(loaded[0]&&loaded[0].metrics){loaded[0].metrics.max_wind_speed_kph=26;loaded[0].metrics.max_wind_direction='SSW'}
+        return new Response(JSON.stringify({ logs: loaded.length?loaded:mockLogs }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
       return realFetch(url, options);
     };
   </script>
@@ -204,6 +285,9 @@
     let profiles={schema:'leaf.profiles',schema_version:'v0.1.0',active_pilot_id:null,active_glider_id:null,pilots:[],gliders:[]};
     let pilotSnapshot={id:null,name:''};
     let gliderSnapshot={id:null,brand:'',model:'',size:'',display_name:''};
+    let logs=[];
+    let logIndex=0;
+    let pendingLogDelete=false;
     const $=id=>document.getElementById(id);
     function id(){return Math.floor(Math.random()*0xffffffff).toString(16).padStart(8,'0')}
     function clean(v){v=(v||'').trim();return v?v:null}
@@ -218,10 +302,98 @@
     function showView(name){
       $('mainView').classList.toggle('active',name=='main');
       $('profilesView').classList.toggle('active',name=='profiles');
+      $('logbookView').classList.toggle('active',name=='logbook');
     }
     function fillProfileSelect(el,items,label){
       el.textContent='';
       items.forEach(x=>{let o=document.createElement('option');o.value=x.id;o.textContent=label(x);el.appendChild(o)});
+    }
+    function fmtDate(v){if(!v)return'--';let d=new Date(v);return isNaN(d)?v:d.toLocaleString([], {month:'short',day:'numeric',hour:'numeric',minute:'2-digit'})}
+    function fmtDuration(s){s=Number(s)||0;let m=Math.floor(s/60),r=s%60;return m?`${m}m ${r}s`:`${r}s`}
+    function fmtNum(v,d,u){return Number.isFinite(Number(v))?`${Number(v).toFixed(d)}${u||''}`:'--'}
+    function fmtAlt(v){return fmtNum(v,0,' m')}
+    function metricPair(label,value){return `<div class="detail-row"><span>${label}</span><strong>${value}</strong></div>`}
+    function optionalMetricPair(label,value){return Number.isFinite(Number(value))?metricPair(label,fmtNum(value,1,' km/h')):''}
+    function windText(m){
+      let v=m.max_wind_speed_kph??m.max_wind_kph;
+      if(!Number.isFinite(Number(v))){
+        let mps=m.max_wind_speed_mps??m.max_wind_mps;
+        v=Number.isFinite(Number(mps))?Number(mps)*3.6:NaN;
+      }
+      return Number.isFinite(Number(v))?`${Number(v).toFixed(0)} km/h${m.max_wind_direction?` ${m.max_wind_direction}`:''}`:'';
+    }
+    function altitudePoint(label,value,x,min,max){
+      if(!Number.isFinite(Number(value)))return '';
+      let span=Math.max(1,max-min),top=22+(1-(value-min)/span)*56;
+      return `<div class="alt-point" style="left:${x}%;top:${top}%"><span>${label}</span><strong>${fmtAlt(value)}</strong></div>`;
+    }
+    function metric(label,value,wide){return `<div class="metric${wide?' wide':''}"><span>${label}</span><strong>${value}</strong></div>`}
+    function renderLogbook(){
+      pendingLogDelete=false;
+      renderLogbookOverview();
+      if(!logs.length){$('logCount').textContent='0/0';$('logSummary').innerHTML='<p class="muted">No logs found.</p>';$('logPrev').disabled=true;$('logNext').disabled=true;return}
+      logIndex=Math.max(0,Math.min(logs.length-1,logIndex));
+      let l=logs[logIndex],m=l.metrics||{};
+      $('logCount').textContent=`${logIndex+1}/${logs.length}`;
+      $('logPrev').disabled=logIndex==0;
+      $('logNext').disabled=logIndex==logs.length-1;
+      let startAlt=l.start&&l.start.location?l.start.location.altitude_m:(l.first_fix&&l.first_fix.location?l.first_fix.location.altitude_m:null);
+      let endAlt=l.end&&l.end.location?l.end.location.altitude_m:null;
+      let maxAlt=m.max_altitude_m;
+      let minAlt=Math.min(...[startAlt,endAlt,maxAlt,m.min_altitude_m].filter(x=>Number.isFinite(Number(x))));
+      let chartMax=Math.max(...[startAlt,endAlt,maxAlt].filter(x=>Number.isFinite(Number(x))));
+      let showMax=Number(maxAlt)>Number(startAlt)&&Number(maxAlt)>Number(endAlt);
+      let trackName=l.track&&l.track.path?l.track.path.split('/').pop():'No track file saved';
+      $('logSummary').innerHTML=`<div class="flight-card">
+        <div class="flight-meta"><span>${fmtDate(l.start&&l.start.time_local)}</span><span>${fmtDuration(m.duration_seconds)}</span></div>
+        <div class="alt-chart">
+          <div class="alt-title">Altitude</div>
+          ${altitudePoint('start',startAlt,14,minAlt,chartMax)}
+          ${showMax?altitudePoint('max',maxAlt,50,minAlt,chartMax):''}
+          ${altitudePoint('end',endAlt,86,minAlt,chartMax)}
+        </div>
+        <div class="flight-detail-grid">
+          <div class="climb-box">
+            <div class="climb-up"><span class="climb-value">${fmtNum(m.max_climb_rate_mps,1,' m/s')}</span></div>
+            <div class="mid">Vario</div>
+            <div class="climb-down"><span class="climb-value">${fmtNum(m.max_sink_rate_mps,1,' m/s')}</span></div>
+          </div>
+          <div class="detail-list">
+            ${metricPair('Max Speed',fmtNum((m.max_ground_speed_mps||0)*3.6,1,' km/h'))}
+            ${windText(m)?metricPair('Max Wind',windText(m)):''}
+            ${metricPair('Path Distance',fmtNum(m.path_distance_m,0,' m'))}
+            ${metricPair('Straight Distance',fmtNum(m.straight_line_distance_m,0,' m'))}
+            ${metricPair('G Force',`${fmtNum(m.min_accel_g,2,'g')} / ${fmtNum(m.max_accel_g,2,'g')}`)}
+            ${metricPair('Temp',`${fmtNum(m.min_temperature_c,1,' C')} / ${fmtNum(m.max_temperature_c,1,' C')}`)}
+          </div>
+        </div>
+        <div class="track-block"><span class="status-block-title">Track File</span><span class="track-link">${trackName}</span></div>
+        <div class="flight-id">Flight ID ${l.flight_id||'--'}</div>
+        <div id="deleteArea"><div class="delete-log"><button class="danger" id="deleteLog">Delete Log</button></div></div>
+      </div>`;
+      $('deleteLog').onclick=showDeleteConfirm;
+    }
+    function showDeleteConfirm(){
+      if(!logs.length)return;
+      pendingLogDelete=true;
+      $('deleteArea').innerHTML='<div class="delete-confirm"><p>Are you sure you want to delete this log and track file?</p><div class="row"><button class="danger" id="confirmDeleteLog">Confirm Delete</button><button class="cancel-delete" id="cancelDeleteLog">Cancel</button></div></div>';
+      $('confirmDeleteLog').onclick=deleteCurrentLog;
+      $('cancelDeleteLog').onclick=()=>{pendingLogDelete=false;renderLogbook()};
+    }
+    function deleteCurrentLog(){
+      if(!pendingLogDelete||!logs.length)return;
+      logs.splice(logIndex,1);
+      if(logIndex>=logs.length)logIndex=logs.length-1;
+      renderLogbook();
+    }
+    function renderLogbookOverview(){
+      if(!logs.length){$('logbookOverview').innerHTML=metric('Flights','No logs found.',true);$('openLogbook').disabled=true;return}
+      let last=logs[logs.length-1],m=(last&&last.metrics)||{};
+      $('openLogbook').disabled=false;
+      $('logbookOverview').innerHTML=[
+        metric('Flights',logs.length),
+        metric('Last Flight',fmtDate(last.start&&last.start.time_local))
+      ].join('');
     }
     function pilotEditor(){return {id:profiles.active_pilot_id,name:$('pilotName').value||''}}
     function gliderEditor(){return {id:profiles.active_glider_id,brand:$('gliderBrand').value||'',model:$('gliderModel').value||'',size:$('gliderSize').value||'',display_name:$('gliderDisplay').value||''}}
@@ -284,8 +456,15 @@
     async function loadProfiles(){
       try{profiles=await(await fetch('/api/profiles')).json();normalize();setPilotMsg('');setGliderMsg('');render()}catch(e){setPilotMsg('Unable to read profiles.');setGliderMsg('')}
     }
+    async function loadLogs(){
+      try{let d=await(await fetch('/api/logbook')).json();logs=d.logs||[];renderLogbook()}catch(e){$('logSummary').innerHTML='<p class="muted">Unable to read logs.</p>'}
+    }
     $('editProfiles').onclick=()=>showView('profiles');
     $('backMain').onclick=()=>showView('main');
+    $('openLogbook').onclick=()=>showView('logbook');
+    $('backLogbookMain').onclick=()=>showView('main');
+    $('logPrev').onclick=()=>{logIndex--;renderLogbook()};
+    $('logNext').onclick=()=>{logIndex++;renderLogbook()};
     ['pilotName','gliderBrand','gliderModel','gliderSize','gliderDisplay'].forEach(x=>$(x).oninput=updateEditorButtons);
     $('activePilotList').onchange=()=>{profiles.active_pilot_id=$('activePilotList').value;render();save('Active pilot saved.').then(()=>setMainProfileMsg('Active pilot saved.')).catch(()=>setMainProfileMsg('Unable to save.'))};
     $('activeGliderList').onchange=()=>{profiles.active_glider_id=$('activeGliderList').value;render();save('Active glider saved.').then(()=>setMainProfileMsg('Active glider saved.')).catch(()=>setMainProfileMsg('Unable to save.'))};
@@ -297,7 +476,7 @@
     $('gliderSave').onclick=()=>{let model=clean($('gliderModel').value);if(!model){setGliderMsg('Glider model is required.');return}let g=selectedGlider();if(!g){g={id:id(),model:''};profiles.gliders.push(g);profiles.active_glider_id=g.id}g.brand=clean($('gliderBrand').value);g.model=model;g.size=clean($('gliderSize').value);g.display_name=clean($('gliderDisplay').value);save('Glider profile saved.').then(()=>setGliderMsg('Glider profile saved.')).catch(()=>setGliderMsg('Unable to save glider.'))};
     $('pilotDelete').onclick=()=>{let p=selectedPilot();if(!p)return;profiles.pilots=profiles.pilots.filter(x=>x.id!=p.id);profiles.active_pilot_id=null;save('Pilot profile deleted.').then(()=>setPilotMsg('Pilot profile deleted.')).catch(()=>setPilotMsg('Unable to delete pilot.'))};
     $('gliderDelete').onclick=()=>{let g=selectedGlider();if(!g)return;profiles.gliders=profiles.gliders.filter(x=>x.id!=g.id);profiles.active_glider_id=null;save('Glider profile deleted.').then(()=>setGliderMsg('Glider profile deleted.')).catch(()=>setGliderMsg('Unable to delete glider.'))};
-    loadStatus();loadProfiles();
+    loadStatus();loadProfiles();loadLogs();
   </script>
 </body>
 </html>

--- a/mock/webapp/index.html
+++ b/mock/webapp/index.html
@@ -1,0 +1,303 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta http-equiv="Cache-Control" content="no-store">
+  <title>Leaf Mock</title>
+  <style>
+    :root{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#202423;background:#363636;line-height:1.35;--leaf:#d8ff00;--ink:#202423;--graphite:#565656;--soft:#f6f7f3;--line:#d7dccf;--muted:#626a5d;--danger:#7a1d1d}
+    body{margin:0;background:#363636}
+    header{background:var(--leaf);color:#0b0d0b;padding:12px 20px;text-align:center}
+    main{max-width:640px;margin:auto;padding:18px 18px 24px}
+    h1{font-family:Arial,sans-serif;font-size:38px;font-weight:500;letter-spacing:.12em;line-height:1;margin:0}
+    h2{font-size:18px;margin:-16px -14px 14px;padding:10px 12px;color:#0b0d0b;background:var(--leaf);text-align:center;border-radius:5px 5px 0 0}
+    section{background:var(--graphite);border:0;border-radius:8px;margin:0 0 14px;padding:16px 14px}
+    section:first-child{padding:14px 14px}
+    section:first-child h2{margin:-14px -14px 14px}
+    .status-panel h2{background:var(--graphite);color:white;border-bottom:1px solid #a9a9a9}
+    .view{display:none}
+    .view.active{display:block}
+    .subbar{position:relative;display:flex;align-items:center;justify-content:center;min-height:38px;color:white;margin:0 0 14px}
+    .back{position:absolute;left:0;top:0;width:42px;height:38px;background:white;color:var(--ink);border-color:white;box-shadow:none;padding:5px 8px;font-size:28px;font-weight:900;line-height:.9}
+    .subbar h2{color:white;background:transparent;margin:0;padding:0;font-size:18px;text-align:center;border-radius:0}
+    .grid{display:grid;gap:10px}
+    .row{display:flex;gap:8px}
+    .row>*{flex:1}
+    .row>.small{flex:0 0 94px}
+    .profile-actions{margin-top:12px;gap:14px}
+    .profile-actions button{padding:8px 10px;font-size:14px}
+    .actions{display:flex;align-items:center;gap:10px;margin-top:12px}
+    .actions .msg{flex:1;margin:0}
+    .actions button{flex:0 0 auto;width:auto;padding:8px 12px;font-size:14px}
+    label{display:block;font-size:13px;font-weight:700;margin:10px 0 4px;color:white}
+    input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:11px;border:1px solid #b9c0b2;border-radius:7px;background:white;color:var(--ink)}
+    input:focus,select:focus{outline:2px solid var(--leaf);outline-offset:1px;border-color:#7d8a69}
+    select:disabled{background:#686868;border-color:#686868;color:#8a8a8a;opacity:1}
+    button{background:var(--ink);color:white;font-weight:750;border-color:var(--ink);box-shadow:inset 0 -2px 0 rgba(0,0,0,.22)}
+    button:focus{outline:2px solid var(--leaf);outline-offset:2px}
+    button:disabled{background:#686868;border-color:#686868;color:#8a8a8a;box-shadow:none}
+    .profile-actions button:first-child:not(:disabled){background:var(--leaf);border-color:var(--leaf);color:#0b0d0b;box-shadow:inset 0 -2px 0 rgba(0,0,0,.18)}
+    .secondary{background:white;color:var(--ink);border-color:#89917f;box-shadow:none}
+    .secondary:disabled{background:#686868;border-color:#686868;color:#8a8a8a}
+    .danger{background:var(--danger);border-color:var(--danger);color:white}
+    .danger:disabled{background:#686868;border-color:#686868;color:#8a8a8a}
+    .muted{color:#e2e7dc}
+    .status{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:13px;white-space:pre-wrap;color:white}
+    .status-body{display:grid;grid-template-columns:max-content max-content max-content;align-items:start;justify-content:space-between;column-gap:14px}
+    .status-block{color:white;font-size:13px;font-weight:700}
+    .status-block-title{display:block;color:#e2e7dc;font-size:12px;font-weight:650;margin-bottom:4px}
+    .battery-status{color:white;text-align:right;font-size:13px;font-weight:700}
+    .battery-line{display:flex;align-items:center;justify-content:flex-end;gap:7px;margin-bottom:4px}
+    .battery{position:relative;width:44px;height:20px;border:2px solid white;border-radius:4px;box-sizing:border-box}
+    .battery:after{content:"";position:absolute;right:-6px;top:4px;width:4px;height:8px;background:white;border-radius:0 2px 2px 0}
+    .battery-fill{display:block;height:100%;background:var(--leaf);border-radius:2px}
+    .battery-meta{font-size:12px;font-weight:650;color:#e2e7dc}
+    .sync-status{color:#e2e7dc;font-size:12px;font-weight:650;text-align:center}
+    .sync-status strong{display:block;color:white;font-size:13px}
+    .msg{min-height:20px;margin-top:10px}
+  </style>
+</head>
+<body>
+  <header><h1>Leaf</h1></header>
+  <main>
+    <div id="mainView" class="view active">
+      <section class="status-panel">
+        <h2>Status</h2>
+        <div class="status-body">
+          <div class="status" id="status">Loading...</div>
+          <div class="sync-status"><strong>Log Sync</strong><span id="syncText">--</span></div>
+          <div class="battery-status">
+            <div class="battery-line"><span id="batteryText">--%</span><div class="battery" aria-label="Battery"><span class="battery-fill" id="batteryFill"></span></div></div>
+            <div class="battery-meta" id="batteryCharge">Unknown</div>
+          </div>
+        </div>
+      </section>
+      <section>
+        <h2>Logbook Profiles</h2>
+        <label>Active pilot</label>
+        <select id="activePilotList"></select>
+        <label>Active glider</label>
+        <select id="activeGliderList"></select>
+        <div class="actions">
+          <p class="muted msg" id="mainProfileMsg"></p>
+          <button class="secondary" id="editProfiles">Edit Profiles</button>
+        </div>
+      </section>
+      <section>
+        <h2>Logbook</h2>
+        <p class="muted">Flight log tools will go here.</p>
+      </section>
+    </div>
+    <div id="profilesView" class="view">
+      <div class="subbar">
+        <button class="back" id="backMain" aria-label="Back">&#x276e;</button>
+        <h2>Edit Profiles</h2>
+      </div>
+      <section>
+        <h2>Pilots</h2>
+        <label>Active pilot</label>
+        <select id="pilotList"></select>
+        <label>Name</label>
+        <input id="pilotName" maxlength="48" autocomplete="name">
+        <div class="row profile-actions">
+          <button id="pilotSave" disabled>Save Profile</button>
+          <button class="secondary" id="pilotNew">New</button>
+          <button class="small danger" id="pilotDelete">Delete</button>
+        </div>
+        <p class="muted msg" id="pilotMsg"></p>
+      </section>
+      <section>
+        <h2>Gliders</h2>
+        <label>Active glider</label>
+        <select id="gliderList"></select>
+        <div class="row">
+          <div>
+            <label>Brand</label>
+            <input id="gliderBrand" maxlength="32">
+          </div>
+          <div>
+            <label>Model</label>
+            <input id="gliderModel" maxlength="48">
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label>Size</label>
+            <input id="gliderSize" maxlength="16">
+          </div>
+          <div>
+            <label>Display name</label>
+            <input id="gliderDisplay" maxlength="64">
+          </div>
+        </div>
+        <div class="row profile-actions">
+          <button id="gliderSave" disabled>Save Profile</button>
+          <button class="secondary" id="gliderNew">New</button>
+          <button class="small danger" id="gliderDelete">Delete</button>
+        </div>
+        <p class="muted msg" id="gliderMsg"></p>
+      </section>
+    </div>
+  </main>
+
+  <script>
+    const mockStatus = {
+      active: true,
+      mode: 'network',
+      ssid: 'SkyWagon',
+      ip_address: '10.0.0.20',
+      url: 'http://10.0.0.20:81/app',
+      firmware_version: '0.1.7-webapp-mock',
+      battery_percent: 75,
+      battery_charging: true,
+      log_sync_uploaded: 3,
+      log_sync_total: 7,
+      log_sync_complete: false
+    };
+
+    const defaultProfiles = {
+      schema: 'leaf.profiles',
+      schema_version: 'v0.1.0',
+      active_pilot_id: 'pilot-a',
+      active_glider_id: 'glider-a',
+      pilots: [
+        { id: 'pilot-a', name: 'Alex Morgan' },
+        { id: 'pilot-b', name: 'Taylor Chen' }
+      ],
+      gliders: [
+        { id: 'glider-a', brand: 'Ozone', model: 'Swift 6', size: 'MS', display_name: 'Swift 6 MS' },
+        { id: 'glider-b', brand: 'Advance', model: 'Epsilon DLS', size: '26', display_name: 'Epsilon DLS 26' }
+      ]
+    };
+
+    function mockProfiles() {
+      try {
+        return JSON.parse(localStorage.getItem('leaf.mock.profiles')) || defaultProfiles;
+      } catch (error) {
+        return defaultProfiles;
+      }
+    }
+
+    function saveMockProfiles(data) {
+      localStorage.setItem('leaf.mock.profiles', JSON.stringify(data));
+    }
+
+    const realFetch = window.fetch.bind(window);
+    window.fetch = async function(url, options = {}) {
+      const path = typeof url === 'string' ? url : url.url;
+      if (path === '/api/user/status') {
+        return new Response(JSON.stringify(mockStatus), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (path === '/api/profiles' && (!options.method || options.method === 'GET')) {
+        return new Response(JSON.stringify(mockProfiles()), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (path === '/api/profiles' && options.method === 'PUT') {
+        saveMockProfiles(JSON.parse(options.body));
+        return new Response(JSON.stringify({ saved: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return realFetch(url, options);
+    };
+  </script>
+
+  <script>
+    let profiles={schema:'leaf.profiles',schema_version:'v0.1.0',active_pilot_id:null,active_glider_id:null,pilots:[],gliders:[]};
+    let pilotSnapshot={id:null,name:''};
+    let gliderSnapshot={id:null,brand:'',model:'',size:'',display_name:''};
+    const $=id=>document.getElementById(id);
+    function id(){return Math.floor(Math.random()*0xffffffff).toString(16).padStart(8,'0')}
+    function clean(v){v=(v||'').trim();return v?v:null}
+    function pilotLabel(p){return p.name||'Unnamed pilot'}
+    function gliderLabel(g){return g.display_name||[g.brand,g.model,g.size].filter(Boolean).join(' ')||'Unnamed glider'}
+    function selectedPilot(){return profiles.pilots.find(p=>p.id==profiles.active_pilot_id)}
+    function selectedGlider(){return profiles.gliders.find(g=>g.id==profiles.active_glider_id)}
+    function setPilotMsg(t){$('pilotMsg').textContent=t||''}
+    function setGliderMsg(t){$('gliderMsg').textContent=t||''}
+    function setMsg(t){setPilotMsg(t);setGliderMsg('')}
+    function setMainProfileMsg(t){$('mainProfileMsg').textContent=t||''}
+    function showView(name){
+      $('mainView').classList.toggle('active',name=='main');
+      $('profilesView').classList.toggle('active',name=='profiles');
+    }
+    function fillProfileSelect(el,items,label){
+      el.textContent='';
+      items.forEach(x=>{let o=document.createElement('option');o.value=x.id;o.textContent=label(x);el.appendChild(o)});
+    }
+    function pilotEditor(){return {id:profiles.active_pilot_id,name:$('pilotName').value||''}}
+    function gliderEditor(){return {id:profiles.active_glider_id,brand:$('gliderBrand').value||'',model:$('gliderModel').value||'',size:$('gliderSize').value||'',display_name:$('gliderDisplay').value||''}}
+    function same(a,b){return JSON.stringify(a)==JSON.stringify(b)}
+    function setSnapshots(){
+      pilotSnapshot=pilotEditor();
+      gliderSnapshot=gliderEditor();
+      updateEditorButtons();
+    }
+    function updateEditorButtons(){
+      let p=pilotEditor();
+      let g=gliderEditor();
+      $('pilotSave').disabled=!clean(p.name)||same(p,pilotSnapshot);
+      $('pilotDelete').disabled=!selectedPilot();
+      $('pilotNew').disabled=!profiles.pilots.length;
+      $('gliderSave').disabled=!([g.brand,g.model,g.size,g.display_name].some(v=>clean(v)))||same(g,gliderSnapshot);
+      $('gliderDelete').disabled=!selectedGlider();
+      $('gliderNew').disabled=!profiles.gliders.length;
+    }
+    function render(){
+      let pl=$('pilotList');pl.textContent='';
+      fillProfileSelect(pl,profiles.pilots,pilotLabel);
+      pl.disabled=!profiles.pilots.length;
+      if(profiles.active_pilot_id)pl.value=profiles.active_pilot_id;
+      fillProfileSelect($('activePilotList'),profiles.pilots,pilotLabel);
+      $('activePilotList').disabled=!profiles.pilots.length;
+      if(profiles.active_pilot_id)$('activePilotList').value=profiles.active_pilot_id;
+      let p=selectedPilot();$('pilotName').value=p?p.name||'':'';
+      if(!profiles.pilots.length)setPilotMsg('Enter pilot name, then Save Profile.');
+      let gl=$('gliderList');gl.textContent='';
+      fillProfileSelect(gl,profiles.gliders,gliderLabel);
+      gl.disabled=!profiles.gliders.length;
+      if(profiles.active_glider_id)gl.value=profiles.active_glider_id;
+      fillProfileSelect($('activeGliderList'),profiles.gliders,gliderLabel);
+      $('activeGliderList').disabled=!profiles.gliders.length;
+      if(profiles.active_glider_id)$('activeGliderList').value=profiles.active_glider_id;
+      let g=selectedGlider();$('gliderBrand').value=g?g.brand||'':'';
+      $('gliderModel').value=g?g.model||'':'';
+      $('gliderSize').value=g?g.size||'':'';
+      $('gliderDisplay').value=g?g.display_name||'':'';
+      if(!profiles.gliders.length)setGliderMsg('Enter glider details, then Save Profile.');
+      setSnapshots();
+    }
+    function normalize(){
+      profiles.schema='leaf.profiles';profiles.schema_version='v0.1.0';
+      profiles.pilots=(profiles.pilots||[]).filter(p=>p&&p.id&&p.name);
+      profiles.gliders=(profiles.gliders||[]).filter(g=>g&&g.id&&g.model);
+      if(!profiles.pilots.find(p=>p.id==profiles.active_pilot_id))profiles.active_pilot_id=profiles.pilots.length==1?profiles.pilots[0].id:null;
+      if(!profiles.gliders.find(g=>g.id==profiles.active_glider_id))profiles.active_glider_id=profiles.gliders.length==1?profiles.gliders[0].id:null;
+    }
+    async function save(note){
+      normalize();
+      let r=await fetch('/api/profiles',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(profiles)});
+      if(!r.ok)throw new Error();
+      render();
+    }
+    async function loadStatus(){
+      try{let s=await(await fetch('/api/user/status')).json();$('status').textContent=`mode: ${s.mode}\nssid: ${s.ssid||'(none)'}\nip: ${s.ip_address||'(none)'}\nfirmware: ${s.firmware_version}`;let p=Math.max(0,Math.min(100,Number(s.battery_percent)||0));$('batteryFill').style.width=p+'%';$('batteryText').textContent=p+'%';$('batteryCharge').textContent=s.battery_charging?'Charging':'Not charging';$('syncText').textContent=s.log_sync_complete?'Complete':`${s.log_sync_uploaded||0}/${s.log_sync_total||0} uploaded`}catch(e){$('status').textContent='Unable to read status.'}
+    }
+    async function loadProfiles(){
+      try{profiles=await(await fetch('/api/profiles')).json();normalize();setPilotMsg('');setGliderMsg('');render()}catch(e){setPilotMsg('Unable to read profiles.');setGliderMsg('')}
+    }
+    $('editProfiles').onclick=()=>showView('profiles');
+    $('backMain').onclick=()=>showView('main');
+    ['pilotName','gliderBrand','gliderModel','gliderSize','gliderDisplay'].forEach(x=>$(x).oninput=updateEditorButtons);
+    $('activePilotList').onchange=()=>{profiles.active_pilot_id=$('activePilotList').value;render();save('Active pilot saved.').then(()=>setMainProfileMsg('Active pilot saved.')).catch(()=>setMainProfileMsg('Unable to save.'))};
+    $('activeGliderList').onchange=()=>{profiles.active_glider_id=$('activeGliderList').value;render();save('Active glider saved.').then(()=>setMainProfileMsg('Active glider saved.')).catch(()=>setMainProfileMsg('Unable to save.'))};
+    $('pilotList').onchange=()=>{profiles.active_pilot_id=$('pilotList').value;render();save('Active pilot selected.').then(()=>setPilotMsg('Active pilot selected.')).catch(()=>setPilotMsg('Unable to save.'))};
+    $('gliderList').onchange=()=>{profiles.active_glider_id=$('gliderList').value;render();save('Active glider selected.').then(()=>setGliderMsg('Active glider selected.')).catch(()=>setGliderMsg('Unable to save.'))};
+    $('pilotNew').onclick=()=>{$('pilotList').value='';profiles.active_pilot_id=null;$('pilotName').value='';setSnapshots();$('pilotName').focus();setPilotMsg('Enter pilot name, then Save Profile.')};
+    $('gliderNew').onclick=()=>{$('gliderList').value='';profiles.active_glider_id=null;['gliderBrand','gliderModel','gliderSize','gliderDisplay'].forEach(x=>$(x).value='');setSnapshots();$('gliderModel').focus();setGliderMsg('Enter glider details, then Save Profile.')};
+    $('pilotSave').onclick=()=>{let name=clean($('pilotName').value);if(!name){setPilotMsg('Pilot name is required.');return}let p=selectedPilot();if(!p){p={id:id(),name:''};profiles.pilots.push(p);profiles.active_pilot_id=p.id}p.name=name;save('Pilot profile saved.').then(()=>setPilotMsg('Pilot profile saved.')).catch(()=>setPilotMsg('Unable to save pilot.'))};
+    $('gliderSave').onclick=()=>{let model=clean($('gliderModel').value);if(!model){setGliderMsg('Glider model is required.');return}let g=selectedGlider();if(!g){g={id:id(),model:''};profiles.gliders.push(g);profiles.active_glider_id=g.id}g.brand=clean($('gliderBrand').value);g.model=model;g.size=clean($('gliderSize').value);g.display_name=clean($('gliderDisplay').value);save('Glider profile saved.').then(()=>setGliderMsg('Glider profile saved.')).catch(()=>setGliderMsg('Unable to save glider.'))};
+    $('pilotDelete').onclick=()=>{let p=selectedPilot();if(!p)return;profiles.pilots=profiles.pilots.filter(x=>x.id!=p.id);profiles.active_pilot_id=null;save('Pilot profile deleted.').then(()=>setPilotMsg('Pilot profile deleted.')).catch(()=>setPilotMsg('Unable to delete pilot.'))};
+    $('gliderDelete').onclick=()=>{let g=selectedGlider();if(!g)return;profiles.gliders=profiles.gliders.filter(x=>x.id!=g.id);profiles.active_glider_id=null;save('Glider profile deleted.').then(()=>setGliderMsg('Glider profile deleted.')).catch(()=>setGliderMsg('Unable to delete glider.'))};
+    loadStatus();loadProfiles();
+  </script>
+</body>
+</html>

--- a/mock/webapp/logbook json files/2026-06-26_11-20-11_6a118bb5.json
+++ b/mock/webapp/logbook json files/2026-06-26_11-20-11_6a118bb5.json
@@ -1,0 +1,75 @@
+{
+  "schema": "leaf.logbook.flight",
+  "schema_version": "v0.1.0",
+  "flight_id": "6a118bb5",
+  "clock": {
+    "system_time_synced_this_boot": true,
+    "time_source": "gps",
+    "timezone_offset_minutes": -420
+  },
+  "start": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T18:20:11Z",
+    "time_local": "2026-06-26T11:20:11",
+    "location": {
+      "lat_deg": 37.37475,
+      "lon_deg": -121.9943,
+      "altitude_m": 41.2
+    },
+    "temperature_c": 24.69051
+  },
+  "end": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T18:22:12Z",
+    "time_local": "2026-06-26T11:22:12",
+    "location": {
+      "lat_deg": 37.37473,
+      "lon_deg": -121.9943,
+      "altitude_m": 30.09
+    },
+    "temperature_c": 25.14255
+  },
+  "metrics": {
+    "duration_seconds": 121,
+    "max_altitude_m": 41.2,
+    "min_altitude_m": 29.11,
+    "max_altitude_above_launch_m": 0,
+    "max_climb_rate_mps": 0.26,
+    "max_sink_rate_mps": -0.16,
+    "max_ground_speed_mps": 0.581322,
+    "average_ground_speed_mps": 0.089284,
+    "straight_line_distance_m": 5.019224,
+    "path_distance_m": 10.80333,
+    "max_accel_g": 1.130168,
+    "min_accel_g": 0.869295,
+    "max_temperature_c": 25.26061,
+    "min_temperature_c": 24.69051
+  },
+  "track": {
+    "saved": true,
+    "format": "igc",
+    "path": "tracks/2026-06-26-XLF-000-02.igc"
+  },
+  "device": {
+    "firmware_version": "0.1.7-b4cd+h3.2.6",
+    "hardware_version": "leaf_3_2_6",
+    "mac_address": "F0:F5:BD:53:60:04"
+  },
+  "pilot": {
+    "name": null
+  },
+  "glider": {
+    "brand": null,
+    "model": null,
+    "size": null
+  },
+  "site": {
+    "launch_name": null,
+    "landing_name": null
+  },
+  "weather": {},
+  "notes": {
+    "pilot_notes": "",
+    "tags": []
+  }
+}

--- a/mock/webapp/logbook json files/2026-06-26_11-38-48_2dd3a567.json
+++ b/mock/webapp/logbook json files/2026-06-26_11-38-48_2dd3a567.json
@@ -1,0 +1,81 @@
+{
+  "schema": "leaf.logbook.flight",
+  "schema_version": "v0.1.0",
+  "flight_id": "2dd3a567",
+  "clock": {
+    "system_time_synced_this_boot": true,
+    "time_source": "gps",
+    "timezone_offset_minutes": -420
+  },
+  "start": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T18:38:48Z",
+    "time_local": "2026-06-26T11:38:48",
+    "temperature_c": 26.39548
+  },
+  "first_fix": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T18:39:55Z",
+    "time_local": "2026-06-26T11:39:55",
+    "location": {
+      "lat_deg": 37.37469,
+      "lon_deg": -121.9943,
+      "altitude_m": 15.87
+    },
+    "temperature_c": 24.85149
+  },
+  "end": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T18:40:09Z",
+    "time_local": "2026-06-26T11:40:09",
+    "location": {
+      "lat_deg": 37.37466,
+      "lon_deg": -121.9943,
+      "altitude_m": 24.68
+    },
+    "temperature_c": 25.45612
+  },
+  "metrics": {
+    "duration_seconds": 80,
+    "max_altitude_m": 24.22,
+    "min_altitude_m": 14.53,
+    "max_altitude_above_launch_m": 8.35,
+    "max_climb_rate_mps": 0.09,
+    "max_sink_rate_mps": -0.22,
+    "max_ground_speed_mps": 0.154333,
+    "average_ground_speed_mps": 0.020706,
+    "straight_line_distance_m": 7.208118,
+    "path_distance_m": 1.656511,
+    "max_accel_g": 1,
+    "min_accel_g": 0.843473,
+    "max_temperature_c": 25.45612,
+    "min_temperature_c": 24.85149
+  },
+  "track": {
+    "saved": true,
+    "format": "igc",
+    "path": "tracks/2026-06-26-XLF-000-03.igc"
+  },
+  "device": {
+    "firmware_version": "0.1.7-282d+h3.2.6",
+    "hardware_version": "leaf_3_2_6",
+    "mac_address": "F0:F5:BD:53:60:04"
+  },
+  "pilot": {
+    "name": null
+  },
+  "glider": {
+    "brand": null,
+    "model": null,
+    "size": null
+  },
+  "site": {
+    "launch_name": null,
+    "landing_name": null
+  },
+  "weather": {},
+  "notes": {
+    "pilot_notes": "",
+    "tags": []
+  }
+}

--- a/mock/webapp/logbook json files/2026-06-26_11-55-20_7375661d.json
+++ b/mock/webapp/logbook json files/2026-06-26_11-55-20_7375661d.json
@@ -1,0 +1,79 @@
+{
+  "schema": "leaf.logbook.flight",
+  "schema_version": "v0.1.0",
+  "flight_id": "7375661d",
+  "clock": {
+    "system_time_synced_this_boot": true,
+    "time_source": "gps",
+    "timezone_offset_minutes": -420
+  },
+  "start": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T18:55:20Z",
+    "time_local": "2026-06-26T11:55:20",
+    "temperature_c": 26.33292
+  },
+  "first_fix": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T18:55:21Z",
+    "time_local": "2026-06-26T11:55:21",
+    "location": {
+      "lat_deg": 37.3746,
+      "lon_deg": -121.9945,
+      "altitude_m": 13.27
+    },
+    "temperature_c": 26.33292
+  },
+  "end": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T18:56:01Z",
+    "time_local": "2026-06-26T11:56:01",
+    "location": {
+      "lat_deg": 37.37443,
+      "lon_deg": -121.9945,
+      "altitude_m": -5.14
+    },
+    "temperature_c": 26.51736
+  },
+  "metrics": {
+    "duration_seconds": 40,
+    "max_altitude_m": 0,
+    "min_altitude_m": -7.86,
+    "max_altitude_above_launch_m": 0,
+    "max_climb_rate_mps": 0.11,
+    "max_sink_rate_mps": -0.11,
+    "max_ground_speed_mps": 2.196678,
+    "average_ground_speed_mps": 0.135299,
+    "straight_line_distance_m": 19.10516,
+    "path_distance_m": 5.411955,
+    "max_accel_g": 1.007131,
+    "min_accel_g": 0.988159,
+    "max_temperature_c": 26.71287,
+    "min_temperature_c": 26.33292
+  },
+  "track": {
+    "saved": false
+  },
+  "device": {
+    "firmware_version": "0.1.7-553d+h3.2.6",
+    "hardware_version": "leaf_3_2_6",
+    "mac_address": "F0:F5:BD:53:60:04"
+  },
+  "pilot": {
+    "name": null
+  },
+  "glider": {
+    "brand": null,
+    "model": null,
+    "size": null
+  },
+  "site": {
+    "launch_name": null,
+    "landing_name": null
+  },
+  "weather": {},
+  "notes": {
+    "pilot_notes": "",
+    "tags": []
+  }
+}

--- a/mock/webapp/logbook json files/2026-06-26_12-13-02_37243116.json
+++ b/mock/webapp/logbook json files/2026-06-26_12-13-02_37243116.json
@@ -1,0 +1,79 @@
+{
+  "schema": "leaf.logbook.flight",
+  "schema_version": "v0.1.0",
+  "flight_id": "37243116",
+  "clock": {
+    "system_time_synced_this_boot": true,
+    "time_source": "gps",
+    "timezone_offset_minutes": -420
+  },
+  "start": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T19:13:02Z",
+    "time_local": "2026-06-26T12:13:02",
+    "temperature_c": 26.92477
+  },
+  "first_fix": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T19:14:18Z",
+    "time_local": "2026-06-26T12:14:18",
+    "location": {
+      "lat_deg": 37.37479,
+      "lon_deg": -121.9942,
+      "altitude_m": 21.4
+    },
+    "temperature_c": 23.48849
+  },
+  "end": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T19:14:25Z",
+    "time_local": "2026-06-26T12:14:25",
+    "location": {
+      "lat_deg": 37.37477,
+      "lon_deg": -121.9941,
+      "altitude_m": 24.6
+    },
+    "temperature_c": 23.49097
+  },
+  "metrics": {
+    "duration_seconds": 82,
+    "max_altitude_m": 24.17,
+    "min_altitude_m": 20.27,
+    "max_altitude_above_launch_m": 2.77,
+    "max_climb_rate_mps": 0.25,
+    "max_sink_rate_mps": -0.13,
+    "max_ground_speed_mps": 0.159478,
+    "average_ground_speed_mps": 0.006776,
+    "straight_line_distance_m": 8.268356,
+    "path_distance_m": 0.5556,
+    "max_accel_g": 1.113732,
+    "min_accel_g": 0.678076,
+    "max_temperature_c": 26.92477,
+    "min_temperature_c": 23.22299
+  },
+  "track": {
+    "saved": false
+  },
+  "device": {
+    "firmware_version": "0.1.7-553d+h3.2.6",
+    "hardware_version": "leaf_3_2_6",
+    "mac_address": "F0:F5:BD:53:60:04"
+  },
+  "pilot": {
+    "name": null
+  },
+  "glider": {
+    "brand": null,
+    "model": null,
+    "size": null
+  },
+  "site": {
+    "launch_name": null,
+    "landing_name": null
+  },
+  "weather": {},
+  "notes": {
+    "pilot_notes": "",
+    "tags": []
+  }
+}

--- a/mock/webapp/logbook json files/2026-06-26_13-59-18_b7d7f6e8.json
+++ b/mock/webapp/logbook json files/2026-06-26_13-59-18_b7d7f6e8.json
@@ -1,0 +1,83 @@
+{
+  "schema": "leaf.logbook.flight",
+  "schema_version": "v0.1.0",
+  "flight_id": "b7d7f6e8",
+  "clock": {
+    "system_time_synced_this_boot": true,
+    "time_source": "gps",
+    "timezone_offset_minutes": -420
+  },
+  "start": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T20:59:18Z",
+    "time_local": "2026-06-26T13:59:18",
+    "temperature_c": 27.1466
+  },
+  "first_fix": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:01:31Z",
+    "time_local": "2026-06-26T14:01:31",
+    "location": {
+      "lat_deg": 37.37487,
+      "lon_deg": -121.9942,
+      "altitude_m": 44.35
+    },
+    "temperature_c": 24.40517
+  },
+  "end": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:02:04Z",
+    "time_local": "2026-06-26T14:02:04",
+    "location": {
+      "lat_deg": 37.3748,
+      "lon_deg": -121.9942,
+      "altitude_m": 28.61
+    },
+    "temperature_c": 23.97048
+  },
+  "metrics": {
+    "duration_seconds": 165,
+    "max_altitude_m": 44.35,
+    "min_altitude_m": 29.19,
+    "max_altitude_above_launch_m": 0,
+    "max_climb_rate_mps": 1.49,
+    "max_sink_rate_mps": -0.88,
+    "max_ground_speed_mps": 1.0649,
+    "max_wind": {
+      "speed_mps": 0.360555,
+      "direction_from_deg": 236.3099
+    },
+    "average_ground_speed_mps": 0.111245,
+    "straight_line_distance_m": 7.755476,
+    "path_distance_m": 18.35538,
+    "max_accel_g": 1.303267,
+    "min_accel_g": 0.777696,
+    "max_temperature_c": 27.1466,
+    "min_temperature_c": 23.51596
+  },
+  "track": {
+    "saved": false
+  },
+  "device": {
+    "firmware_version": "0.1.7-06fd+h3.2.6",
+    "hardware_version": "leaf_3_2_6",
+    "mac_address": "F0:F5:BD:53:60:04"
+  },
+  "pilot": {
+    "name": null
+  },
+  "glider": {
+    "brand": null,
+    "model": null,
+    "size": null
+  },
+  "site": {
+    "launch_name": null,
+    "landing_name": null
+  },
+  "weather": {},
+  "notes": {
+    "pilot_notes": "",
+    "tags": []
+  }
+}

--- a/mock/webapp/logbook json files/2026-06-26_14-53-13_68278e6a.json
+++ b/mock/webapp/logbook json files/2026-06-26_14-53-13_68278e6a.json
@@ -1,0 +1,84 @@
+{
+  "schema": "leaf.logbook.flight",
+  "schema_version": "v0.1.0",
+  "flight_id": "68278e6a",
+  "clock": {
+    "system_time_synced_this_boot": true,
+    "time_source": "gps",
+    "timezone_offset_minutes": -420
+  },
+  "start": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:53:13Z",
+    "time_local": "2026-06-26T14:53:13",
+    "temperature_c": 25.64895
+  },
+  "first_fix": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:53:13Z",
+    "time_local": "2026-06-26T14:53:13",
+    "location": {
+      "lat_deg": 37.37478,
+      "lon_deg": -121.9942,
+      "altitude_m": 24.81
+    },
+    "temperature_c": 25.64895
+  },
+  "end": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:53:24Z",
+    "time_local": "2026-06-26T14:53:24",
+    "location": {
+      "lat_deg": 37.37474,
+      "lon_deg": -121.9942,
+      "altitude_m": 24.32
+    },
+    "temperature_c": 25.64494
+  },
+  "metrics": {
+    "duration_seconds": 10,
+    "max_altitude_m": 24.81,
+    "min_altitude_m": 24.32,
+    "max_altitude_above_launch_m": 0,
+    "max_climb_rate_mps": 1.01,
+    "max_sink_rate_mps": -0.65,
+    "max_ground_speed_mps": 0.6945,
+    "average_ground_speed_mps": 0.466601,
+    "straight_line_distance_m": 4.296201,
+    "path_distance_m": 4.666012,
+    "max_accel_g": 1.065156,
+    "min_accel_g": 0.706098,
+    "max_temperature_c": 25.67603,
+    "min_temperature_c": 25.56541
+  },
+  "track": {
+    "saved": true,
+    "format": "igc",
+    "path": "tracks/2026-06-26-XLF-000-04.igc"
+  },
+  "device": {
+    "firmware_version": "0.1.7-978d+h3.2.6",
+    "hardware_version": "leaf_3_2_6",
+    "mac_address": "F0:F5:BD:53:60:04"
+  },
+  "pilot": {
+    "id": "a1b2c3",
+    "name": "Test Pilot"
+  },
+  "glider": {
+    "id": "d4e5f6",
+    "brand": "Ozone",
+    "model": "Swift",
+    "size": "MS",
+    "display_name": "Swift MS"
+  },
+  "site": {
+    "launch_name": null,
+    "landing_name": null
+  },
+  "weather": {},
+  "notes": {
+    "pilot_notes": "",
+    "tags": []
+  }
+}

--- a/mock/webapp/logbook json files/2026-06-26_14-53-49_013725e8.json
+++ b/mock/webapp/logbook json files/2026-06-26_14-53-49_013725e8.json
@@ -1,0 +1,84 @@
+{
+  "schema": "leaf.logbook.flight",
+  "schema_version": "v0.1.0",
+  "flight_id": "013725e8",
+  "clock": {
+    "system_time_synced_this_boot": true,
+    "time_source": "gps",
+    "timezone_offset_minutes": -420
+  },
+  "start": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:53:49Z",
+    "time_local": "2026-06-26T14:53:49",
+    "temperature_c": 25.45058
+  },
+  "first_fix": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:53:50Z",
+    "time_local": "2026-06-26T14:53:50",
+    "location": {
+      "lat_deg": 37.37474,
+      "lon_deg": -121.9942,
+      "altitude_m": 24.29
+    },
+    "temperature_c": 25.45058
+  },
+  "end": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:53:56Z",
+    "time_local": "2026-06-26T14:53:56",
+    "location": {
+      "lat_deg": 37.37474,
+      "lon_deg": -121.9942,
+      "altitude_m": 24.28
+    },
+    "temperature_c": 25.22723
+  },
+  "metrics": {
+    "duration_seconds": 6,
+    "max_altitude_m": 24.29,
+    "min_altitude_m": 24.28,
+    "max_altitude_above_launch_m": 0,
+    "max_climb_rate_mps": 0.68,
+    "max_sink_rate_mps": -0.62,
+    "max_ground_speed_mps": 0.920856,
+    "average_ground_speed_mps": 0.596756,
+    "straight_line_distance_m": 0.674359,
+    "path_distance_m": 3.580533,
+    "max_accel_g": 1.294264,
+    "min_accel_g": 0.994915,
+    "max_temperature_c": 25.40004,
+    "min_temperature_c": 25.22723
+  },
+  "track": {
+    "saved": true,
+    "format": "igc",
+    "path": "tracks/2026-06-26-XLF-000-05.igc"
+  },
+  "device": {
+    "firmware_version": "0.1.7-978d+h3.2.6",
+    "hardware_version": "leaf_3_2_6",
+    "mac_address": "F0:F5:BD:53:60:04"
+  },
+  "pilot": {
+    "id": null,
+    "name": null
+  },
+  "glider": {
+    "id": null,
+    "brand": null,
+    "model": null,
+    "size": null,
+    "display_name": null
+  },
+  "site": {
+    "launch_name": null,
+    "landing_name": null
+  },
+  "weather": {},
+  "notes": {
+    "pilot_notes": "",
+    "tags": []
+  }
+}

--- a/mock/webapp/logbook json files/2026-06-26_14-55-34_31c02d5d.json
+++ b/mock/webapp/logbook json files/2026-06-26_14-55-34_31c02d5d.json
@@ -1,0 +1,84 @@
+{
+  "schema": "leaf.logbook.flight",
+  "schema_version": "v0.1.0",
+  "flight_id": "31c02d5d",
+  "clock": {
+    "system_time_synced_this_boot": true,
+    "time_source": "gps",
+    "timezone_offset_minutes": -420
+  },
+  "start": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:55:34Z",
+    "time_local": "2026-06-26T14:55:34",
+    "temperature_c": 26.07982
+  },
+  "first_fix": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:55:34Z",
+    "time_local": "2026-06-26T14:55:34",
+    "location": {
+      "lat_deg": 37.37474,
+      "lon_deg": -121.9942,
+      "altitude_m": 24.29
+    },
+    "temperature_c": 26.07982
+  },
+  "end": {
+    "time_valid": true,
+    "time_utc": "2026-06-26T21:55:40Z",
+    "time_local": "2026-06-26T14:55:40",
+    "location": {
+      "lat_deg": 37.37474,
+      "lon_deg": -121.9942,
+      "altitude_m": 0
+    },
+    "temperature_c": 26.11396
+  },
+  "metrics": {
+    "duration_seconds": 6,
+    "max_altitude_m": 24.29,
+    "min_altitude_m": 24.29,
+    "max_altitude_above_launch_m": 0,
+    "max_climb_rate_mps": 0.11,
+    "max_sink_rate_mps": -0.17,
+    "max_ground_speed_mps": 0.010289,
+    "average_ground_speed_mps": 0,
+    "straight_line_distance_m": 0,
+    "path_distance_m": 0,
+    "max_accel_g": 1,
+    "min_accel_g": 0.985889,
+    "max_temperature_c": 26.11396,
+    "min_temperature_c": 26.07982
+  },
+  "track": {
+    "saved": true,
+    "format": "igc",
+    "path": "tracks/2026-06-26-XLF-000-06.igc"
+  },
+  "device": {
+    "firmware_version": "0.1.7-978d+h3.2.6",
+    "hardware_version": "leaf_3_2_6",
+    "mac_address": "F0:F5:BD:53:60:04"
+  },
+  "pilot": {
+    "id": null,
+    "name": null
+  },
+  "glider": {
+    "id": null,
+    "brand": null,
+    "model": null,
+    "size": null,
+    "display_name": null
+  },
+  "site": {
+    "launch_name": null,
+    "landing_name": null
+  },
+  "weather": {},
+  "notes": {
+    "pilot_notes": "",
+    "tags": []
+  }
+}


### PR DESCRIPTION
## Summary

- Add a local mock of the Leaf web app at `mock/webapp/index.html`
- Prototype the branded dashboard layout, profile management flow, status panel, and logbook viewer without requiring Leaf hardware
- Add sample logbook JSON files under `mock/webapp/logbook json files/` for local UI iteration

## Web App Mock

- Uses Leaf brand colors:
  - hero yellow-green title bar
  - graphite page/panel styling
  - Arial `Leaf` wordmark
- Adds a main dashboard with:
  - device/network/firmware status
  - log sync status
  - battery status indicator
  - active pilot/glider selectors
  - compact logbook summary
- Adds subpages for:
  - editing pilot/glider profiles
  - viewing detailed logbook entries

## Profile UI

- Splits active profile selection from profile editing
- Adds disabled/active state handling for save, new, delete, and empty dropdowns
- Adds empty-state guidance when no pilots or gliders exist
- Adds section-specific status messages for selected/saved/deleted profile actions

## Logbook UI

- Adds mock logbook summary on the main page
- Adds dedicated logbook detail view with:
  - previous/next flight navigation
  - date/time and duration
  - graphical altitude summary
  - Vario climb/sink panel
  - detailed flight metrics
  - track filename and flight ID
- Adds protected delete flow with confirm/cancel step for deleting a log and track file

## Notes

- This is a mock/prototype only and does not change firmware webserver behavior yet
- The mock currently loads sample JSON files locally and falls back to embedded sample data if needed
- Future firmware implementation should keep the app shell static and stream/load log data incrementally to avoid heap pressure.