### PR TITLE
Prepare release - menu and diagnostics cleanup

### DIFF
--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -82,7 +82,10 @@ namespace {
   uint32_t wifi_setup_started_ms = 0;
   uint32_t wifi_setup_last_diag_ms = 0;
 
+  bool diagnosticsEnabled() { return settings.dev_mode; }
+
   void logWifiSetupTiming(const char* event) {
+    if (!diagnosticsEnabled()) return;
     Serial.printf("Leaf WiFi setup cycle %lu +%lums: %s heap=%u maxAlloc=%u\n",
                   static_cast<unsigned long>(wifi_setup_cycle),
                   static_cast<unsigned long>(millis() - wifi_setup_started_ms), event,
@@ -90,6 +93,7 @@ namespace {
   }
 
   void resetUserAppCounters() {
+    if (!diagnosticsEnabled()) return;
     user_app_loop_count = 0;
     user_app_handle_count = 0;
     user_app_route_root_count = 0;
@@ -105,6 +109,7 @@ namespace {
   }
 
   void updateUserAppStationPeak() {
+    if (!diagnosticsEnabled()) return;
     const uint8_t station_count = WiFi.softAPgetStationNum();
     if (station_count > user_app_max_ap_stations) user_app_max_ap_stations = station_count;
   }
@@ -133,6 +138,7 @@ namespace {
   }
 
   void appendWifiSetupDiagnostics(const char* event, bool force = false) {
+    if (!diagnosticsEnabled()) return;
     const uint32_t now = millis();
     if (!force && now - wifi_setup_last_diag_ms < 1000) return;
     wifi_setup_last_diag_ms = now;
@@ -207,6 +213,7 @@ namespace {
   }
 
   void dumpUserAppCounters(const char* event) {
+    if (!diagnosticsEnabled()) return;
     if (!SD_MMC.exists(DIAGNOSTICS_DIR)) SD_MMC.mkdir(DIAGNOSTICS_DIR);
 
     const bool existed = SD_MMC.exists(USER_APP_DIAGNOSTICS_FILE);
@@ -918,6 +925,7 @@ namespace {
 
     static constexpr char USER_APP_PAGE[] PROGMEM =
         R"leafapp(<!doctype html><html lang=en><head><meta charset=utf-8><meta name=viewport content="width=device-width,initial-scale=1"><meta http-equiv=Cache-Control content=no-store><title>Leaf</title><style>:root{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#202423;background:#363636;line-height:1.35;--leaf:#d8ff00;--ink:#202423;--panel:#565656;--sub:#4d4d4d;--danger:#7a1d1d}body{margin:0;background:#363636}header{background:var(--leaf);color:#0b0d0b;padding:11px 20px;text-align:center}main{max-width:640px;margin:auto;padding:18px}h1{font-family:Arial,sans-serif;font-size:38px;font-weight:500;letter-spacing:.12em;line-height:1;margin:0}h2{font-size:18px;margin:-16px -14px 14px;padding:10px 12px;color:#0b0d0b;background:var(--leaf);text-align:center;border-radius:5px 5px 0 0}section{background:var(--panel);border-radius:8px;margin:0 0 14px;padding:16px 14px}.status-panel{padding-top:14px}.status-panel h2{background:var(--panel);color:white;border-bottom:1px solid #a9a9a9;margin:-14px -14px 14px}.view{display:none}.view.active{display:block}.subbar{position:relative;display:flex;align-items:center;justify-content:center;min-height:34px;color:white;margin:0 0 14px}.back{position:absolute;left:0;top:-3px;width:44px;height:40px;background:white;color:var(--ink);border-color:white;box-shadow:none;padding:3px 8px;font-size:32px;font-weight:900;line-height:.85}.subbar h2{color:white;background:transparent;margin:0;padding:0;font-size:18px}.row{display:flex;gap:8px}.row>*{flex:1}.row>.small{flex:0 0 94px}.actions{display:flex;align-items:center;gap:10px;margin-top:12px}.actions .msg{flex:1;margin:0}.actions button,.profile-actions button{width:auto;padding:8px 10px;font-size:14px}.profile-actions{margin-top:12px;gap:14px}label{display:block;font-size:13px;font-weight:700;margin:10px 0 4px;color:white}input,select,button{box-sizing:border-box;width:100%;font:inherit;padding:11px;border:1px solid #b9c0b2;border-radius:7px;background:white;color:var(--ink)}input:focus,select:focus,button:focus{outline:2px solid var(--leaf);outline-offset:1px}select:disabled,button:disabled,.secondary:disabled,.danger:disabled{background:#686868;border-color:#686868;color:#8a8a8a;opacity:1;box-shadow:none}button{background:var(--ink);color:white;font-weight:750;border-color:var(--ink);box-shadow:inset 0 -2px 0 rgba(0,0,0,.22)}.secondary{background:white;color:var(--ink);border-color:#89917f;box-shadow:none}.danger{background:var(--danger);border-color:var(--danger);color:white}.hero{background:var(--leaf);border-color:var(--leaf);color:#0b0d0b}.profile-actions button:first-child:not(:disabled){background:var(--leaf);border-color:var(--leaf);color:#0b0d0b}.muted{color:#e2e7dc}.msg{min-height:20px;margin-top:10px}#profilesView section{padding-bottom:4px}#profilesView .msg{min-height:0;margin:6px 0 0;line-height:1.2}.leaf-log-panel{display:none;margin-top:10px;background:rgba(0,0,0,.16);border-radius:7px;padding:10px}.leaf-log-panel.active{display:block}.leaf-log-step{display:grid;grid-template-columns:1fr auto;gap:8px;align-items:center;color:white;font-weight:700}.leaf-log-step button,#leafLogWifi{width:auto}.status{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;font-size:13px;white-space:pre-wrap;color:white;min-width:0}.status-body{display:grid;grid-template-columns:minmax(0,1fr) max-content;align-items:start;justify-content:space-between;column-gap:14px}.status-side{display:grid;gap:8px;justify-items:end}.battery-status{color:white;text-align:right;font-size:13px;font-weight:700}.battery-line{display:flex;align-items:center;justify-content:flex-end;gap:7px;margin-bottom:4px}.battery{position:relative;width:44px;height:20px;border:2px solid white;border-radius:4px;box-sizing:border-box}.battery:after{content:"";position:absolute;right:-6px;top:4px;width:4px;height:8px;background:white;border-radius:0 2px 2px 0}.battery-fill{display:block;height:100%;background:var(--leaf);border-radius:2px}.battery-meta{font-size:12px;font-weight:650;color:#e2e7dc}.metrics{display:grid;grid-template-columns:1fr 1fr;gap:9px}.metric{background:var(--sub);border-radius:7px;padding:8px 10px;color:white}.metric span{display:block;color:#dfe5d9;font-size:12px;font-weight:650;margin-bottom:2px}.metric strong{display:block;font-size:16px}#logCount{font-size:34px;line-height:1}.pager{display:grid;grid-template-columns:44px 1fr 44px;align-items:center;gap:8px;margin-bottom:12px}.pager button{height:38px;padding:0;background:var(--leaf);border-color:var(--leaf);color:#0b0d0b}.pager button:disabled{background:#686868;border-color:#686868;color:#8a8a8a;box-shadow:none}.page-title{text-align:center;color:white;font-weight:800}.flight-head{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px;color:white;margin-bottom:8px}.flight-head div:nth-child(2){text-align:center}.flight-head div:nth-child(3){text-align:right}.flight-head span{display:block;color:#dfe5d9;font-size:12px;font-weight:650}.flight-head strong{display:block;color:white;font-size:14px;font-weight:800;white-space:nowrap}.flight-profiles{display:flex;justify-content:space-between;gap:10px;color:var(--leaf);font-weight:800;margin:0 0 10px}.flight-profiles div{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.flight-profiles div:last-child{text-align:right}.flight-card{color:white}.alt-box,.vario-box{background:var(--sub);border-radius:7px;padding:12px;margin:10px 0}.alt-box{position:relative;padding:8px 10px 28px}.alt-title{position:absolute;left:0;right:0;bottom:6px;text-align:center}.alt-title,.vario-title{font-size:18px;font-weight:800}.vario-title{text-align:center}.alt-row{position:relative;height:100px;margin-top:0}.alt-row .pill{position:absolute;min-width:74px;background:#111;color:white}.alt-row .pill.high{background:var(--leaf);color:#0b0d0b}.pill{background:var(--leaf);color:#0b0d0b;border-radius:6px;padding:5px 8px;font-weight:800;text-align:center}.pill span{display:block;font-size:11px}.detail-grid{display:grid;grid-template-columns:1fr 1.45fr;gap:10px}.vario-box{display:flex;flex-direction:column;justify-content:center;gap:9px}.vario-title{order:2}.vario-values{display:contents}#climbMax{order:1}#sinkMax{order:3}.sink{background:#111;color:white}.mini-metrics{background:var(--sub);border-radius:7px;padding:8px 10px}.mini-row{display:flex;justify-content:space-between;gap:8px;border-bottom:1px solid #777;padding:5px 0}.mini-row:last-child{border-bottom:0}.track{overflow-wrap:anywhere;color:#e2e7dc;margin-top:12px;font-size:13px;display:flex;justify-content:space-between;gap:12px;align-items:baseline}.track-file-name{color:var(--leaf);font-weight:800}.flight-id{font-size:12px;text-align:right;white-space:nowrap}.delete-area{margin-top:10px;display:flex;justify-content:flex-end}.delete-area>button{width:auto;padding:8px 10px;font-size:14px}.delete-confirm{display:none;width:100%;text-align:left;background:rgba(0,0,0,.18);border-radius:7px;padding:7px 8px}.delete-confirm button{width:100%;font-size:15px;padding:8px 9px}.delete-warning{font-weight:500;margin:0 0 7px;color:white}#logDetailMsg{min-height:0;margin:6px 0 0}#logDetailMsg:empty{display:none}@media(max-width:520px){.detail-grid{grid-template-columns:1fr 1.45fr}.status-body{grid-template-columns:minmax(0,1fr) max-content}.status-side{justify-items:end}.battery-status{text-align:right}.battery-line{justify-content:flex-end}}</style></head><body><header><h1>Leaf</h1></header><main><div id=mainView class="view active"><section class=status-panel><h2>Status</h2><div class=status-body><div class=status id=status>Loading...</div><div class=status-side><div class=battery-status id=batteryBox><div class=battery-line><span id=batteryText>--%</span><div class=battery><span class=battery-fill id=batteryFill></span></div></div><div class=battery-meta id=batteryCharge>Unknown</div></div></div></div></section><section><h2>Profiles</h2><label>Active pilot</label><select id=activePilotList></select><label>Active glider</label><select id=activeGliderList></select><div class=actions><p class="muted msg" id=mainProfileMsg></p><button class=secondary id=editProfiles>Edit Profiles</button></div></section><section><h2>Logbook</h2><div class=metrics><div class=metric><span>Total Flights</span><strong id=logCount>--</strong></div><div class=metric><span>Last Flight</span><strong id=logLatest>Loading...</strong></div></div><div class=actions><p class="muted msg" id=logMsg></p><button class=secondary id=openLogbook disabled>Open Logbook</button></div></section></div><div id=profilesView class=view><div class=subbar><button class=back id=backMain aria-label=Back>&#x276e;</button><h2>Edit Profiles</h2></div><section><h2>Pilots</h2><label>Active pilot</label><select id=pilotList></select><label>Name</label><input id=pilotName maxlength=48 autocomplete=name><label>Email</label><input id=pilotEmail maxlength=80 type=email autocomplete=email><div class=actions><button class=secondary id=leafLogLink disabled>Link Leaf Log</button><button class=secondary id=leafLogWifi>WiFi Setup</button><p class="muted msg" id=leafLogStatus></p></div><div class=leaf-log-panel id=leafLogPanel><div class=leaf-log-step><span>Open Leaf Log and sign in to get a Link Code</span><button class=hero id=leafLogOpen>Open Leaf Log</button></div><label>Leaf Log Link Code</label><input id=leafLogCode maxlength=160 autocomplete=off><div class=actions><p class="muted msg" id=leafLogMsg></p><button class=secondary id=leafLogSave>Save Link</button></div></div><div class="row profile-actions"><button id=pilotSave disabled>Save Profile</button><button class=secondary id=pilotNew>New</button><button class="small danger" id=pilotDelete>Delete</button></div><p class="muted msg" id=pilotMsg></p></section><section><h2>Gliders</h2><label>Active glider</label><select id=gliderList></select><div class=row><div><label>Brand</label><input id=gliderBrand maxlength=32></div><div><label>Model</label><input id=gliderModel maxlength=48></div></div><div class=row><div><label>Size</label><input id=gliderSize maxlength=16></div><div><label>Display name</label><input id=gliderDisplay maxlength=64></div></div><div class="row profile-actions"><button id=gliderSave disabled>Save Profile</button><button class=secondary id=gliderNew>New</button><button class="small danger" id=gliderDelete>Delete</button></div><p class="muted msg" id=gliderMsg></p></section></div><div id=logbookView class=view><div class=subbar><button class=back id=backLogMain aria-label=Back>&#x276e;</button><h2>Logbook</h2></div><section class=flight-card><div class=pager><button id=logPrev>&#x276e;</button><div class=page-title id=logPage>--</div><button id=logNext>&#x276f;</button></div><div class=flight-head><div><span id=flightDay>--</span><strong id=flightDate>Loading...</strong></div><div><span>Start:</span><strong id=flightTime>--</strong></div><div><span>Duration:</span><strong id=flightDuration>--</strong></div></div><div class=flight-profiles><div id=flightPilot></div><div id=flightGlider></div></div><div class=alt-box><div class=alt-title>Altitude</div><div class=alt-row><div class=pill id=altStart><span>Start</span>--</div><div class=pill id=altMax><span>Max</span>--</div><div class=pill id=altEnd><span>End</span>--</div></div></div><div class=detail-grid><div class=vario-box><div class=vario-title>Vario</div><div class=vario-values><div class=pill id=climbMax>--</div><div class="pill sink" id=sinkMax>--</div></div></div><div class=mini-metrics id=flightMetrics></div></div><div class=track id=trackInfo></div><div class=delete-area><button class=danger id=deleteLog>Delete Log</button><div class=delete-confirm id=deleteConfirm><p class=delete-warning>Delete log and track file?</p><div class=row><button class=danger id=confirmDelete>Confirm Delete</button><button class=hero id=cancelDelete>Cancel</button></div></div></div><p class="muted msg" id=logDetailMsg></p></section></div></main><script>
+const LEAF_LOG_ENABLED=false;
 let profiles={schema:'leaf.profiles',schema_version:'v0.1.0',active_pilot_id:null,active_glider_id:null,pilots:[],gliders:[]},pilotSnap={},gliderSnap={},logState={prev:'',next:'',path:''},unitPrefs={alt_feet:false,climb_fpm:false,speed_mph:false,distance_miles:false,heading_cardinal:false,temp_f:false,time_12h:false},userStatus={mode:'',mac_address:''};
 const $=id=>document.getElementById(id),clean=v=>{v=(v||'').trim();return v?v:null},newId=()=>Math.floor(Math.random()*0xffffffff).toString(16).padStart(8,'0');
 function pilotLabel(p){return p.name||'Unnamed pilot'}function gliderLabel(g){return g.display_name||[g.brand,g.model,g.size].filter(Boolean).join(' ')||'Unnamed glider'}
@@ -930,7 +938,7 @@ function buttons(){let p=pilotEditor(),g=gliderEditor();$('pilotSave').disabled=
 function render(){fillSelect($('pilotList'),profiles.pilots,pilotLabel);fillSelect($('activePilotList'),profiles.pilots,pilotLabel);if(profiles.active_pilot_id){$('pilotList').value=profiles.active_pilot_id;$('activePilotList').value=profiles.active_pilot_id}let p=selectedPilot();$('pilotName').value=p?p.name||'':'';$('pilotEmail').value=p?p.email||'':'';$('leafLogCode').value=p?p.leaf_log_api_key||'':'';$('leafLogPanel').classList.remove('active');msg('leafLogMsg','');if(!profiles.pilots.length)msg('pilotMsg','Enter pilot name, then Save Profile.');fillSelect($('gliderList'),profiles.gliders,gliderLabel);fillSelect($('activeGliderList'),profiles.gliders,gliderLabel);if(profiles.active_glider_id){$('gliderList').value=profiles.active_glider_id;$('activeGliderList').value=profiles.active_glider_id}let g=selectedGlider();$('gliderBrand').value=g?g.brand||'':'';$('gliderModel').value=g?g.model||'':'';$('gliderSize').value=g?g.size||'':'';$('gliderDisplay').value=g?g.display_name||'':'';if(!profiles.gliders.length)msg('gliderMsg','Enter glider details, then Save Profile.');setSnaps()}
 function normalize(){profiles.schema='leaf.profiles';profiles.schema_version='v0.1.0';profiles.pilots=(profiles.pilots||[]).filter(p=>p&&p.id&&p.name);profiles.gliders=(profiles.gliders||[]).filter(g=>g&&g.id&&g.model);if(!profiles.pilots.find(p=>p.id==profiles.active_pilot_id))profiles.active_pilot_id=profiles.pilots.length==1?profiles.pilots[0].id:null;if(!profiles.gliders.find(g=>g.id==profiles.active_glider_id))profiles.active_glider_id=profiles.gliders.length==1?profiles.gliders[0].id:null}
 async function save(){normalize();let r=await fetch('/api/profiles',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify(profiles)});if(!r.ok)throw new Error();render()}
-function leafLogLinked(){return !!clean($('leafLogCode').value)}function leafLogButtons(){let p=pilotEditor(),saved=!!selectedPilot(),email=validEmail(p.email),network=userStatus.mode=='network',linked=leafLogLinked();$('leafLogWifi').style.display=network?'none':'block';$('leafLogLink').disabled=!saved||!email||!network;if(!saved)msg('leafLogStatus','Save this pilot profile before linking Leaf Log.');else if(!email)msg('leafLogStatus','Add the email you use for Leaf Log.');else if(!network)msg('leafLogStatus','Join a Wifi network to link');else msg('leafLogStatus',linked?'Linked':'Not linked')}function leafLogUrl(){let q=new URLSearchParams({email:clean($('pilotEmail').value)||'',mac:userStatus.mac_address||'',profile:profiles.active_pilot_id||''});return 'https://leaflogonline.com/link?'+q.toString()}function versionText(s){let fw=s.firmware_display_version||'',hw=s.hardware_display_version||'';if(!fw){let a=(s.firmware_version||'').split('+');fw=a[0]||'unknown';hw=a[1]||hw||'';if(fw[0]!='v')fw='v'+fw;if(hw&&hw[0]=='h')hw=hw.slice(1);if(hw&&hw[0]!='v')hw='v'+hw}return `firmware: ${fw}`+(hw?`\nhardware: ${hw}`:'')}
+function leafLogLinked(){return !!clean($('leafLogCode').value)}function leafLogButtons(){let row=$('leafLogLink').parentElement;if(!LEAF_LOG_ENABLED){row.style.display='none';$('leafLogPanel').classList.remove('active');msg('leafLogStatus','');msg('leafLogMsg','');return}row.style.display='flex';let p=pilotEditor(),saved=!!selectedPilot(),email=validEmail(p.email),network=userStatus.mode=='network',linked=leafLogLinked();$('leafLogWifi').style.display=network?'none':'block';$('leafLogLink').disabled=!saved||!email||!network;if(!saved)msg('leafLogStatus','Save this pilot profile before linking Leaf Log.');else if(!email)msg('leafLogStatus','Add the email you use for Leaf Log.');else if(!network)msg('leafLogStatus','Join a Wifi network to link');else msg('leafLogStatus',linked?'Linked':'Not linked')}function leafLogUrl(){let q=new URLSearchParams({email:clean($('pilotEmail').value)||'',mac:userStatus.mac_address||'',profile:profiles.active_pilot_id||''});return 'https://leaflogonline.com/link?'+q.toString()}function versionText(s){let fw=s.firmware_display_version||'',hw=s.hardware_display_version||'';if(!fw){let a=(s.firmware_version||'').split('+');fw=a[0]||'unknown';hw=a[1]||hw||'';if(fw[0]!='v')fw='v'+fw;if(hw&&hw[0]=='h')hw=hw.slice(1);if(hw&&hw[0]!='v')hw='v'+hw}return `firmware: ${fw}`+(hw?`\nhardware: ${hw}`:'')}
 function useUnits(u){if(u)unitPrefs=u}function logParts(t,h12){if(!t)return{day:'--',date:'--',time:'--'};let a=t.split('T'),d=a[0]||'--',hm=(a[1]||'').slice(0,5)||'--',dt=new Date(t),day=isNaN(dt)?'--':dt.toLocaleDateString('en-US',{weekday:'long'}),date=isNaN(dt)?d:dt.toLocaleDateString('en-GB',{day:'numeric',month:'short',year:'numeric'}),h=Number(hm.slice(0,2)),m=hm.slice(3,5);if(h12&&Number.isFinite(h)){let ap=h>=12?'PM':'AM';h=h%12||12;hm=h+':'+m+'\u00a0'+ap}return{day:day,date:date,time:hm}}function logDateTime(t,h12){let p=logParts(t,h12);return p.date?(p.date+'  '+p.time):''}
 function dur(s){s=Number(s)||0;let h=Math.floor(s/3600),m=Math.floor((s%3600)/60);return h?h+'h '+m+'m':m+'m'}
 function good(v){return v!==null&&v!==undefined&&v!==""&&Number.isFinite(Number(v))}function m(v){if(!good(v))return'--';v=Number(v);return unitPrefs.alt_feet?Math.round(v*3.28084)+' ft':Math.round(v)+' m'}function ms(v){if(!good(v))return'--';v=Number(v);return unitPrefs.climb_fpm?Math.round(v*196.85)+' fpm':v.toFixed(1)+' m/s'}function spd(v){if(!good(v))return'--';v=Number(v);return unitPrefs.speed_mph?(v*2.23694).toFixed(1)+' mph':(v*3.6).toFixed(1)+' kph'}function windSpd(v){if(!good(v))return'--';v=Number(v);return unitPrefs.speed_mph?Math.round(v*2.23694)+' mph':Math.round(v*3.6)+' kph'}function dist(v){if(!good(v))return'--';v=Number(v);if(unitPrefs.distance_miles)return v>805?(v*0.000621371).toFixed(2)+' mi':Math.round(v*3.28084)+' ft';return v>=1000?(v/1000).toFixed(2)+' km':Math.round(v)+' m'}function tempVal(c){if(!good(c))return'--';c=Number(c);return unitPrefs.temp_f?Math.round(c*9/5+32):Math.round(c)}function tempRange(a,b){return good(a)&&good(b)?tempVal(a)+'\u00b0 / '+tempVal(b)+'\u00b0'+(unitPrefs.temp_f?'F':'C'):'--'}function hdg(d){if(!good(d))return'--';d=(Math.round(Number(d))%360+360)%360;if(!unitPrefs.heading_cardinal)return d+' deg';let a=['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW'];return a[Math.round(d/22.5)%16]}function wind(v,d){return windSpd(v)+' '+hdg(d)}
@@ -953,7 +961,7 @@ $('pilotSave').onclick=()=>{let name=clean($('pilotName').value);if(!name){msg('
 $('gliderSave').onclick=()=>{let model=clean($('gliderModel').value);if(!model){msg('gliderMsg','Glider model is required.');return}let g=selectedGlider();if(!g){g={id:newId(),model:''};profiles.gliders.push(g);profiles.active_glider_id=g.id}g.brand=clean($('gliderBrand').value);g.model=model;g.size=clean($('gliderSize').value);g.display_name=clean($('gliderDisplay').value);save().then(()=>msg('gliderMsg','Glider profile saved.')).catch(()=>msg('gliderMsg','Unable to save glider.'))};
 $('pilotDelete').onclick=()=>{let p=selectedPilot();if(!p)return;profiles.pilots=profiles.pilots.filter(x=>x.id!=p.id);profiles.active_pilot_id=null;save().then(()=>msg('pilotMsg','Pilot profile deleted.')).catch(()=>msg('pilotMsg','Unable to delete pilot.'))};
 $('gliderDelete').onclick=()=>{let g=selectedGlider();if(!g)return;profiles.gliders=profiles.gliders.filter(x=>x.id!=g.id);profiles.active_glider_id=null;save().then(()=>msg('gliderMsg','Glider profile deleted.')).catch(()=>msg('gliderMsg','Unable to delete glider.'))};
-loadStatus();loadProfiles();loadLogbook();
+leafLogButtons();loadStatus();loadProfiles();loadLogbook();
 </script></body></html>)leafapp";
     sendNoStoreHeaders(target);
     target.send_P(200, "text/html", USER_APP_PAGE);
@@ -1380,38 +1388,38 @@ loadStatus();loadProfiles();loadLogbook();
 
     if (!user_server_routes_configured) {
       user_server.on("/", HTTP_GET, []() {
-        user_app_route_root_count++;
+        if (diagnosticsEnabled()) user_app_route_root_count++;
         sendRedirect(user_server, user_app_provisioning ? "/wifi" : "/app");
       });
       user_server.on("/app", HTTP_GET, []() {
-        user_app_route_app_count++;
+        if (diagnosticsEnabled()) user_app_route_app_count++;
         sendUserAppShell(user_server);
       });
       user_server.on("/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
       user_server.on("/app/wifi", HTTP_GET, []() { sendWifiSetupPage(user_server); });
       user_server.on("/api/user/status", HTTP_GET, []() {
-        user_app_route_status_count++;
+        if (diagnosticsEnabled()) user_app_route_status_count++;
         sendUserStatus(user_server);
       });
       user_server.on("/api/profiles", HTTP_GET, []() {
-        user_app_route_profiles_get_count++;
+        if (diagnosticsEnabled()) user_app_route_profiles_get_count++;
         sendProfiles(user_server);
       });
       user_server.on("/api/profiles", HTTP_PUT, []() {
-        user_app_route_profiles_put_count++;
+        if (diagnosticsEnabled()) user_app_route_profiles_put_count++;
         saveProfiles(user_server);
       });
       user_server.on("/api/logbook", HTTP_GET, []() {
-        user_app_route_logbook_count++;
+        if (diagnosticsEnabled()) user_app_route_logbook_count++;
         heap_monitor::record("logbook-summary");
         sendLogbookSummary(user_server);
       });
       user_server.on("/api/logbook/entry", HTTP_GET, []() {
-        user_app_route_logbook_entry_count++;
+        if (diagnosticsEnabled()) user_app_route_logbook_entry_count++;
         sendLogbookEntry(user_server);
       });
       user_server.on("/api/logbook/entry", HTTP_DELETE, []() {
-        user_app_route_logbook_delete_count++;
+        if (diagnosticsEnabled()) user_app_route_logbook_delete_count++;
         deleteLogbookEntry(user_server);
       });
       user_server.on("/api/wifi/status", HTTP_GET,
@@ -1428,7 +1436,7 @@ loadStatus();loadProfiles();loadLogbook();
       user_server.on("/ncsi.txt", HTTP_GET,
                      []() { sendNoCaptivePortalResponse(user_server, "Microsoft NCSI"); });
       user_server.onNotFound([]() {
-        user_app_route_not_found_count++;
+        if (diagnosticsEnabled()) user_app_route_not_found_count++;
         if (handleCaptivePortalRequest(user_server)) return;
         user_server.send(404, "text/plain", "Not found");
       });
@@ -1707,11 +1715,11 @@ void webserver_setup() {
 void webserver_loop() {
   if (WiFi.status() == WL_CONNECTED || user_app_enabled) {
     if (user_app_enabled) {
-      user_app_loop_count++;
+      if (diagnosticsEnabled()) user_app_loop_count++;
       updateUserAppStationPeak();
       if (user_app_provisioning) updateWifiNetworkScan();
       if (user_app_dns_started) dns_server.processNextRequest();
-      user_app_handle_count++;
+      if (diagnosticsEnabled()) user_app_handle_count++;
       user_server.handleClient();
       if (user_app_provisioning) appendWifiSetupDiagnostics("loop");
       if (webserver_wifi_setup_ready_for_network_app()) {
@@ -1760,8 +1768,10 @@ void webserver_enable_user_app(bool useLeafWifi) {
 void webserver_enable_wifi_setup() {
   pauseServicesForUserApp();
 
-  wifi_setup_cycle++;
-  wifi_setup_started_ms = millis();
+  if (diagnosticsEnabled()) {
+    wifi_setup_cycle++;
+    wifi_setup_started_ms = millis();
+  }
   logWifiSetupTiming("start");
   leaf_wifi::prepareForUserWifiSetupFast();
   logWifiSetupTiming("after-fast-prepare");

--- a/src/vario/diagnostics/heap_monitor.cpp
+++ b/src/vario/diagnostics/heap_monitor.cpp
@@ -7,6 +7,7 @@
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "ui/settings/settings.h"
 
 namespace heap_monitor {
   namespace {
@@ -52,6 +53,7 @@ namespace heap_monitor {
   }  // namespace
 
   void record(const char* event) {
+    if (!settings.dev_mode) return;
     Sample& sample = samples[nextSample];
     sample.millis = millis();
     copyEvent(sample.event, event);
@@ -66,6 +68,7 @@ namespace heap_monitor {
   }
 
   bool dumpToSd(const char* path) {
+    if (!settings.dev_mode) return false;
     if (!path || path[0] == '\0') return false;
     if (!ensureDiagnosticsDirectory()) return false;
 
@@ -90,6 +93,7 @@ namespace heap_monitor {
   }
 
   void clear() {
+    if (!settings.dev_mode) return;
     nextSample = 0;
     sampleTotal = 0;
   }

--- a/src/vario/ui/display/pages/dialogs/page_list_select.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_list_select.cpp
@@ -1,5 +1,7 @@
 #include "ui/display/pages/dialogs/page_list_select.h"
 
+#include "ui/audio/sound_effects.h"
+#include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 
 void PageListSelect::show(const char* title, const etl::array_view<const char*> entries,
@@ -21,19 +23,15 @@ void PageListSelect::draw_menu_input(int8_t cursor_position) {
 }
 
 void PageListSelect::setting_change(Button dir, ButtonEvent state, uint8_t count) {
-  // Call the parent class to handle the back button
-  SimpleSettingsMenuPage::setting_change(dir, state, count);
-
   if (state != ButtonEvent::CLICKED) return;
 
-  // If 255, it's the back button
-  if (cursor_position != -1) {
-    // Handle the selected item
-    // Perform the callback
-    callback(cursor_position);
+  if (cursor_position == CURSOR_BACK) {
+    speaker.playSound(fx::cancel);
+    pop_page();
+    return;
   }
 
-  // Close the selection page
+  callback(cursor_position);
   pop_page();
 }
 

--- a/src/vario/ui/display/pages/dialogs/page_menu_about.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_menu_about.cpp
@@ -5,8 +5,11 @@
 
 #include "comms/fanet_radio.h"
 #include "system/version_info.h"
+#include "ui/audio/sound_effects.h"
+#include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 #include "ui/display/fonts.h"
+#include "ui/display/pages.h"
 
 void PageMenuAbout::draw_extra() {
   auto y = 22;
@@ -63,3 +66,16 @@ void PageMenuAbout::draw_extra() {
 }
 
 void PageMenuAbout::show() { push_page(this); }
+
+void PageMenuAbout::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (cursor_position == CURSOR_BACK && state == ButtonEvent::CLICKED) {
+    speaker.playSound(fx::cancel);
+    pop_page();
+  }
+}
+
+void PageMenuAbout::closed(bool removed_from_Stack) {
+  if (removed_from_Stack) {
+    systemMenuPage.backToSystemMenu();
+  }
+}

--- a/src/vario/ui/display/pages/dialogs/page_menu_about.h
+++ b/src/vario/ui/display/pages/dialogs/page_menu_about.h
@@ -8,4 +8,8 @@ class PageMenuAbout : public SimpleSettingsMenuPage {
   uint8_t get_title_glyph() const override { return menu_ui::GLYPH_SETTINGS; }
   void draw_extra() override;
   void show();
+  void closed(bool removed_from_Stack) override;
+
+ protected:
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
 };

--- a/src/vario/ui/display/pages/fanet/page_fanet.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet.cpp
@@ -1,5 +1,8 @@
 #include "ui/display/pages/fanet/page_fanet.h"
 
+#include "ui/audio/sound_effects.h"
+#include "ui/audio/speaker.h"
+#include "ui/display/pages.h"
 #include "ui/display/pages/dialogs/page_list_select.h"
 #include "ui/display/pages/fanet/page_fanet_ground_select.h"
 #include "ui/display/pages/fanet/page_fanet_neighbors.h"
@@ -10,6 +13,12 @@
 
 void PageFanet::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   if (state != ButtonEvent::CLICKED) return;
+
+  if (cursor_position == CURSOR_BACK) {
+    speaker.playSound(fx::cancel);
+    pop_page();
+    return;
+  }
 
   // Handle menu item selection
   switch (cursor_position) {
@@ -43,9 +52,14 @@ void PageFanet::setting_change(Button dir, ButtonEvent state, uint8_t count) {
       PageFanetNeighbors::show();
       break;
   }
+}
 
-  // Call parent class to handle back button
-  SimpleSettingsMenuPage::setting_change(dir, state, count);
+void PageFanet::closed(bool removed_from_Stack) {
+  if (removed_from_Stack) {
+    settingsMenuPage.backToSettingsMenu();
+  } else {
+    cursor_position = CURSOR_BACK;
+  }
 }
 
 void PageFanet::draw_menu_input(int8_t row_position) {

--- a/src/vario/ui/display/pages/fanet/page_fanet.h
+++ b/src/vario/ui/display/pages/fanet/page_fanet.h
@@ -16,6 +16,7 @@ class PageFanet : public SimpleSettingsMenuPage {
 
   // Menu item button icons will depend on the current setting
   virtual void draw_menu_input(int8_t cursor_position) override;
+  void closed(bool removed_from_Stack) override;
 
  protected:
   void setting_change(Button dir, ButtonEvent state, uint8_t count) override;

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
@@ -5,6 +5,8 @@
 #include "instruments/baro.h"
 #include "instruments/gps.h"
 #include "logging/log.h"
+#include "ui/audio/sound_effects.h"
+#include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 #include "ui/display/display_fields.h"
 #include "ui/display/fonts.h"
@@ -55,6 +57,13 @@ void PageFanetGround::show(FanetGroundTrackingMode mode) {
 }
 
 const char* PageFanetGround::get_title() const { return "Ground Tracking"; }
+
+void PageFanetGround::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (cursor_position == CURSOR_BACK && state == ButtonEvent::CLICKED) {
+    speaker.playSound(fx::cancel);
+    pop_page();
+  }
+}
 
 void PageFanetGround::closed(bool removed_from_Stack) {
   // Ground tracking should only occur while we're showing this page.

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground.h
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground.h
@@ -12,6 +12,9 @@ class PageFanetGround : public SimpleSettingsMenuPage {
   virtual void closed(bool removed_from_Stack) override;
   void draw_extra() override;
 
+ protected:
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
+
  private:
   PageFanetGround() {}
   FanetGroundTrackingMode mode;

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground_select.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground_select.cpp
@@ -1,21 +1,28 @@
 #include "ui/display/pages/fanet/page_fanet_ground_select.h"
 
+#include "ui/audio/sound_effects.h"
+#include "ui/audio/speaker.h"
 #include "ui/display/pages/fanet/page_fanet_ground.h"
 
 void PageFanetGroundSelect::show() { push_page(&getInstance()); }
 
 void PageFanetGroundSelect::setting_change(Button dir, ButtonEvent state, uint8_t count) {
-  // Call the parent method
-  SimpleSettingsMenuPage::setting_change(dir, state, count);
-  if (cursor_position == CURSOR_BACK) return;
+  if (state != ButtonEvent::CLICKED) return;
 
-  if (state != ButtonEvent::CLICKED) {
+  if (cursor_position == CURSOR_BACK) {
+    speaker.playSound(fx::cancel);
+    pop_page();
     return;
   }
 
-  // Show the tracking page
   FanetGroundTrackingMode mode = (FanetGroundTrackingMode)cursor_position;
   PageFanetGround::show(mode);
+}
+
+void PageFanetGroundSelect::closed(bool removed_from_Stack) {
+  if (!removed_from_Stack) {
+    cursor_position = CURSOR_BACK;
+  }
 }
 
 PageFanetGroundSelect& PageFanetGroundSelect::getInstance() {

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground_select.h
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground_select.h
@@ -20,6 +20,7 @@ class PageFanetGroundSelect : SimpleSettingsMenuPage {
 
  protected:
   void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
+  void closed(bool removed_from_Stack) override;
 
  private:
   PageFanetGroundSelect() {}

--- a/src/vario/ui/display/pages/fanet/page_fanet_neighbors.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_neighbors.cpp
@@ -1,12 +1,21 @@
 #include "ui/display/pages/fanet/page_fanet_neighbors.h"
 
 #include "comms/fanet_radio.h"
+#include "ui/audio/sound_effects.h"
+#include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 #include "ui/display/fonts.h"
 
 void PageFanetNeighbors::show() {
   static PageFanetNeighbors instance;
   push_page(&instance);
+}
+
+void PageFanetNeighbors::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (cursor_position == CURSOR_BACK && state == ButtonEvent::CLICKED) {
+    speaker.playSound(fx::cancel);
+    pop_page();
+  }
 }
 
 void PageFanetNeighbors::draw_extra() {

--- a/src/vario/ui/display/pages/fanet/page_fanet_neighbors.h
+++ b/src/vario/ui/display/pages/fanet/page_fanet_neighbors.h
@@ -9,4 +9,7 @@ class PageFanetNeighbors : public SimpleSettingsMenuPage {
   const char* get_title() const override { return "Fanet Neighbors"; }
   uint8_t get_title_glyph() const override { return menu_ui::GLYPH_FANET; }
   void draw_extra() override;
+
+ protected:
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
 };

--- a/src/vario/ui/display/pages/fanet/page_fanet_stats.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_stats.cpp
@@ -2,10 +2,19 @@
 
 #include <Arduino.h>
 #include "comms/fanet_radio.h"
+#include "ui/audio/sound_effects.h"
+#include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 #include "ui/display/fonts.h"
 
 void PageFanetStats::show() { push_page(&getInstance()); }
+
+void PageFanetStats::setting_change(Button dir, ButtonEvent state, uint8_t count) {
+  if (cursor_position == CURSOR_BACK && state == ButtonEvent::CLICKED) {
+    speaker.playSound(fx::cancel);
+    pop_page();
+  }
+}
 
 void PageFanetStats::draw_extra() {
   auto radioStats = fanetRadio.getStats();

--- a/src/vario/ui/display/pages/fanet/page_fanet_stats.h
+++ b/src/vario/ui/display/pages/fanet/page_fanet_stats.h
@@ -10,6 +10,9 @@ class PageFanetStats : public SimpleSettingsMenuPage {
   uint8_t get_title_glyph() const override { return menu_ui::GLYPH_FANET; }
   void draw_extra() override;
 
+ protected:
+  void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
+
  private:
   static PageFanetStats& getInstance();
 };

--- a/src/vario/ui/display/pages/menu/page_gpx_file_select.cpp
+++ b/src/vario/ui/display/pages/menu/page_gpx_file_select.cpp
@@ -11,6 +11,7 @@
 #include "ui/display/display.h"
 #include "ui/display/display_fields.h"
 #include "ui/display/fonts.h"
+#include "ui/display/pages.h"
 
 namespace {
   constexpr const char* GPX_DIR = "/gpx files";
@@ -267,6 +268,7 @@ void PageGpxFileSelect::ensureCursorVisible() {
 
 void PageGpxFileSelect::close() {
   speaker.playSound(fx::cancel);
+  navDataMenuPage.backToNavDataMenu();
   pop_page();
 }
 
@@ -280,6 +282,7 @@ void PageGpxFileSelect::loadSelectedFile() {
   const bool success = gpx_readFile(SD_MMC, path);
   if (success) {
     speaker.playSound(fx::confirm);
+    navDataMenuPage.backToNavDataMenu();
     pop_page();
   } else {
     speaker.playSound(fx::bad);

--- a/src/vario/ui/display/pages/menu/page_logbook.cpp
+++ b/src/vario/ui/display/pages/menu/page_logbook.cpp
@@ -194,6 +194,7 @@ void PageLogbook::setting_change(Button dir, ButtonEvent state, uint8_t count) {
       speaker.playSound(state == ButtonEvent::HELD ? fx::exit : fx::cancel);
       if (modal) {
         modal = false;
+        mainMenuPage.backToMainMenu();
         pop_page();
       } else {
         logMenuPage.backToLogMenu();

--- a/src/vario/ui/display/pages/menu/page_menu_nav_data.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_nav_data.cpp
@@ -21,12 +21,15 @@ enum nav_data_menu_items {
 };
 
 namespace {
-  constexpr char* labels[5] = {"Back", "Load GPX", "Select Pt.", "Select Rte", "Build Rte"};
+  constexpr char* labels[5] = {"Back", "Load GPX", "Select Pt", "Select Rt", "Build Rt"};
   constexpr uint8_t glyphs[5] = {0, menu_ui::GLYPH_GPX, menu_ui::GLYPH_NAV_POINT_SELECT,
                                  menu_ui::GLYPH_NAV_ROUTE_SELECT, menu_ui::GLYPH_NAV_ROUTE_BUILD};
   constexpr uint8_t MENU_INPUT_X = 76;
   constexpr uint8_t FITTED_TEXT_MAX_WIDTH = 92;
+  constexpr uint8_t STATUS_DIVIDER_Y = 106;
 }  // namespace
+
+void NavDataMenuPage::backToNavDataMenu() { cursor_position = cursor_nav_data_back; }
 
 bool NavDataMenuPage::button_event(Button button, ButtonEvent state, uint8_t count) {
   switch (button) {
@@ -60,7 +63,7 @@ void NavDataMenuPage::draw() {
     menu_ui::drawTitle("Nav Data", menu_ui::GLYPH_NAV_DATA);
 
     uint8_t setting_name_x = 2;
-    uint8_t menu_items_y[] = {190, 35, 135, 150, 165};
+    uint8_t menu_items_y[] = {190, 122, 137, 152, 167};
 
     for (int i = 0; i <= cursor_max; i++) {
       if (row_hidden(i)) continue;
@@ -82,31 +85,33 @@ void NavDataMenuPage::draw() {
       const bool hasActivePoint = !hasActiveRoute && navigator.activeWaypointIndex;
 
       u8g2.setFont(leaf_5x8);
-      u8g2.setCursor(2, 55);
+      u8g2.setCursor(2, 35);
       u8g2.print("Active File:");
 
       u8g2.setFont(leaf_6x12);
-      drawFittedText(2, 68, navigator.loadedGpxFilename(), FITTED_TEXT_MAX_WIDTH);
+      drawFittedText(2, 48, navigator.loadedGpxFilename(), FITTED_TEXT_MAX_WIDTH);
 
       u8g2.setFont(leaf_5x8);
-      u8g2.setCursor(2, 78);
+      u8g2.setCursor(2, 58);
       u8g2.print("Points: ");
       u8g2.print(navigator.totalWaypoints);
-      u8g2.print(" Routes: ");
+
+      u8g2.setCursor(2, 68);
+      u8g2.print("Routes: ");
       u8g2.print(navigator.totalRoutes);
 
       if (hasActiveRoute || hasActivePoint) {
-        u8g2.setCursor(2, 94);
+        u8g2.setCursor(2, 84);
         u8g2.print(hasActiveRoute ? "Active Route:" : "Active Point:");
 
         u8g2.setFont(leaf_6x12);
         const char* activeName = hasActiveRoute ? navigator.routes[navigator.activeRouteIndex].name
                                                 : navigator.activePoint.name;
-        drawFittedText(2, 107, activeName, FITTED_TEXT_MAX_WIDTH);
+        drawFittedText(2, 97, activeName, FITTED_TEXT_MAX_WIDTH);
       }
-
-      u8g2.drawHLine(0, 120, 96);
     }
+
+    u8g2.drawHLine(0, STATUS_DIVIDER_Y, 96);
   } while (u8g2.nextPage());
 }
 

--- a/src/vario/ui/display/pages/menu/page_menu_nav_data.h
+++ b/src/vario/ui/display/pages/menu/page_menu_nav_data.h
@@ -14,6 +14,7 @@ class NavDataMenuPage : public SettingsMenuPage {
     cursor_position = 0;
     cursor_max = 4;
   }
+  void backToNavDataMenu();
   void draw();
   bool button_event(Button button, ButtonEvent state, uint8_t count) override;
 

--- a/src/vario/ui/display/pages/menu/page_menu_settings.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_settings.cpp
@@ -10,6 +10,7 @@
 #include "ui/display/fonts.h"
 #include "ui/display/pages.h"
 #include "ui/display/pages/fanet/page_fanet.h"
+#include "ui/display/pages/menu/page_menu_wifi.h"
 #include "ui/input/buttons.h"
 #include "ui/settings/settings.h"
 
@@ -118,10 +119,11 @@ void SettingsRootMenuPage::drawSettingsMenu() {
   u8g2.firstPage();
   do {
     menu_ui::drawTitle("Settings", menu_ui::GLYPH_SETTINGS);
+    wifi_menu_ui::drawStatusLine(30);
 
     uint8_t setting_name_x = 2;
     uint8_t setting_choice_x = 76;
-    uint8_t menu_items_y[] = {190, 45, 60, 75, 90, 105, 120, 135, 150};
+    uint8_t menu_items_y[] = {190, 60, 75, 90, 105, 120, 135, 150, 165};
 
     for (int i = 0; i <= cursor_max; i++) {
       if (row_hidden(i)) continue;

--- a/src/vario/ui/display/pages/menu/page_menu_system.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_system.cpp
@@ -196,7 +196,6 @@ void SystemMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count
       break;
     case cursor_system_about:
       if (state == ButtonEvent::CLICKED) {
-        speaker.playSound(fx::confirm);
         about_page.show();
       } else if (state == ButtonEvent::INCREMENTED && count == 4) {
         // toggle developer mode

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -21,6 +21,14 @@
 
 namespace {
   constexpr uint8_t RESET_HOLD_COUNT = 5;
+
+  char searchingWifiIcon() {
+    static int wifiIcon = 62;  // empty signal
+    const char icon = static_cast<char>(wifiIcon);
+    wifiIcon++;
+    if (wifiIcon > 65) wifiIcon = 62;  // loop through full signal
+    return icon;
+  }
 }  // namespace
 
 int wifi_menu_ui::iconForCurrentConnection() {
@@ -68,7 +76,8 @@ void wifi_menu_ui::drawStatusLine(uint8_t y) {
   u8g2.print(statusText);
   u8g2.setFont(leaf_icons);
   u8g2.setCursor(85, y + 2);
-  u8g2.print((char)iconForCurrentConnection());
+  u8g2.print(savedNetworkAttemptActive || wifiSettling ? searchingWifiIcon()
+                                                       : (char)iconForCurrentConnection());
   u8g2.setFont(leaf_6x12);
 }
 
@@ -80,11 +89,6 @@ enum wifi_menu_items_connected {
 };
 
 void WifiMenuPage::draw() {
-  if (firstOpened) {
-    firstOpened = false;
-    attemptWifiConnection();
-  }
-
   u8g2.firstPage();
   do {
     // Title
@@ -203,7 +207,6 @@ void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) 
         speaker.playSound(fx::cancel);
         settings.save();
         settingsMenuPage.backToSettingsMenu();
-        firstOpened = true;  // reset for the next time user enters wifi menu
         if (state == ButtonEvent::HELD) {
           speaker.playSound(fx::exit);
           mainMenuPage.quitMenu();
@@ -223,13 +226,6 @@ void WifiMenuPage::showFirmwareUpdate() { push_page(&page_wifi_update); }
 void WifiMenuPage::showWebApp() { push_page(&page_wifi_web_app); }
 
 void PageMenuSystemWifiSetup::beginWifiSetup() { webserver_enable_wifi_setup(); }
-
-void WifiMenuPage::attemptWifiConnection() {
-  wifi_state = WifiState::CONNECTING;
-
-  // This attempts to connect using credentials stored by the ESP WiFi stack.
-  wifi_menu_ui::attemptSavedNetworkConnection();
-}
 
 namespace {
   void drawQrCodeScaled(const char* text, uint8_t xOffset, uint8_t yOffset, uint8_t version,
@@ -278,6 +274,7 @@ void PageMenuSystemWifiWebApp::closed(bool removed_from_Stack) {
     if (reconnectToSavedNetwork) {
       wifi_menu_ui::attemptSavedNetworkConnection();
     }
+    mainMenuPage.backToMainMenu();
   }
 }
 
@@ -334,6 +331,7 @@ void PageMenuSystemWifiWebApp::setting_change(Button dir, ButtonEvent state, uin
   syncWebAppMode();
 
   if (cursor_position == CURSOR_BACK && state == ButtonEvent::CLICKED) {
+    speaker.playSound(fx::cancel);
     pop_page();
     return;
   }
@@ -423,13 +421,6 @@ void PageMenuSystemWifiSetup::loop() {
 }
 
 void PageMenuSystemWifiSetup::draw_extra() {
-  // wifi searching status
-  wifiIcon++;
-  if (wifiIcon > 65) wifiIcon = 62;  // loop back to empty signal icon
-  u8g2.setFont(leaf_icons);
-  u8g2.setCursor(85, 12);
-  u8g2.print((char)wifiIcon);
-
   if (millis() - starting_message_started_ms < STARTING_MESSAGE_MS) {
     u8g2.setFont(leaf_6x12);
     u8g2.setCursor(24, 52);

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.h
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.h
@@ -47,7 +47,6 @@ class PageMenuSystemWifiSetup : public SimpleSettingsMenuPage {
 
  private:
   static constexpr uint32_t STARTING_MESSAGE_MS = 8000;
-  int wifiIcon = 62;  // the "empty signal" icon
   uint32_t starting_message_started_ms = 0;
   void beginWifiSetup(void);
 };
@@ -113,7 +112,6 @@ class WifiMenuPage : public SettingsMenuPage {
   void showSetup();
   void showFirmwareUpdate();
   void showWebApp();
-  bool firstOpened = true;
 
  protected:
   void setting_change(Button dir, ButtonEvent state, uint8_t count);
@@ -125,7 +123,6 @@ class WifiMenuPage : public SettingsMenuPage {
   PageMenuSystemWifiSetup page_wifi_setup;
   PageMenuSystemWifiUpdate page_wifi_update;
   PageMenuSystemWifiWebApp page_wifi_web_app;
-  void attemptWifiConnection(void);
 };
 
 #endif

--- a/src/vario/ui/display/pages/menu/page_nav_data_select.cpp
+++ b/src/vario/ui/display/pages/menu/page_nav_data_select.cpp
@@ -9,6 +9,7 @@
 #include "ui/display/display.h"
 #include "ui/display/display_fields.h"
 #include "ui/display/fonts.h"
+#include "ui/display/pages.h"
 
 namespace {
   constexpr uint8_t ROW_START_Y = 35;
@@ -151,6 +152,7 @@ void PageNavDataSelect::ensureCursorVisible() {
 
 void PageNavDataSelect::close() {
   speaker.playSound(fx::cancel);
+  navDataMenuPage.backToNavDataMenu();
   pop_page();
 }
 
@@ -162,6 +164,7 @@ void PageNavDataSelect::selectCurrent() {
                              ? navigator.activatePoint(WaypointID(cursor_position + 1))
                              : navigator.activateRoute(RouteID(cursor_position + 1));
   if (activated) {
+    navDataMenuPage.backToNavDataMenu();
     pop_page();
   } else {
     speaker.playSound(fx::bad);


### PR DESCRIPTION

## Title

Prepare release menu and diagnostics cleanup

## Summary

- Hide Leaf Log linking UI behind a disabled feature flag while preserving the pilot email field.
- Gate SD diagnostic output behind `dev_mode` so normal users do not create diagnostic folders/files or run diagnostic counters.
- Refine WiFi menu/status behavior:
  - Avoid starting a second saved-network auto-connect attempt from the Connect submenu.
  - Show WiFi status through Main Menu, Settings, and Connect flows.
  - Use the animated WiFi icon only while searching, signal icons when connected, and disconnected icon only when truly not connected.
  - Remove the animated WiFi icon from the WiFi setup instruction pages.
- Normalize menu exit behavior:
  - Return parent menu cursors to `Back` after Logbook, Web App, Fanet, About, Fanet child pages, and Nav Data child pages.
  - Add the expected cancel sound when exiting Fanet/Web App/About/Fanet child pages.
  - Fix the Fanet Region selector double-pop when backing out.
- Rework the Nav Data menu layout:
  - Keep status info in the upper half of the page.
  - Group `Load GPX`, `Select Pt`, `Select Rt`, and `Build Rt` below the divider.
  - Split `Points` and `Routes` onto separate lines to avoid overflow.

## Testing

- Ran Leaf C++ formatter:
  - `powershell.exe -ExecutionPolicy Bypass -File .\src\scripts\format_all_files.ps1`
- Built firmware for available hardware target:
  - `C:\Users\oxoth\.platformio\penv\Scripts\pio.exe run -e leaf_3_2_6_release`
- Verified final release build passed.
- Ran `git diff --check`; no whitespace errors reported, only existing CRLF warnings.
