### PR TITLE
Save multiple networks

### DIFF
--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -45,7 +45,9 @@ namespace {
   uint32_t wifi_setup_connect_started_ms = 0;
   uint32_t wifi_setup_connected_ms = 0;
   String wifi_setup_connect_ssid = "";
+  String wifi_setup_connect_password = "";
   String wifi_setup_connect_error = "";
+  bool wifi_setup_connect_saved = false;
   uint32_t user_app_loop_count = 0;
   uint32_t user_app_handle_count = 0;
   uint32_t user_app_route_root_count = 0;
@@ -186,6 +188,21 @@ namespace {
                 static_cast<unsigned long>(ESP.getFreeHeap()),
                 static_cast<unsigned long>(ESP.getMaxAllocHeap()));
     file.close();
+  }
+
+  void rememberSuccessfulWifiSetupNetwork() {
+    if (wifi_setup_connect_saved || wifi_setup_connect_ssid.isEmpty()) return;
+    leaf_wifi::rememberSuccessfulNetwork(wifi_setup_connect_ssid, wifi_setup_connect_password);
+    wifi_setup_connect_saved = true;
+    wifi_setup_connect_password = "";
+  }
+
+  void markWifiSetupConnected(const char* event) {
+    wifi_setup_connecting = false;
+    if (wifi_setup_connected_ms == 0) wifi_setup_connected_ms = millis();
+    wifi_setup_connect_error = "";
+    rememberSuccessfulWifiSetupNetwork();
+    appendWifiSetupDiagnostics(event, true);
   }
 
   void dumpUserAppCounters(const char* event) {
@@ -640,10 +657,12 @@ namespace {
     wifi_setup_connecting = false;
     wifi_setup_connected_ms = 0;
     wifi_setup_connect_error = error;
+    wifi_setup_connect_password = "";
+    wifi_setup_connect_saved = false;
 
-    // A failed WiFi.begin() can leave bad setup credentials saved and the STA
-    // side retrying. Stop that while keeping the Leaf AP available.
-    WiFi.disconnect(false, true);
+    // Stop the RAM-only setup attempt while keeping the previous saved default
+    // and the Leaf AP available.
+    WiFi.disconnect(false, false);
     WiFi.mode(WIFI_AP_STA);
     WiFi.setSleep(false);
     startLeafAp();
@@ -653,17 +672,12 @@ namespace {
     appendWifiSetupDiagnostics("status", true);
     wl_status_t status = WiFi.status();
     if (wifi_setup_connecting && stationConnectionReady()) {
-      wifi_setup_connecting = false;
-      wifi_setup_connected_ms = millis();
-      wifi_setup_connect_error = "";
-      appendWifiSetupDiagnostics("status-connected", true);
+      markWifiSetupConnected("status-connected");
     } else if (wifi_setup_connecting &&
                millis() - wifi_setup_connect_started_ms > WIFI_SETUP_CONNECT_TIMEOUT_MS) {
       const wl_status_t timed_out_status = WiFi.status();
       if (timed_out_status == WL_CONNECTED) {
-        wifi_setup_connecting = false;
-        wifi_setup_connected_ms = millis();
-        wifi_setup_connect_error = "";
+        markWifiSetupConnected("status-connected-after-timeout");
       } else if (timed_out_status == WL_NO_SSID_AVAIL) {
         stopFailedWifiSetupAttempt("network_not_found");
       } else if (timed_out_status == WL_CONNECT_FAILED) {
@@ -1321,9 +1335,16 @@ loadStatus();loadProfiles();loadLogbook();
       return;
     }
 
+    if (wifi_setup_scan_running) {
+      WiFi.scanDelete();
+      wifi_setup_scan_running = false;
+      wifi_setup_networks_json = "{\"scanning\":false,\"networks\":[]}";
+    }
+
     WiFi.mode(WIFI_AP_STA);
     WiFi.setSleep(false);
-    WiFi.persistent(true);
+    WiFi.disconnect(false, false);
+    WiFi.persistent(false);
     WiFi.begin(ssid.c_str(), password.c_str());
     if (user_app_enabled && user_app_using_leaf_wifi) {
       user_app_provisioning = true;
@@ -1332,7 +1353,9 @@ loadStatus();loadProfiles();loadLogbook();
     wifi_setup_connect_started_ms = millis();
     wifi_setup_connected_ms = 0;
     wifi_setup_connect_ssid = ssid;
+    wifi_setup_connect_password = password;
     wifi_setup_connect_error = "";
+    wifi_setup_connect_saved = false;
     Serial.printf("Leaf WiFi setup connecting to SSID: %s\n", ssid.c_str());
     appendWifiSetupDiagnostics("connect-request", true);
     target.send(202, "application/json", "{\"ok\":true}");
@@ -1760,7 +1783,9 @@ void webserver_disable_user_app() {
   wifi_setup_connecting = false;
   wifi_setup_connected_ms = 0;
   wifi_setup_connect_ssid = "";
+  wifi_setup_connect_password = "";
   wifi_setup_connect_error = "";
+  wifi_setup_connect_saved = false;
   if (user_server_started) {
     user_server.stop();
     user_server_started = false;
@@ -1786,10 +1811,9 @@ bool webserver_wifi_setup_ready_for_network_app() {
   if (!stationConnectionReady()) return false;
 
   if (wifi_setup_connecting) {
-    wifi_setup_connecting = false;
-    wifi_setup_connect_error = "";
+    markWifiSetupConnected("transition-connected");
   }
-  if (wifi_setup_connected_ms == 0) wifi_setup_connected_ms = millis();
+  if (wifi_setup_connected_ms == 0) markWifiSetupConnected("transition-ready");
   return millis() - wifi_setup_connected_ms >= WIFI_SETUP_AP_SUCCESS_GRACE_MS;
 }
 

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -72,6 +72,7 @@ namespace {
   static constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
   static constexpr const char* USER_APP_DIAGNOSTICS_FILE = "/diagnostics/webapp_requests.csv";
   static constexpr const char* WIFI_SETUP_DIAGNOSTICS_FILE = "/diagnostics/wifi_setup.csv";
+  static constexpr size_t WIFI_SETUP_NETWORKS_JSON_RESERVE = 896;
 
   SelfTestMode last_self_test_mode = SelfTestMode::None;
   bool interactive_self_test_pending = false;
@@ -653,6 +654,17 @@ namespace {
     target.sendHeader("Expires", "0");
   }
 
+  void setWifiSetupNetworksJson(const char* json) {
+    wifi_setup_networks_json = "";
+    wifi_setup_networks_json.reserve(WIFI_SETUP_NETWORKS_JSON_RESERVE);
+    wifi_setup_networks_json = json;
+  }
+
+  void releaseWifiSetupNetworksJson() {
+    wifi_setup_networks_json = String();
+    wifi_setup_networks_json = "{\"scanning\":false,\"networks\":[]}";
+  }
+
   void stopFailedWifiSetupAttempt(const char* error) {
     wifi_setup_connecting = false;
     wifi_setup_connected_ms = 0;
@@ -957,7 +969,7 @@ loadStatus();loadProfiles();loadLogbook();
     sendNoStoreHeaders(target);
     static constexpr char WIFI_SETUP_PAGE[] =
         R"leafhtml(<!doctype html><html><head><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf WiFi</title><style>:root{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#202423;background:#363636;line-height:1.35;--leaf:#d8ff00;--ink:#202423;--panel:#565656;--sub:#4d4d4d}body{margin:0;background:#363636}header{background:var(--leaf);color:#0b0d0b;padding:11px 20px;text-align:center}main{max-width:640px;margin:auto;padding:18px}h1{font-family:Arial,sans-serif;font-size:38px;font-weight:500;letter-spacing:.12em;line-height:1;margin:0}.subbar{display:flex;align-items:center;justify-content:center;min-height:34px;color:white;margin:0 0 14px}.subbar h2{color:white;background:transparent;margin:0;padding:0;font-size:18px}section{background:var(--panel);border-radius:8px;margin:0 0 14px;padding:16px 14px}label{display:block;font-size:13px;font-weight:700;margin:10px 0 4px;color:white}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:11px;border:1px solid #b9c0b2;border-radius:7px;background:white;color:var(--ink)}input:focus,select:focus,button:focus{outline:2px solid var(--leaf);outline-offset:1px}button{background:var(--ink);color:white;font-weight:750;border-color:var(--ink);box-shadow:inset 0 -2px 0 rgba(0,0,0,.22)}button:disabled{background:#686868;border-color:#686868;color:#8a8a8a;opacity:1;box-shadow:none}.hero:not(:disabled){background:var(--leaf);border-color:var(--leaf);color:#0b0d0b}.status{min-height:20px;margin:0 0 12px;color:#e2e7dc}.network-row,.row{display:flex;gap:8px}.network-row select,.row input{flex:1}.refresh{flex:0 0 44px;width:44px;height:44px;padding:0;font-size:23px;line-height:1}.show{display:flex;align-items:center;gap:6px;width:auto;white-space:nowrap;color:white;font-weight:700}.show input{width:auto;accent-color:var(--leaf)}#n{margin-top:8px}#save{margin-top:16px}</style><script>async function init(){let s=document.getElementById('s'),l=document.getElementById('l'),n=document.getElementById('n'),p=document.getElementById('p'),w=document.getElementById('w'),f=document.getElementById('f'),r=document.getElementById('r'),save=document.getElementById('save');function chosen(){let o=l.options[l.selectedIndex];return o&&o.value&&o.value==n.value.trim()?o:null}function buttons(){let o=chosen(),need=o&&o.dataset.secure=='1';save.disabled=!n.value.trim()||(need&&!p.value)}l.onchange=()=>{if(l.value)n.value=l.value;buttons()};n.oninput=buttons;p.oninput=buttons;w.onchange=()=>p.type=w.checked?'text':'password';r.onclick=()=>nets(true);let params=new URLSearchParams(location.search),autoScan=params.has('scan'),returnToApp=params.get('return')=='app';async function nets(refresh){try{let d=await(await fetch('/api/wifi/networks'+(refresh?'?refresh=1':''))).json();if(d.scanning){s.textContent='Scanning for networks...';setTimeout(nets,1500);return}l.innerHTML='<option value="">Select network...</option>';d.networks.forEach(x=>{let o=document.createElement('option');o.value=x.ssid;o.dataset.secure=x.secure?'1':'0';o.textContent=x.ssid+' ('+x.rssi+' dBm)';l.appendChild(o)});s.textContent=d.networks.length?'Choose a network or type one manually.':'No networks found. Type the network name manually.';buttons()}catch(e){s.textContent='Unable to read network list. Type the network name manually.';buttons()}}async function poll(){try{let d=await(await fetch('/api/wifi/status')).json();if(d.connected){let appUrl=d.app_url||('http://'+d.ip_address+'/app');s.textContent=returnToApp?('Leaf is now on '+d.ssid+'. Connect to that network and open the Leaf app again using the QR code on the Leaf display.'):('Connected to '+d.ssid+'. Open '+appUrl);return}if(d.error){s.textContent='Unable to connect. Check password and try again.';return}s.textContent=d.target_ssid?'Trying to connect to '+d.target_ssid+'...':'Trying to connect...';setTimeout(poll,1500)}catch(e){s.textContent='Trying to connect...';setTimeout(poll,2000)}}f.onsubmit=async e=>{e.preventDefault();let ssid=n.value.trim();if(save.disabled)return;s.textContent='Saving credentials...';try{await fetch('/api/wifi/connect',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid:ssid,password:p.value})});save.disabled=true;poll()}catch(x){s.textContent='Unable to save network details. Try again.';buttons()}};buttons();nets(autoScan)}</script></head><body onload=init()><header><h1>Leaf</h1></header><main><div class=subbar><h2>WiFi Setup</h2></div><section><p class=status id=s>Loading...</p><form id=f><label>Network</label><div class=network-row><select id=l><option value="">Select network...</option></select><button type=button id=r class=refresh title=Refresh aria-label=Refresh>&#x21bb;</button></div><input id=n autocomplete=off placeholder="Type network name"><label>Password</label><div class=row><input id=p type=password autocomplete=current-password><label class=show><input id=w type=checkbox>Show</label></div><button id=save class=hero disabled>Save and Connect</button></form></section></main></body></html>)leafhtml";
-    target.send(200, "text/html", WIFI_SETUP_PAGE);
+    target.send_P(200, "text/html", WIFI_SETUP_PAGE);
   }
 
   void sendUserStatus(WebServer& target) {
@@ -1264,7 +1276,9 @@ loadStatus();loadProfiles();loadLogbook();
       if (top_count < MAX_WIFI_SETUP_NETWORKS) top_count++;
     }
 
-    String json = "{\"scanning\":false,\"networks\":[";
+    String json;
+    json.reserve(WIFI_SETUP_NETWORKS_JSON_RESERVE);
+    json = "{\"scanning\":false,\"networks\":[";
     for (int16_t top_i = 0; top_i < top_count; top_i++) {
       const int16_t i = top_indices[top_i];
       if (top_i > 0) json += ",";
@@ -1305,7 +1319,7 @@ loadStatus();loadProfiles();loadLogbook();
   void startWifiNetworkScan() {
     logWifiSetupTiming("scan-start");
     WiFi.scanDelete();
-    wifi_setup_networks_json = "{\"scanning\":true,\"networks\":[]}";
+    setWifiSetupNetworksJson("{\"scanning\":true,\"networks\":[]}");
     const int16_t result = WiFi.scanNetworks(/*async=*/true, /*hidden=*/false);
     if (result == WIFI_SCAN_RUNNING) {
       wifi_setup_scan_running = true;
@@ -1338,7 +1352,7 @@ loadStatus();loadProfiles();loadLogbook();
     if (wifi_setup_scan_running) {
       WiFi.scanDelete();
       wifi_setup_scan_running = false;
-      wifi_setup_networks_json = "{\"scanning\":false,\"networks\":[]}";
+      setWifiSetupNetworksJson("{\"scanning\":false,\"networks\":[]}");
     }
 
     WiFi.mode(WIFI_AP_STA);
@@ -1779,7 +1793,7 @@ void webserver_disable_user_app() {
   user_app_provisioning = false;
   if (wifi_setup_scan_running) WiFi.scanDelete();
   wifi_setup_scan_running = false;
-  wifi_setup_networks_json = "{\"scanning\":false,\"networks\":[]}";
+  releaseWifiSetupNetworksJson();
   wifi_setup_connecting = false;
   wifi_setup_connected_ms = 0;
   wifi_setup_connect_ssid = "";

--- a/src/vario/comms/wifi_coordinator.cpp
+++ b/src/vario/comms/wifi_coordinator.cpp
@@ -313,6 +313,7 @@ namespace leaf_wifi {
 
   void attemptSavedNetworkConnection() {
     disableDiagnostics();
+    clearSavedNetworkAttempt();
     WiFi.scanDelete();
     WiFi.mode(WIFI_STA);
     WiFi.setSleep(false);

--- a/src/vario/comms/wifi_coordinator.cpp
+++ b/src/vario/comms/wifi_coordinator.cpp
@@ -1,17 +1,39 @@
 #include "comms/wifi_coordinator.h"
 
 #include <Arduino.h>
+#include <Preferences.h>
 #include <WiFi.h>
 #include <esp_wifi.h>
+#include <cstring>
 
 namespace leaf_wifi {
   namespace {
     bool diagnostics_disabled_until_reboot = false;
-    bool saved_network_connecting = false;
+    enum class SavedNetworkConnectStage : uint8_t {
+      IDLE,
+      CONNECTING,
+    };
+
+    struct SavedNetwork {
+      String ssid;
+      String password;
+    };
+
+    struct SavedNetworkList {
+      SavedNetwork items[3];
+      uint8_t count = 0;
+    };
+
+    SavedNetworkConnectStage saved_network_stage = SavedNetworkConnectStage::IDLE;
     uint32_t saved_network_connect_started_ms = 0;
+    uint8_t saved_network_connect_index = 0;
+    String saved_network_fallback_ssid = "";
+    String saved_network_fallback_password = "";
     constexpr uint32_t WIFI_SETTLE_MS = 150;
     constexpr uint32_t WIFI_HARD_RESET_SETTLE_MS = 500;
-    constexpr uint32_t SAVED_NETWORK_CONNECT_DISPLAY_MS = 6500;
+    constexpr uint32_t SAVED_NETWORK_CONNECT_MS = 4000;
+    constexpr uint8_t SAVED_NETWORK_SCHEMA_VERSION = 1;
+    constexpr const char* WIFI_CREDENTIALS_NAMESPACE = "leafWifi";
 
     void settleWifi() { delay(WIFI_SETTLE_MS); }
 
@@ -25,22 +47,184 @@ namespace leaf_wifi {
     }
 
     void clearSavedNetworkAttempt() {
-      saved_network_connecting = false;
+      saved_network_stage = SavedNetworkConnectStage::IDLE;
       saved_network_connect_started_ms = 0;
+      saved_network_connect_index = 0;
+      saved_network_fallback_ssid = "";
+      saved_network_fallback_password = "";
     }
 
-    void updateSavedNetworkAttempt() {
-      if (!saved_network_connecting) return;
-      if (WiFi.status() == WL_CONNECTED ||
-          millis() - saved_network_connect_started_ms > SAVED_NETWORK_CONNECT_DISPLAY_MS) {
-        clearSavedNetworkAttempt();
+    String fixedWifiFieldToString(const uint8_t* field, size_t field_size) {
+      char buffer[65] = {};
+      const size_t copy_len = field_size < sizeof(buffer) - 1 ? field_size : sizeof(buffer) - 1;
+      memcpy(buffer, field, copy_len);
+      buffer[copy_len] = '\0';
+      return String(buffer);
+    }
+
+    bool readActiveStationConfig(SavedNetwork& network) {
+      wifi_config_t config = {};
+      if (esp_wifi_get_config(WIFI_IF_STA, &config) != ESP_OK) return false;
+      network.ssid = fixedWifiFieldToString(config.sta.ssid, sizeof(config.sta.ssid));
+      network.password = fixedWifiFieldToString(config.sta.password, sizeof(config.sta.password));
+      return !network.ssid.isEmpty();
+    }
+
+    void storeSavedNetworkList(const SavedNetworkList& networks) {
+      Preferences prefs;
+      if (!prefs.begin(WIFI_CREDENTIALS_NAMESPACE, false)) {
+        Serial.println("WiFi coordinator: failed to open saved network store");
+        return;
       }
+
+      prefs.clear();
+      prefs.putUChar("ver", SAVED_NETWORK_SCHEMA_VERSION);
+      prefs.putUChar("count", networks.count);
+      for (uint8_t i = 0; i < networks.count; i++) {
+        char ssid_key[8];
+        char pass_key[8];
+        snprintf(ssid_key, sizeof(ssid_key), "ssid%u", i);
+        snprintf(pass_key, sizeof(pass_key), "pass%u", i);
+        prefs.putString(ssid_key, networks.items[i].ssid);
+        prefs.putString(pass_key, networks.items[i].password);
+      }
+      prefs.end();
+    }
+
+    SavedNetworkList loadSavedNetworkList(bool migrate_legacy_station = true) {
+      SavedNetworkList networks;
+
+      Preferences prefs;
+      if (prefs.begin(WIFI_CREDENTIALS_NAMESPACE, true)) {
+        const uint8_t version = prefs.getUChar("ver", 0);
+        const uint8_t count = prefs.getUChar("count", 0);
+        if (version == SAVED_NETWORK_SCHEMA_VERSION) {
+          for (uint8_t i = 0; i < count && networks.count < 3; i++) {
+            char ssid_key[8];
+            char pass_key[8];
+            snprintf(ssid_key, sizeof(ssid_key), "ssid%u", i);
+            snprintf(pass_key, sizeof(pass_key), "pass%u", i);
+            SavedNetwork network;
+            network.ssid = prefs.getString(ssid_key, "");
+            network.password = prefs.getString(pass_key, "");
+            if (!network.ssid.isEmpty()) {
+              networks.items[networks.count++] = network;
+            }
+          }
+        }
+        prefs.end();
+      }
+
+      if (networks.count == 0 && migrate_legacy_station) {
+        SavedNetwork legacy_network;
+        if (readActiveStationConfig(legacy_network)) {
+          networks.items[0] = legacy_network;
+          networks.count = 1;
+          storeSavedNetworkList(networks);
+          Serial.printf("WiFi coordinator: migrated saved network '%s'\n",
+                        legacy_network.ssid.c_str());
+        }
+      }
+
+      return networks;
     }
 
     bool hasSavedStationConfig() {
       wifi_config_t config = {};
       if (esp_wifi_get_config(WIFI_IF_STA, &config) != ESP_OK) return false;
       return config.sta.ssid[0] != '\0';
+    }
+
+    bool writeActiveStationConfig(const String& ssid, const String& password) {
+      if (ssid.isEmpty()) return false;
+
+      wifi_config_t config = {};
+      strlcpy(reinterpret_cast<char*>(config.sta.ssid), ssid.c_str(), sizeof(config.sta.ssid));
+      strlcpy(reinterpret_cast<char*>(config.sta.password), password.c_str(),
+              sizeof(config.sta.password));
+
+      WiFi.persistent(true);
+      const esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &config);
+      WiFi.persistent(false);
+      if (err != ESP_OK) {
+        Serial.printf("WiFi coordinator: failed to save active station config: %d\n", err);
+        return false;
+      }
+      return true;
+    }
+
+    void clearActiveStationConfig() {
+      clearSavedNetworkAttempt();
+      WiFi.scanDelete();
+      WiFi.disconnect(/*wifioff=*/false, /*eraseCredentials=*/false);
+      WiFi.mode(WIFI_STA);
+      WiFi.setSleep(false);
+
+      wifi_config_t config = {};
+      WiFi.persistent(true);
+      const esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &config);
+      WiFi.persistent(false);
+      if (err != ESP_OK) {
+        Serial.printf("WiFi coordinator: failed to clear active station config: %d\n", err);
+      }
+    }
+
+    void connectToSavedNetwork(const SavedNetwork& network, uint8_t index) {
+      WiFi.disconnect(/*wifioff=*/false, /*eraseCredentials=*/false);
+      WiFi.mode(WIFI_STA);
+      WiFi.setSleep(false);
+      if (index == 0) {
+        writeActiveStationConfig(network.ssid, network.password);
+        WiFi.begin();
+      } else {
+        WiFi.persistent(false);
+        WiFi.begin(network.ssid.c_str(), network.password.c_str());
+      }
+      saved_network_stage = SavedNetworkConnectStage::CONNECTING;
+      saved_network_connect_started_ms = millis();
+      saved_network_connect_index = index;
+      saved_network_fallback_ssid = network.ssid;
+      saved_network_fallback_password = network.password;
+      Serial.printf("WiFi coordinator: trying saved network %u '%s'\n", index,
+                    network.ssid.c_str());
+    }
+
+    void tryNextSavedNetwork() {
+      const SavedNetworkList networks = loadSavedNetworkList();
+      const uint8_t next_index = saved_network_connect_index + 1;
+      if (next_index >= networks.count) {
+        Serial.println("WiFi coordinator: no more saved networks to try");
+        clearSavedNetworkAttempt();
+        return;
+      }
+
+      connectToSavedNetwork(networks.items[next_index], next_index);
+    }
+
+    void updateSavedNetworkAttempt() {
+      if (saved_network_stage == SavedNetworkConnectStage::IDLE) return;
+
+      if (WiFi.status() == WL_CONNECTED) {
+        if (saved_network_connect_index > 0 && !saved_network_fallback_ssid.isEmpty()) {
+          rememberSuccessfulNetwork(saved_network_fallback_ssid, saved_network_fallback_password);
+        }
+        clearSavedNetworkAttempt();
+        return;
+      }
+
+      const uint32_t elapsed = millis() - saved_network_connect_started_ms;
+      switch (saved_network_stage) {
+        case SavedNetworkConnectStage::CONNECTING:
+          if (elapsed > SAVED_NETWORK_CONNECT_MS) {
+            Serial.printf("WiFi coordinator: saved network '%s' did not connect\n",
+                          saved_network_fallback_ssid.c_str());
+            tryNextSavedNetwork();
+          }
+          break;
+        case SavedNetworkConnectStage::IDLE:
+        default:
+          break;
+      }
     }
 
     void stopScansAndSta(bool eraseCredentials) {
@@ -80,6 +264,7 @@ namespace leaf_wifi {
     disableDiagnostics();
     clearSavedNetworkAttempt();
     WiFi.scanDelete();
+    WiFi.disconnect(/*wifioff=*/false, /*eraseCredentials=*/false);
     WiFi.mode(WIFI_STA);
     WiFi.setSleep(false);
   }
@@ -91,8 +276,39 @@ namespace leaf_wifi {
 
   void resetUserWifiSettings() {
     disableDiagnostics();
-    resetRadioForSetup(/*eraseCredentials=*/true);
+    clearSavedNetworkCredentials();
+    resetRadioForSetup(/*eraseCredentials=*/false);
     Serial.println("WiFi settings reset");
+  }
+
+  void clearSavedNetworkCredentials() {
+    clearSavedNetworkAttempt();
+
+    Preferences prefs;
+    if (prefs.begin(WIFI_CREDENTIALS_NAMESPACE, false)) {
+      prefs.clear();
+      prefs.end();
+    }
+
+    clearActiveStationConfig();
+  }
+
+  void rememberSuccessfulNetwork(const String& ssid, const String& password) {
+    if (ssid.isEmpty()) return;
+
+    const SavedNetworkList existing = loadSavedNetworkList();
+    SavedNetworkList updated;
+    updated.items[updated.count++] = SavedNetwork{ssid, password};
+
+    for (uint8_t i = 0; i < existing.count && updated.count < 3; i++) {
+      if (existing.items[i].ssid == ssid) continue;
+      updated.items[updated.count++] = existing.items[i];
+    }
+
+    storeSavedNetworkList(updated);
+    writeActiveStationConfig(ssid, password);
+    Serial.printf("WiFi coordinator: saved network '%s' as default (%u stored)\n", ssid.c_str(),
+                  updated.count);
   }
 
   void attemptSavedNetworkConnection() {
@@ -100,13 +316,17 @@ namespace leaf_wifi {
     WiFi.scanDelete();
     WiFi.mode(WIFI_STA);
     WiFi.setSleep(false);
-    if (!hasSavedStationConfig()) {
+    const SavedNetworkList networks = loadSavedNetworkList();
+    if (networks.count > 0) {
+      connectToSavedNetwork(networks.items[0], 0);
+    } else if (hasSavedStationConfig()) {
+      WiFi.begin();
+      saved_network_stage = SavedNetworkConnectStage::CONNECTING;
+      saved_network_connect_started_ms = millis();
+    } else {
       clearSavedNetworkAttempt();
       return;
     }
-    WiFi.begin();
-    saved_network_connecting = true;
-    saved_network_connect_started_ms = millis();
   }
 
   void disconnectFromNetwork() {
@@ -118,7 +338,7 @@ namespace leaf_wifi {
 
   bool savedNetworkConnectionInProgress() {
     updateSavedNetworkAttempt();
-    return saved_network_connecting;
+    return saved_network_stage != SavedNetworkConnectStage::IDLE;
   }
 
 }  // namespace leaf_wifi

--- a/src/vario/comms/wifi_coordinator.h
+++ b/src/vario/comms/wifi_coordinator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Arduino.h>
+
 namespace leaf_wifi {
 
   void disableDiagnosticsUntilReboot();
@@ -9,6 +11,8 @@ namespace leaf_wifi {
   void prepareForUserWifiSetupFast();
   void prepareForLeafAccessPoint();
   void resetUserWifiSettings();
+  void clearSavedNetworkCredentials();
+  void rememberSuccessfulNetwork(const String& ssid, const String& password);
   void attemptSavedNetworkConnection();
   void disconnectFromNetwork();
   bool savedNetworkConnectionInProgress();

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -44,15 +44,15 @@ void wifi_menu_ui::attemptSavedNetworkConnection() { leaf_wifi::attemptSavedNetw
 void wifi_menu_ui::disconnectFromNetwork() { leaf_wifi::disconnectFromNetwork(); }
 
 void wifi_menu_ui::drawStatusLine(uint8_t y) {
+  const bool savedNetworkAttemptActive = leaf_wifi::savedNetworkConnectionInProgress();
   const String connectedSsid = WiFi.SSID();
   const bool wifiConnected = WiFi.status() == WL_CONNECTED && !connectedSsid.isEmpty();
   const bool wifiSettling = WiFi.status() == WL_CONNECTED && connectedSsid.isEmpty();
-  const bool wifiSearching = !wifiConnected && leaf_wifi::savedNetworkConnectionInProgress();
 
   String statusText;
   if (wifiConnected) {
     statusText = connectedSsid;
-  } else if (wifiSearching || wifiSettling) {
+  } else if (savedNetworkAttemptActive || wifiSettling) {
     statusText = "Searching..";
   } else {
     statusText = "Not Connected";
@@ -416,7 +416,7 @@ void PageMenuSystemWifiSetup::closed(bool removed_from_Stack) {
 }
 
 void PageMenuSystemWifiSetup::loop() {
-  if (WiFi.status() == WL_CONNECTED) {
+  if (WiFi.status() == WL_CONNECTED && !webserver_user_app_using_leaf_wifi()) {
     pop_page();
     return;
   }

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -6,6 +6,7 @@
 #include <esp_wifi.h>
 #include <nvs_flash.h>
 
+#include "comms/wifi_coordinator.h"
 #include "instruments/baro.h"
 #include "instruments/gps.h"
 #include "ui/audio/sound_effects.h"
@@ -29,13 +30,6 @@ Preferences leafPrefs;
 namespace {
   constexpr auto FACTORY_FLAGS_NAMESPACE = "factoryFlags";
   constexpr auto FORCE_FORMAT_SD_CARD_KEY = "FORCE_FMT_SD";
-
-  void clearSavedWifiCredentials() {
-    esp_err_t err = esp_wifi_restore();
-    if (err != ESP_OK) {
-      Serial.printf("Failed to erase saved WiFi credentials: %d\n", err);
-    }
-  }
 }  // namespace
 
 bool Settings::init() {
@@ -112,7 +106,7 @@ bool Settings::consumeProductionTestForceFormatSdCard() {
 // Reset Leaf user settings and info to defaults
 void Settings::reset() {
   loadDefaults();
-  clearSavedWifiCredentials();
+  leaf_wifi::clearSavedNetworkCredentials();
   save();
 }
 


### PR DESCRIPTION
Committed the latest changes:

`0261693 Harden WiFi setup memory handling`

Working tree is clean, and `leaf_3_2_6_release` built successfully.

**PR Notes**

## Summary
- Adds capped multi-network WiFi support so Leaf can remember up to 3 external networks.
- Promotes the last successfully connected network as the preferred/default network for fast reconnects.
- Falls back through other saved networks when the preferred network is unavailable.
- Keeps the existing captive portal setup flow for adding networks.
- Hardens WiFi setup memory handling by serving the setup page from program memory and reducing scan JSON heap churn.

## Validation
- Built `leaf_3_2_6_release` successfully.
- Hardware-tested reset WiFi, setup home network, setup hotspot, then switching back and forth.
- Confirmed Leaf prefers the last successful network.
- Confirmed Leaf falls back to a secondary saved network when the preferred one is unavailable.
- Confirmed latest test completed repeated captive portal setup cycles without crash or connection failure.

## Follow-Up
- Add saved-network controls to the Leaf web app settings page.
- Consider renaming/reset menu language from “Reset WiFi” to something like “Reset Networks.”
- Consider on-device menu options for forgetting or selecting saved networks.

App-only flash command for COM7:

```powershell
Set-Location C:\Users\oxoth\projects\leaf; & "$env:USERPROFILE\.platformio\penv\Scripts\python.exe" "$env:USERPROFILE\.platformio\packages\tool-esptoolpy\esptool.py" --chip esp32s3 --port COM7 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode qio --flash_freq 80m --flash_size 8MB 0x10000 ".pio\build\leaf_3_2_6_release\firmware.bin"
```

::git-stage{cwd="C:\Users\oxoth\projects\leaf"}

::git-commit{cwd="C:\Users\oxoth\projects\leaf"}