### PR TITLE
Sanitize enabled/disabled page settings 

### DIFF
--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -83,42 +83,78 @@ void Display::setContrast(uint8_t contrast) {
 #endif
 }
 
+bool Display::isMainPageVisible(MainPage targetPage) const {
+  switch (targetPage) {
+    case MainPage::Debug:
+    case MainPage::Debug2:
+      return settings.dev_mode && settings.disp_showDebugPage;
+    case MainPage::Simple:
+      return settings.disp_showSimplePage;
+    case MainPage::Thermal:
+      return settings.disp_showThmPage;
+    case MainPage::ThermalAdv:
+      return settings.disp_showThmAdvPage;
+    case MainPage::Nav:
+      return settings.disp_showNavPage;
+    case MainPage::Menu:
+    case MainPage::Charging:
+    case MainPage::Blank:
+      return true;
+  }
+  return false;
+}
+
+bool Display::hasEnabledPrimaryPage() const {
+  return settings.disp_showSimplePage || settings.disp_showThmPage ||
+         settings.disp_showThmAdvPage || settings.disp_showNavPage;
+}
+
+void Display::ensurePrimaryPageEnabled() {
+  if (!hasEnabledPrimaryPage()) settings.disp_showThmPage = true;
+}
+
+MainPage Display::firstVisiblePrimaryPage(MainPage preferredPage) const {
+  if (isMainPageVisible(preferredPage) && preferredPage != MainPage::Menu &&
+      preferredPage != MainPage::Charging && preferredPage != MainPage::Blank) {
+    return preferredPage;
+  }
+
+  if (settings.disp_showThmPage) return MainPage::Thermal;
+  if (settings.disp_showSimplePage) return MainPage::Simple;
+  if (settings.disp_showNavPage) return MainPage::Nav;
+  if (settings.disp_showThmAdvPage) return MainPage::ThermalAdv;
+  if (settings.dev_mode && settings.disp_showDebugPage) return MainPage::Debug;
+  return MainPage::Thermal;
+}
+
+MainPage Display::sanitizedMainPage(MainPage targetPage) {
+  ensurePrimaryPageEnabled();
+  if (isMainPageVisible(targetPage)) return targetPage;
+  return firstVisiblePrimaryPage(targetPage);
+}
+
 void Display::turnPage(PageAction action) {
   MainPage tempPage = displayPage_;
 
   switch (action) {
     case PageAction::Home:
-      displayPage_ = MainPage::Thermal;
+      displayPage_ = sanitizedMainPage(MainPage::Thermal);
       break;
 
     case PageAction::Next:
-      displayPage_++;
-
-      // skip past any pages not enabled for display
-      if (displayPage_ == MainPage::Debug2 && !settings.disp_showDebugPage) displayPage_++;
-      if (displayPage_ == MainPage::Simple && !settings.disp_showSimplePage) displayPage_++;
-      if (displayPage_ == MainPage::Thermal && !settings.disp_showThmPage) displayPage_++;
-      if (displayPage_ == MainPage::ThermalAdv && !settings.disp_showThmAdvPage) displayPage_++;
-      if (displayPage_ == MainPage::Nav && !settings.disp_showNavPage) displayPage_++;
-
+      do {
+        displayPage_++;
+      } while (!isMainPageVisible(displayPage_));
       break;
 
     case PageAction::Prev:
-      displayPage_--;
-
-      // skip past any pages not enabled for display
-      if (displayPage_ == MainPage::Nav && !settings.disp_showNavPage) displayPage_--;
-      if (displayPage_ == MainPage::ThermalAdv && !settings.disp_showThmAdvPage) displayPage_--;
-      if (displayPage_ == MainPage::Thermal && !settings.disp_showThmPage) displayPage_--;
-      if (displayPage_ == MainPage::Simple && !settings.disp_showSimplePage) displayPage_--;
-      if (displayPage_ == MainPage::Debug2 && !settings.disp_showDebugPage) displayPage_--;
-      if (displayPage_ == MainPage::Debug && !settings.disp_showDebugPage)
-        displayPage_ = tempPage;  // go back to the page we were on if we can't go further left
-
+      do {
+        displayPage_--;
+      } while (!isMainPageVisible(displayPage_));
       break;
 
     case PageAction::Back:
-      displayPage_ = displayPagePrior_;
+      displayPage_ = sanitizedMainPage(displayPagePrior_);
   }
 
   if (displayPage_ != tempPage) displayPagePrior_ = tempPage;
@@ -126,7 +162,7 @@ void Display::turnPage(PageAction action) {
 
 void Display::setPage(MainPage targetPage) {
   MainPage tempPage = displayPage_;
-  displayPage_ = targetPage;
+  displayPage_ = sanitizedMainPage(targetPage);
 
   if (displayPage_ != tempPage) displayPagePrior_ = tempPage;
 }
@@ -176,6 +212,8 @@ void Display::update() {
     modalPage->draw();
     return;
   }
+
+  if (!isMainPageVisible(displayPage_)) displayPage_ = sanitizedMainPage(displayPage_);
 
   switch (displayPage_) {
     case MainPage::Simple:

--- a/src/vario/ui/display/display.h
+++ b/src/vario/ui/display/display.h
@@ -45,6 +45,9 @@ class Display {
   void turnPage(PageAction action);
   void setPage(MainPage targetPage);
   MainPage getPage() { return displayPage_; }
+  bool isMainPageVisible(MainPage targetPage) const;
+  bool hasEnabledPrimaryPage() const;
+  void ensurePrimaryPageEnabled();
 
   void showOnSplash();
 
@@ -52,6 +55,9 @@ class Display {
   void dismissWarning() { showWarning_ = false; }
 
  private:
+  MainPage sanitizedMainPage(MainPage targetPage);
+  MainPage firstVisiblePrimaryPage(MainPage preferredPage) const;
+
   MainPage displayPage_ = MainPage::Thermal;
 
   // track the page we used to be on, so we can "go back" if needed (like cancelling out of a menu

--- a/src/vario/ui/display/pages/menu/page_menu_display.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_display.cpp
@@ -20,7 +20,28 @@ enum display_menu_items {
   cursor_display_contrast,
 };
 
+namespace {
+  uint8_t enabledPrimaryPageCount() {
+    uint8_t count = 0;
+    if (settings.disp_showSimplePage) count++;
+    if (settings.disp_showThmPage) count++;
+    if (settings.disp_showThmAdvPage) count++;
+    if (settings.disp_showNavPage) count++;
+    return count;
+  }
+
+  void togglePrimaryPageSetting(bool* showPage) {
+    if (*showPage && enabledPrimaryPageCount() <= 1) {
+      speaker.playSound(fx::bad);
+      return;
+    }
+    settings.toggleBoolOnOff(showPage);
+  }
+}  // namespace
+
 void DisplayMenuPage::draw() {
+  display.ensurePrimaryPageEnabled();
+
   u8g2.firstPage();
   do {
     // Title
@@ -84,21 +105,15 @@ void DisplayMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t coun
   switch (cursor_position) {
     case cursor_display_show_simple:
       if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
-        settings.toggleBoolOnOff(&settings.disp_showSimplePage);
+        togglePrimaryPageSetting(&settings.disp_showSimplePage);
       break;
     case cursor_display_show_thrm:
       if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
-        settings.toggleBoolOnOff(&settings.disp_showThmPage);
+        togglePrimaryPageSetting(&settings.disp_showThmPage);
       break;
-      /*
-      case cursor_display_show_thrm_adv:
-        if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
-          settings.toggleBoolOnOff(&settings.disp_showThmAdvPage);
-        break;
-      */
     case cursor_display_show_nav:
       if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
-        settings.toggleBoolOnOff(&settings.disp_showNavPage);
+        togglePrimaryPageSetting(&settings.disp_showNavPage);
       break;
     case cursor_display_contrast:
       if (state == ButtonEvent::CLICKED || state == ButtonEvent::INCREMENTED)


### PR DESCRIPTION
## Summary

- Centralized main-page visibility checks so hidden pages cannot be restored or drawn after firmware/page-order changes.
- Sanitized boot restore, menu exit/back navigation, home navigation, page scrolling, and display updates to fall back to a visible primary page.
- Prevented users from disabling every primary display page in the Display settings menu, with Thermal re-enabled as a recovery default for invalid legacy settings.

## Verification

- Ran formatter: `powershell -ExecutionPolicy Bypass -File src\scripts\format_all_files.ps1`
- Built release firmware: `pio run -e leaf_3_2_6_release`
- Ran whitespace check: `git diff --check`