### PR TITLE
Guard logging and nav against stale GPS fixes

### DIFF
--- a/src/vario/comms/ble.cpp
+++ b/src/vario/comms/ble.cpp
@@ -266,7 +266,7 @@ void BLE::sendFanetUpdate(FanetPacket& msg) {
   {
     // Create a lock, and work out our offsets
     GpsLockGuard gpsMutex;
-    if (!gps.location.isValid()) {
+    if (!gps.hasUsableFix()) {
       return;
     }
     constexpr auto EarthRadius = 6378137;

--- a/src/vario/instruments/gps.cpp
+++ b/src/vario/instruments/gps.cpp
@@ -25,6 +25,8 @@ LeafGPS gps;
 #define DEBUG_GPS 0
 
 namespace {
+  constexpr uint32_t MAX_USABLE_GPS_AGE_MS = 3000;
+
   int64_t daysFromCivil(int year, unsigned month, unsigned day) {
     year -= month <= 2;
     const int era = (year >= 0 ? year : year - 399) / 400;
@@ -178,8 +180,9 @@ void LeafGPS::update() {
   syncSystemClockIfNeeded();
 
   // update sats if we're tracking sat NMEA sentences
-  navigator.update();
   updateFixInfo();
+  updateLastValidFix();
+  navigator.update();
   calculateGlideRatio();
 
   if (LOG::GPS && bus_) {
@@ -286,6 +289,34 @@ void LeafGPS::updateSatList(const NMEAString& nmea) {
     }
     fixInfo.numberOfSats = satelliteCount;  // save counted satellites
   }
+}
+
+bool LeafGPS::hasUsableFix() const {
+  return fixInfo.fix && location.isValid() && altitude.isValid() &&
+         location.age() <= MAX_USABLE_GPS_AGE_MS && altitude.age() <= MAX_USABLE_GPS_AGE_MS;
+}
+
+bool LeafGPS::hasFreshGroundSpeed() const {
+  return hasUsableFix() && speed.isValid() && speed.age() <= MAX_USABLE_GPS_AGE_MS;
+}
+
+bool LeafGPS::lastValidFix(GPSPositionSnapshot& snapshot) const {
+  if (!lastValidFix_.valid) return false;
+  snapshot = lastValidFix_;
+  return true;
+}
+
+void LeafGPS::updateLastValidFix() {
+  if (!hasUsableFix()) return;
+
+  lastValidFix_.valid = true;
+  lastValidFix_.latitude = location.lat();
+  lastValidFix_.longitude = location.lng();
+  lastValidFix_.altitudeM = altitude.meters();
+  lastValidFix_.speedMps = speed.mps();
+  lastValidFix_.courseDeg = course.deg();
+  lastValidFix_.fixError = fixInfo.error;
+  lastValidFix_.capturedAtMs = millis();
 }
 
 void LeafGPS::testSats() {

--- a/src/vario/instruments/gps.h
+++ b/src/vario/instruments/gps.h
@@ -48,6 +48,17 @@ struct NMEASentenceContents {
   bool course;
 };
 
+struct GPSPositionSnapshot {
+  bool valid = false;
+  double latitude = 0;
+  double longitude = 0;
+  float altitudeM = 0;
+  float speedMps = 0;
+  float courseDeg = 0;
+  float fixError = 0;
+  uint32_t capturedAtMs = 0;
+};
+
 // enum time_formats {hhmmss, }
 
 class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, GpsMessage> {
@@ -82,6 +93,10 @@ class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, 
 
   bool systemTimeSyncedThisBoot() const { return systemTimeSyncedThisBoot_; }
 
+  bool hasUsableFix() const;
+  bool hasFreshGroundSpeed() const;
+  bool lastValidFix(GPSPositionSnapshot& snapshot) const;
+
   float getGlideRatio(void) { return glideRatio; }
 
   // Cached version of the sat info for showing on display (this will be re-written each time a
@@ -93,6 +108,7 @@ class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, 
  private:
   void updateFixInfo();
   void updateSatList(const NMEAString& nmea);
+  void updateLastValidFix();
   void syncSystemClockIfNeeded();
 
   void calculateGlideRatio();
@@ -133,6 +149,7 @@ class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, 
   int nmeaBufferIndex = 0;         // index into the buffer currently writing to
   bool gsvSentenceGroupActive = false;
   bool systemTimeSyncedThisBoot_ = false;
+  GPSPositionSnapshot lastValidFix_;
 };
 extern LeafGPS gps;
 

--- a/src/vario/logbook/igc.cpp
+++ b/src/vario/logbook/igc.cpp
@@ -151,6 +151,7 @@ const String Igc::desiredFileName() const {
 void Igc::log(unsigned long durationSec) {
   // Short-circuit if we've not yet started a flight
   if (!started()) return;
+  if (!gps.hasUsableFix()) return;
 
   logger.writeBRecord(utcTimeString(),  // Time in HHMMSS
                       latDegreeToStr(gps.location.lat()), lngDegreeToStr(gps.location.lng()), true,

--- a/src/vario/logbook/kml.cpp
+++ b/src/vario/logbook/kml.cpp
@@ -25,6 +25,8 @@ bool Kml::startFlight() {
 }
 
 void Kml::log(unsigned long durationSec) {
+  if (!gps.hasUsableFix()) return;
+
   // First format and print the GPS coordinate
   char lonStr[20];
   char latStr[20];

--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -45,16 +45,19 @@ PageAlertTimerAutoStop pageAlertTimerAutoStop;
 
 namespace {
   void captureFirstGpsFixForLogbook() {
-    logbook.gpsalt_start = gps.altitude.meters();
+    GPSPositionSnapshot fix;
+    if (!gps.lastValidFix(fix)) return;
+
+    logbook.gpsalt_start = fix.altitudeM;
     logbook.gpsalt = logbook.gpsalt_start;
     logbook.gpsalt_above_launch = 0;
     logbook.gpsalt_max = logbook.gpsalt_start;
     logbook.gpsalt_min = logbook.gpsalt_start;
     logbook.gpsalt_above_launch_max = 0;
-    logbook.speed = gps.speed.mps();
+    logbook.speed = fix.speedMps;
     logbook.speed_max = logbook.speed;
-    logbook.startLocationLat = gps.location.lat();
-    logbook.startLocationLng = gps.location.lng();
+    logbook.startLocationLat = fix.latitude;
+    logbook.startLocationLng = fix.longitude;
     logbookEntry.captureFirstFix(logbook);
   }
 }  // namespace
@@ -92,7 +95,7 @@ void log_update() {
 
     // We wish to save a tracklog, but the tracklog has not yet started.
     if (trackLogEnabledForFlight && !flight->started()) {
-      if (!gps.location.isValid())
+      if (!gps.hasUsableFix())
         // We don't have a valid GPS location yet, try again later
         return;
 
@@ -125,13 +128,13 @@ void log_update() {
       }
     }
 
-    if (!trackLogEnabledForFlight && gps.location.isValid() && logbook.startLocationLat == 0 &&
+    if (!trackLogEnabledForFlight && gps.hasUsableFix() && logbook.startLocationLat == 0 &&
         logbook.startLocationLng == 0) {
       captureFirstGpsFixForLogbook();
     }
 
     // Generate a tracklog record.
-    if (trackLogEnabledForFlight) flight->log(logbook.duration);
+    if (trackLogEnabledForFlight && gps.hasUsableFix()) flight->log(logbook.duration);
     log_captureValues();      // TODO:  Update this to an "Update Flight Stats" or something
     log_checkMinMaxValues();  // TODO:  Probably rename this to be "bound Flight Stats"
   }
@@ -148,6 +151,11 @@ bool flightTimer_autoStart() {
   bool startTheTimer = false;  // default to not auto-start
 
   if (PageFlightSummary::isShowing()) {
+    autoStartCounter = 0;
+    return false;
+  }
+
+  if (!gps.hasFreshGroundSpeed()) {
     autoStartCounter = 0;
     return false;
   }
@@ -199,8 +207,12 @@ bool flightTimer_autoStop() {
 
   int32_t altDifference = abs(baro.alt() - autoStopAltitude);
 
-  if ((altDifference < AUTO_STOP_MAX_ALT) &&      // Check if altitude is stable
-      (gps.speed.mph() < AUTO_STOP_MAX_SPEED) &&  // And GPS speed is slow enough
+  const bool gpsSpeedQuiet =
+      gps.hasUsableFix() ? gps.hasFreshGroundSpeed() && gps.speed.mph() < AUTO_STOP_MAX_SPEED
+                         : true;
+
+  if ((altDifference < AUTO_STOP_MAX_ALT) &&  // Check if altitude is stable
+      gpsSpeedQuiet &&                        // And GPS speed is slow enough, if current
       (imu.accelValid() && abs(imu.getAccel() - 1.0f) < AUTO_STOP_MAX_ACCEL)) {  // and IMU is calm
 
     // if all three conditions are met, increment the counter
@@ -352,14 +364,17 @@ void log_captureValues() {
     if (baro.climbRateFilteredValid()) logbook.climb = baro.climbRateFiltered();
   }
 
-  if (gps.fixInfo.fix) {
-    logbook.speed = gps.speed.mps();
+  if (gps.hasUsableFix()) {
+    GPSPositionSnapshot fix;
+    if (gps.lastValidFix(fix)) {
+      logbook.speed = fix.speedMps;
 
-    logbook.gpsalt = gps.altitude.meters();
-    logbook.gpsalt_above_launch = gps.altitude.meters() - logbook.gpsalt_start;
+      logbook.gpsalt = fix.altitudeM;
+      logbook.gpsalt_above_launch = fix.altitudeM - logbook.gpsalt_start;
 
-    // accumulate distance flown
-    logbook.distanceAlongPath += gps.speed.mps();
+      // accumulate distance flown
+      logbook.distanceAlongPath += fix.speedMps;
+    }
   }
 
   if (ambient.state() == Ambient::State::Ready) {
@@ -376,16 +391,18 @@ void log_captureEndingValues() {
     logbook.alt_end = baro.alt();
   }
 
-  if (gps.fixInfo.fix) {
-    logbook.gpsalt_end = gps.altitude.meters();
+  GPSPositionSnapshot fix;
+  if (gps.lastValidFix(fix)) {
+    logbook.gpsalt_end = fix.altitudeM;
+    logbook.endLocationLat = fix.latitude;
+    logbook.endLocationLng = fix.longitude;
+
+    if (logbook.startLocationLat != 0 || logbook.startLocationLng != 0) {
+      logbook.distanceStraightLine =
+          gps.distanceBetween(logbook.startLocationLat, logbook.startLocationLng,
+                              logbook.endLocationLat, logbook.endLocationLng);
+    }
   }
-
-  logbook.endLocationLat = gps.location.lat();
-  logbook.endLocationLng = gps.location.lng();
-
-  logbook.distanceStraightLine =
-      gps.distanceBetween(logbook.startLocationLat, logbook.startLocationLng,
-                          logbook.endLocationLat, logbook.endLocationLng);
 }
 
 void log_checkMinMaxValues() {
@@ -413,7 +430,7 @@ void log_checkMinMaxValues() {
     }
   }
 
-  if (gps.fixInfo.fix) {
+  if (gps.hasUsableFix()) {
     if (logbook.gpsalt > logbook.gpsalt_max) {
       logbook.gpsalt_max = logbook.gpsalt;
       if (logbook.gpsalt_above_launch > logbook.gpsalt_above_launch_max)

--- a/src/vario/navigation/gpx.cpp
+++ b/src/vario/navigation/gpx.cpp
@@ -14,6 +14,7 @@
 
 #include "instruments/baro.h"
 #include "instruments/gps.h"
+#include "logging/log.h"
 #include "navigation/gpx_parser.h"
 #include "navigation/route_store.h"
 #include "navigation/user_waypoints.h"
@@ -549,11 +550,11 @@ void Navigator::update() {
     if (segmentDistance <= 0) segmentDistance = pointDistanceRemaining;
     const uint16_t activeRadius =
         activeRouteIndex ? activeRoutePoint.radiusM : defaultWaypointRadius;
-    if (pointDistanceRemaining < activeRadius && !reachedGoal_)
+    if (pointDistanceRemaining < activeRadius && !reachedGoal_ && flightTimer_isLogging())
       sequenceWaypoint();  //  (this will also update distance to the new point)
 
     // update time remaining
-    if (gps.speed.mps() < 0.5) {
+    if (!gps.hasFreshGroundSpeed() || gps.speed.mps() < 0.5) {
       pointTimeRemaining = 0;
     } else {
       const double distanceToCylinder =
@@ -600,8 +601,10 @@ void Navigator::update() {
 
   // update additional values that are required regardless of if we're navigating to a point
   // average speed
-  averageSpeed =
-      (averageSpeed * (AVERAGE_SPEED_SAMPLES - 1) + gps.speed.kmph()) / AVERAGE_SPEED_SAMPLES;
+  if (gps.hasFreshGroundSpeed()) {
+    averageSpeed =
+        (averageSpeed * (AVERAGE_SPEED_SAMPLES - 1) + gps.speed.kmph()) / AVERAGE_SPEED_SAMPLES;
+  }
 }
 
 // Start, Sequence, and End Navigation Functions
@@ -794,7 +797,7 @@ void Navigator::cancelNav() {
 
 bool Navigator::hasActivePoint() const { return activeWaypointIndex || activeRoutePointIndex; }
 
-bool Navigator::gpsPositionUsable() const { return gps.fixInfo.fix && gps.location.isValid(); }
+bool Navigator::gpsPositionUsable() const { return gps.hasUsableFix(); }
 
 bool Navigator::hasNavSolution() const { return hasActivePoint() && gpsPositionUsable(); }
 

--- a/src/vario/navigation/user_waypoints.cpp
+++ b/src/vario/navigation/user_waypoints.cpp
@@ -176,7 +176,7 @@ namespace user_waypoints {
       error = "SD card is not mounted.";
       return false;
     }
-    if (!gps.location.isValid() || !gps.fixInfo.fix) {
+    if (!gps.hasUsableFix()) {
       error = "GPS fix is required.";
       return false;
     }

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -195,7 +195,7 @@ void display_distance(uint8_t cursor_x, uint8_t cursor_y, double distance) {
 void display_heading(uint8_t cursor_x, uint8_t cursor_y, bool degSymbol) {
   u8g2.setCursor(cursor_x, cursor_y);
 
-  if (!gps.fixInfo.fix) {  // blank out heading if no gps fix
+  if (!gps.hasUsableFix()) {  // blank out heading if no gps fix
     u8g2.print("---");
   } else if (settings.units_heading) {  // Cardinal heading direction
     const char* displayHeadingCardinal =
@@ -754,7 +754,7 @@ void display_GPS_icon(uint8_t x, uint8_t y) {
   if (settings.gpsMode == 0) {    // GPS Off
     u8g2.print((char)44);         // GPS icon with X through it
   } else if (settings.gpsMode) {  // GPS not-off
-    if (gps.fixInfo.fix) {
+    if (gps.hasUsableFix()) {
       u8g2.print((char)43);  // GPS icon with fix
     } else {
       // blink the icon to convey "searching"
@@ -1034,7 +1034,7 @@ void display_header(bool showTurnArrows) {
   // Speed in upper right corner
   bool speedIsThreeDigits = false;
   // If don't have a fix, show GPS searching icon; otherwise show speed
-  if (!gps.fixInfo.fix) {
+  if (!gps.hasUsableFix()) {
     display_GPS_icon(84, 12);
   } else {
     // Speed in upper right corner

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
@@ -105,7 +105,7 @@ void PageFanetGround::draw_extra() {
   u8g2.println((String) "lng: " + gps.location.lng());
 
   // Update the ground station for our position
-  if (gps.location.isValid()) {
+  if (gps.hasUsableFix()) {
     // Update the FANet radio module of our current location...
     // This really, really shouldn't be done in a Display object
     // but whatever, we'll refactor later.

--- a/src/vario/ui/display/pages/primary/page_simple.cpp
+++ b/src/vario/ui/display/pages/primary/page_simple.cpp
@@ -51,7 +51,7 @@ void simplePage_draw() {
     uint8_t speed_y = 28;
     bool speedIsThreeDigits = false;
     // If don't have a fix, show GPS searching icon; otherwise show speed
-    if (!gps.fixInfo.fix) {
+    if (!gps.hasUsableFix()) {
       display_GPS_icon(84, 12);
     } else {
       u8g2.setFont(leaf_labels);


### PR DESCRIPTION
## Summary
- Add a fresh GPS-fix helper and last-valid-fix snapshot so stale TinyGPSPlus values do not drive live behavior after fix loss.
- Require fresh GPS speed for log auto-start and skip IGC/KML track points while current fix is unavailable.
- Preserve end-of-flight summary/location data by finalizing from the last valid GPS fix when current fix is lost.
- Prevent route waypoint sequencing until the flight timer is actually logging, while still showing active route guidance before launch.

## Verification
- Ran `powershell -ExecutionPolicy Bypass -File src\scripts\format_all_files.ps1`
- Ran `C:\Users\oxoth\.platformio\penv\Scripts\pio.exe run -e leaf_3_2_6_release`
- Ran `git diff --check` before commit; only CRLF warning was reported.