### PR TITLE
Factory interface update

### DIFF
--- a/docs/dev-references/backlog/factory-commissioning-followup.md
+++ b/docs/dev-references/backlog/factory-commissioning-followup.md
@@ -1,0 +1,25 @@
+---
+title: Factory Commissioning Follow-up
+description: Future hardening notes for factory_interface commissioning and flashing behavior.
+---
+
+# Factory Commissioning Follow-up
+
+The factory flash flow currently erases the NVS partition before writing firmware so previously
+commissioned units can be recommissioned. The current Leaf partition table uses the standard Arduino
+ESP32 NVS range:
+
+- Partition: `nvs`
+- Type/subtype: `data`, `nvs`
+- Offset: `0x9000`
+- Size: `0x5000` (`20K`)
+
+This was verified against both the configured `default_8MB.csv` partition table and the generated
+`leaf_3_2_6_release` `partitions.bin` artifact.
+
+Future work:
+
+- Replace the factory_interface hardcoded NVS erase range with partition-table-derived values.
+- Prefer parsing the configured/generated partition table and erasing the partition named `nvs`.
+- Keep the current hardcoded range acceptable while Leaf continues to use the standard
+  `default_8MB.csv` layout.

--- a/factory_interface/src/factory_interface/commissioning_sessions.py
+++ b/factory_interface/src/factory_interface/commissioning_sessions.py
@@ -32,7 +32,6 @@ from factory_interface.network_discovery import (
     discovery_identifier_values,
     normalize_discovery_identifier,
     probe_ip_once,
-    probe_once,
 )
 from factory_interface.settings import (
     FactoryInterfaceSettings,
@@ -45,8 +44,6 @@ from factory_interface.settings import (
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 HTTP_TIMEOUT_SECONDS = DEFAULT_HTTP_TIMEOUT_SECONDS
-RECONNECT_GRACE_SECONDS = 2.0
-RECONNECT_POLL_SECONDS = 1.0
 SELF_TEST_POLL_SECONDS = 1.0
 SELF_TEST_HTTP_TIMEOUT_SECONDS = 20.0
 SELF_TEST_COMMUNICATION_GRACE_SECONDS = 180.0
@@ -84,14 +81,6 @@ class CommissioningSession:
                 "status": "success",
                 "details": f"IP address: {self.device.ip_address}:{self.device.port}",
                 "device": self.device.snapshot(),
-            },
-            "reset_nonvolatile_memory": {
-                "status": "idle",
-                "details": "",
-                "reset_status": "idle",
-                "reset_details": "",
-                "reconnect_status": "idle",
-                "reconnect_details": "",
             },
             "firmware_version": idle_task(),
             "fanet_id": idle_task(),
@@ -204,21 +193,6 @@ def response_matches_session(
     return any(session_key(candidate or "") == expected for candidate in candidates)
 
 
-async def rediscover_session_device(session: CommissioningSession) -> LeafDiscoveryResponse:
-    for response in await probe_once():
-        if response_matches_session(response, session):
-            session.device = response
-            session.tasks["network_discovery"] = {
-                "status": "success",
-                "details": f"IP address: {response.ip_address}:{response.port}",
-                "device": response.snapshot(),
-            }
-            session.touch()
-            return response
-
-    raise RuntimeError("Device was not found on the network.")
-
-
 async def manually_rediscover_session_device(
     session: CommissioningSession,
     ip_address: str,
@@ -239,11 +213,6 @@ async def manually_rediscover_session_device(
         "details": f"IP address: {response.ip_address}:{response.port}",
         "device": response.snapshot(),
     }
-    reset_task = session.tasks.get("reset_nonvolatile_memory", {})
-    if reset_task.get("reconnect_status") == "running":
-        reset_task["reconnect_details"] = (
-            f"Manual IP accepted: {response.ip_address}:{response.port}"
-        )
     session.touch()
     return response
 
@@ -258,24 +227,6 @@ async def read_session_mac_address(session: CommissioningSession) -> str:
             f"Device MAC address changed from {session.mac_address} to {mac_address}."
         )
     return mac_address
-
-
-async def wait_for_session_device(session: CommissioningSession) -> None:
-    while True:
-        try:
-            await read_session_mac_address(session)
-            return
-        except (OSError, URLError, TimeoutError, RuntimeError):
-            pass
-
-        try:
-            await rediscover_session_device(session)
-            await read_session_mac_address(session)
-            return
-        except (OSError, URLError, TimeoutError, RuntimeError):
-            pass
-
-        await asyncio.sleep(RECONNECT_POLL_SECONDS)
 
 
 def active_fanet_ids(except_mac_address: str | None = None) -> set[int]:
@@ -522,51 +473,6 @@ def persist_configuration_event(session: CommissioningSession) -> int:
 
 async def run_commissioning_session(session: CommissioningSession) -> None:
     try:
-        reset_task = session.tasks["reset_nonvolatile_memory"]
-        reset_task.update(
-            {
-                "status": "running",
-                "details": "Resetting nonvolatile memory...",
-                "reset_status": "running",
-                "reset_details": "Resetting nonvolatile memory...",
-                "reconnect_status": "idle",
-                "reconnect_details": "",
-            }
-        )
-        session.touch()
-        payload = await asyncio.to_thread(
-            post_json,
-            f"{device_base_url(session)}/settings/factory-reset",
-            {
-                "force_format_sd_card": session.preflight.get(
-                    "force_format_sd_card", False
-                )
-            },
-        )
-        if not payload.get("reset_requested", False):
-            raise RuntimeError("Device did not acknowledge the reset request.")
-
-        reset_task.update(
-            {
-                "reset_status": "success",
-                "reset_details": "Nonvolatile memory reset command accepted.",
-                "reconnect_status": "running",
-                "reconnect_details": "Waiting for device to reconnect...",
-                "details": "Waiting for device to reboot after settings reset...",
-            }
-        )
-        session.touch()
-        await asyncio.sleep(RECONNECT_GRACE_SECONDS)
-        await wait_for_session_device(session)
-        reset_task.update(
-            {
-                "status": "success",
-                "details": "Nonvolatile memory reset.",
-                "reconnect_status": "success",
-                "reconnect_details": "Device reconnected.",
-            }
-        )
-
         mac_address = await read_session_mac_address(session)
         session.mac_address = mac_address
         session.tasks["network_discovery"]["details"] = (
@@ -785,9 +691,6 @@ def mark_running_task_failed(session: CommissioningSession, details: str) -> Non
         if task.get("reset_status") == "running":
             task["reset_status"] = "failure"
             task["reset_details"] = details
-        if task.get("reconnect_status") == "running":
-            task["reconnect_status"] = "failure"
-            task["reconnect_details"] = details
         return
 
 

--- a/factory_interface/src/factory_interface/commissioning_tasks.py
+++ b/factory_interface/src/factory_interface/commissioning_tasks.py
@@ -19,6 +19,9 @@ from factory_interface.settings import load_settings, resolve_application_firmwa
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
+ERASE_NVS_BEFORE_FLASH = True
+NVS_PARTITION_OFFSET = "0x9000"
+NVS_PARTITION_SIZE = "0x5000"
 
 
 @dataclass
@@ -199,7 +202,7 @@ def find_boot_app0_path(firmware_path: Path) -> Path | None:
     return None
 
 
-def build_flash_firmware_command() -> tuple[list[str], Path]:
+def build_flash_firmware_commands() -> tuple[list[list[str]], Path]:
     settings = load_settings()
     if settings.esptool_path is None:
         raise FlashCommandError("esptool.py path is not configured.")
@@ -269,7 +272,23 @@ def build_flash_firmware_command() -> tuple[list[str], Path]:
     upload_flash_mode = platformio_upload_flash_mode(flash_mode)
     upload_flash_freq = normalize_frequency(flash_freq)
 
-    command = [
+    erase_nvs_command = [
+        sys.executable,
+        str(esptool_path),
+        "--chip",
+        "esp32s3",
+        "--baud",
+        str(upload_speed),
+        "--before",
+        "default_reset",
+        "--after",
+        "no_reset",
+        "erase_region",
+        NVS_PARTITION_OFFSET,
+        NVS_PARTITION_SIZE,
+    ]
+
+    write_flash_command = [
         sys.executable,
         str(esptool_path),
         "--chip",
@@ -296,14 +315,38 @@ def build_flash_firmware_command() -> tuple[list[str], Path]:
 
     boot_app0_path = find_boot_app0_path(non_application_path)
     if boot_app0_path is not None:
-        command.extend(["0xe000", str(boot_app0_path)])
+        write_flash_command.extend(["0xe000", str(boot_app0_path)])
 
-    command.extend([
+    write_flash_command.extend([
         "0x10000",
         str(firmware_file),
     ])
 
-    return command, non_application_path
+    commands = [write_flash_command]
+    if ERASE_NVS_BEFORE_FLASH:
+        commands.insert(0, erase_nvs_command)
+
+    return commands, non_application_path
+
+
+async def run_esptool_command(command: list[str], cwd: Path, task: FlashFirmwareTask) -> int:
+    task.output += f"$ {format_command(command)}\n"
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        cwd=cwd,
+    )
+    task.process = process
+
+    if process.stdout is not None:
+        while True:
+            chunk = await process.stdout.read(1024)
+            if not chunk:
+                break
+            task.output += chunk.decode(errors="replace")
+
+    return await process.wait()
 
 
 async def run_flash_firmware() -> None:
@@ -316,24 +359,13 @@ async def run_flash_firmware() -> None:
 
         try:
             await start_preflash_monitor()
-            command, firmware_path = build_flash_firmware_command()
-            task.output += f"$ {format_command(command)}\n"
-            process = await asyncio.create_subprocess_exec(
-                *command,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.STDOUT,
-                cwd=firmware_path,
-            )
-            task.process = process
+            commands, firmware_path = build_flash_firmware_commands()
+            task.return_code = 0
+            for command in commands:
+                task.return_code = await run_esptool_command(command, firmware_path, task)
+                if task.return_code != 0:
+                    break
 
-            if process.stdout is not None:
-                while True:
-                    chunk = await process.stdout.read(1024)
-                    if not chunk:
-                        break
-                    task.output += chunk.decode(errors="replace")
-
-            task.return_code = await process.wait()
             if task.return_code == 0:
                 task.status = "success"
                 excluded_device_ids = (

--- a/factory_interface/src/factory_interface/static/styles.css
+++ b/factory_interface/src/factory_interface/static/styles.css
@@ -1,14 +1,20 @@
 :root {
   color-scheme: light;
-  font-family: "Segoe UI", Arial, sans-serif;
-  --bg: #f4f7f4;
-  --surface: #ffffff;
-  --ink: #18231f;
-  --muted: #60706a;
-  --line: #d8e1dc;
-  --accent: #176c53;
-  --accent-strong: #10533f;
-  --focus: #d08b2c;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+  --bg: #363636;
+  --surface: #565656;
+  --surface-subtle: #4d4d4d;
+  --field: #ffffff;
+  --ink: #ffffff;
+  --field-ink: #202423;
+  --muted: #e2e7dc;
+  --line: #707070;
+  --accent: #d8ff00;
+  --accent-strong: #c5e900;
+  --button: #202423;
+  --button-strong: #111513;
+  --focus: #d8ff00;
+  --danger: #7a1d1d;
 }
 
 * {
@@ -32,7 +38,8 @@ body {
   height: 56px;
   padding: 0 12px;
   border-bottom: 1px solid var(--line);
-  background: #ffffff;
+  background: var(--accent);
+  color: #0b0d0b;
 }
 
 .topbar-primary-actions {
@@ -58,7 +65,7 @@ body {
 .operator-link {
   max-width: min(34vw, 240px);
   overflow: hidden;
-  color: var(--muted);
+  color: #202423;
   font-size: 0.92rem;
   font-weight: 700;
   text-decoration: none;
@@ -68,7 +75,7 @@ body {
 
 .operator-link:hover,
 .operator-link:focus-visible {
-  color: var(--ink);
+  color: #0b0d0b;
   outline: 2px solid transparent;
   text-decoration: underline;
 }
@@ -80,13 +87,13 @@ body {
   width: 40px;
   height: 40px;
   border-radius: 6px;
-  color: var(--ink);
+  color: #202423;
   text-decoration: none;
 }
 
 .icon-link:hover,
 .icon-link:focus-visible {
-  background: #e9f1ed;
+  background: rgb(0 0 0 / 12%);
   outline: 2px solid transparent;
 }
 
@@ -109,6 +116,10 @@ body {
 .panel {
   display: grid;
   gap: 24px;
+  padding: 16px 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
 }
 
 .panel.narrow {
@@ -140,18 +151,18 @@ h1 {
   padding: 22px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: var(--surface);
+  background: var(--surface-subtle);
   color: var(--ink);
   font-size: 1.35rem;
   font-weight: 700;
   text-decoration: none;
-  box-shadow: 0 1px 2px rgb(24 35 31 / 8%);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 16%);
 }
 
 .task-card:hover,
 .task-card:focus-visible {
   border-color: var(--accent);
-  outline: 3px solid rgb(208 139 44 / 35%);
+  outline: 3px solid rgb(216 255 0 / 35%);
 }
 
 .device-form,
@@ -185,8 +196,8 @@ textarea {
   padding: 10px 12px;
   border: 1px solid #b9c7c1;
   border-radius: 6px;
-  background: #ffffff;
-  color: var(--ink);
+  background: var(--field);
+  color: var(--field-ink);
   font: inherit;
 }
 
@@ -194,7 +205,7 @@ input:focus,
 select:focus,
 textarea:focus {
   border-color: var(--accent);
-  outline: 3px solid rgb(208 139 44 / 35%);
+  outline: 3px solid rgb(216 255 0 / 35%);
 }
 
 select {
@@ -210,10 +221,10 @@ button {
   justify-self: start;
   min-height: 48px;
   padding: 0 18px;
-  border: 0;
+  border: 1px solid var(--accent);
   border-radius: 6px;
   background: var(--accent);
-  color: #ffffff;
+  color: #0b0d0b;
   font: inherit;
   font-weight: 700;
   cursor: pointer;
@@ -222,7 +233,14 @@ button {
 button:hover,
 button:focus-visible {
   background: var(--accent-strong);
-  outline: 3px solid rgb(208 139 44 / 35%);
+  outline: 3px solid rgb(216 255 0 / 35%);
+}
+
+button:disabled {
+  background: #686868;
+  border-color: #686868;
+  color: #8a8a8a;
+  cursor: not-allowed;
 }
 
 .button-link {
@@ -234,7 +252,7 @@ button:focus-visible {
   padding: 0 16px;
   border-radius: 6px;
   background: var(--accent);
-  color: #ffffff;
+  color: #0b0d0b;
   font-weight: 700;
   text-decoration: none;
 }
@@ -242,7 +260,7 @@ button:focus-visible {
 .button-link:hover,
 .button-link:focus-visible {
   background: var(--accent-strong);
-  outline: 3px solid rgb(208 139 44 / 35%);
+  outline: 3px solid rgb(216 255 0 / 35%);
 }
 
 .icon-button {
@@ -267,7 +285,9 @@ button:focus-visible {
 }
 
 .icon-button:disabled {
-  background: #9aaba3;
+  background: #686868;
+  border-color: #686868;
+  color: #8a8a8a;
   cursor: wait;
 }
 
@@ -279,7 +299,7 @@ button:focus-visible {
 
 .error-message {
   margin: 0;
-  color: #b42318;
+  color: #ffb0a8;
   font-weight: 700;
 }
 
@@ -306,16 +326,20 @@ button:focus-visible {
   flex: 0 0 auto;
   min-height: 40px;
   padding: 0 14px;
-  background: #b42318;
+  background: var(--danger);
+  border-color: var(--danger);
+  color: #ffffff;
 }
 
 .cancel-setup-button:hover,
 .cancel-setup-button:focus-visible {
-  background: #8f1c14;
+  background: #5f1515;
 }
 
 .cancel-setup-button:disabled {
-  background: #9aaba3;
+  background: #686868;
+  border-color: #686868;
+  color: #8a8a8a;
   cursor: not-allowed;
 }
 
@@ -323,7 +347,7 @@ button:focus-visible {
   display: grid;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: var(--surface);
+  background: var(--surface-subtle);
   overflow: hidden;
 }
 
@@ -345,8 +369,8 @@ button:focus-visible {
 
 .session-row:hover,
 .session-row:focus-visible {
-  background: #e9f1ed;
-  outline: 3px solid rgb(208 139 44 / 35%);
+  background: var(--surface-subtle);
+  outline: 3px solid rgb(216 255 0 / 35%);
   outline-offset: -3px;
 }
 
@@ -359,7 +383,7 @@ button:focus-visible {
   min-width: 76px;
   padding: 4px 8px;
   border-radius: 999px;
-  background: #e7eeea;
+  background: var(--surface-subtle);
   color: var(--muted);
   font-size: 0.84rem;
   font-weight: 700;
@@ -368,18 +392,18 @@ button:focus-visible {
 }
 
 .session-status-running {
-  background: #dbeafe;
-  color: #1d4ed8;
+  background: #202423;
+  color: var(--accent);
 }
 
 .session-status-success {
-  background: #dcfce7;
-  color: #15803d;
+  background: var(--accent);
+  color: #0b0d0b;
 }
 
 .session-status-failure {
-  background: #fee2e2;
-  color: #b42318;
+  background: var(--danger);
+  color: #ffffff;
 }
 
 .session-details {
@@ -401,7 +425,7 @@ button:focus-visible {
   overflow-x: auto;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: var(--surface);
+  background: var(--surface-subtle);
 }
 
 .discovery-table {
@@ -419,7 +443,7 @@ button:focus-visible {
 }
 
 .discovery-table th {
-  background: #edf3ef;
+  background: var(--surface-subtle);
   color: var(--muted);
   font-size: 0.84rem;
   text-transform: uppercase;
@@ -460,7 +484,7 @@ button:focus-visible {
 .discovery-details-grid div {
   min-width: 0;
   padding: 12px 14px;
-  background: var(--surface);
+  background: var(--surface-subtle);
 }
 
 .discovery-details-grid dt {
@@ -512,14 +536,14 @@ button:focus-visible {
 }
 
 .setup-notes-field textarea:read-only {
-  background: #eef4f1;
+  background: var(--surface-subtle);
   color: var(--muted);
   resize: none;
 }
 
 .setup-notes-error {
   grid-column: 1;
-  color: #b42318;
+  color: #ffb0a8;
   font-weight: 700;
 }
 
@@ -611,7 +635,7 @@ button:focus-visible {
   padding: 4px 9px;
   border: 1px solid var(--line);
   border-radius: 6px;
-  background: #edf3ef;
+  background: var(--surface-subtle);
   color: var(--muted);
   font-size: 0.84rem;
   font-weight: 700;
@@ -621,23 +645,23 @@ button:focus-visible {
 .verification-result-pass,
 .verification-result-success,
 .verification-result-complete {
-  border-color: #bbf7d0;
-  background: #dcfce7;
-  color: #15803d;
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #0b0d0b;
 }
 
 .verification-result-fail,
 .verification-result-failure {
-  border-color: #fecaca;
-  background: #fee2e2;
-  color: #b42318;
+  border-color: var(--danger);
+  background: var(--danger);
+  color: #ffffff;
 }
 
 .verification-result-running,
 .verification-result-pending {
-  border-color: #bfdbfe;
-  background: #dbeafe;
-  color: #1d4ed8;
+  border-color: #202423;
+  background: #202423;
+  color: var(--accent);
 }
 
 .verification-failure-details {
@@ -665,7 +689,7 @@ button:focus-visible {
   min-height: 24px;
   height: 24px;
   margin: 0;
-  accent-color: #15803d;
+  accent-color: var(--accent);
   cursor: pointer;
 }
 
@@ -681,7 +705,7 @@ button:focus-visible {
   height: 24px;
   min-height: 24px;
   padding: 0;
-  border: 2px solid #9aaba3;
+  border: 2px solid #8a8a8a;
   border-radius: 50%;
   background: #ffffff;
   color: #ffffff;
@@ -700,14 +724,14 @@ button:focus-visible {
 }
 
 .task-icon-running {
-  border-color: #2f6f91;
+  border-color: var(--accent);
   border-top-color: transparent;
   animation: spin 0.8s linear infinite;
 }
 
 .task-icon-success {
-  border-color: #15803d;
-  background: #15803d;
+  border-color: var(--accent);
+  background: var(--accent);
 }
 
 .task-icon-success::after {
@@ -716,15 +740,15 @@ button:focus-visible {
   left: 7px;
   width: 6px;
   height: 11px;
-  border: solid #ffffff;
+  border: solid #0b0d0b;
   border-width: 0 2px 2px 0;
   content: "";
   transform: rotate(45deg);
 }
 
 .task-icon-failure {
-  border-color: #b42318;
-  background: #b42318;
+  border-color: var(--danger);
+  background: var(--danger);
 }
 
 .task-icon-failure::before,

--- a/factory_interface/src/factory_interface/templates/setup_checklist.html
+++ b/factory_interface/src/factory_interface/templates/setup_checklist.html
@@ -100,45 +100,6 @@
     <div class="checklist-item checklist-item-with-details">
       <button
         class="task-icon task-icon-empty"
-        id="reset-nonvolatile-task-icon"
-        type="button"
-        aria-label="Toggle nonvolatile memory reset details"
-        disabled
-      ></button>
-      <span>Reset nonvolatile memory</span>
-      <p class="checklist-details" id="reset-nonvolatile-details" hidden></p>
-    </div>
-
-    <div class="checklist-item checklist-item-with-details">
-      <button
-        class="task-icon task-icon-empty"
-        id="reconnect-task-icon"
-        type="button"
-        aria-label="Toggle device reconnect details"
-        disabled
-      ></button>
-      <span>Wait for device to reconnect</span>
-      <div class="checklist-details-group" id="reconnect-details-group" hidden>
-        <p class="checklist-details" id="reconnect-details"></p>
-        <form class="manual-ip-entry" id="reconnect-manual-ip-form" hidden>
-          <label for="reconnect-manual-ip">Device IP</label>
-          <div class="manual-ip-controls">
-            <input
-              id="reconnect-manual-ip"
-              type="text"
-              inputmode="decimal"
-              autocomplete="off"
-              placeholder="192.168.137.21"
-            >
-            <button type="submit">Use IP</button>
-          </div>
-        </form>
-      </div>
-    </div>
-
-    <div class="checklist-item checklist-item-with-details">
-      <button
-        class="task-icon task-icon-empty"
         id="firmware-version-task-icon"
         type="button"
         aria-label="Toggle firmware version details"
@@ -236,13 +197,6 @@
   const discoveryDetails = document.querySelector("#discovery-details");
   const discoveryManualIpForm = document.querySelector("#discovery-manual-ip-form");
   const discoveryManualIp = document.querySelector("#discovery-manual-ip");
-  const resetNonvolatileTaskIcon = document.querySelector("#reset-nonvolatile-task-icon");
-  const resetNonvolatileDetails = document.querySelector("#reset-nonvolatile-details");
-  const reconnectTaskIcon = document.querySelector("#reconnect-task-icon");
-  const reconnectDetailsGroup = document.querySelector("#reconnect-details-group");
-  const reconnectDetails = document.querySelector("#reconnect-details");
-  const reconnectManualIpForm = document.querySelector("#reconnect-manual-ip-form");
-  const reconnectManualIp = document.querySelector("#reconnect-manual-ip");
   const firmwareVersionTaskIcon = document.querySelector("#firmware-version-task-icon");
   const firmwareVersionDetails = document.querySelector("#firmware-version-details");
   const fanetIdTaskIcon = document.querySelector("#fanet-id-task-icon");
@@ -259,7 +213,6 @@
   const notifyCommissioningCompleteDetails = document.querySelector("#notify-commissioning-complete-details");
   let flashPollTimer = null;
   let discoveryPollTimer = null;
-  let resetNonvolatilePollTimer = null;
   let firmwareVersionPollTimer = null;
   let fanetIdPollTimer = null;
   let selfTestPollTimer = null;
@@ -268,14 +221,12 @@
   const taskStatuses = {
     flash: "idle",
     discovery: "idle",
-    resetNonvolatile: "idle",
     firmwareVersion: "idle",
     fanetId: "idle",
     selfTest: "idle",
     retrieveTestDetails: "idle",
   };
   let discoveryStartRequested = false;
-  let resetNonvolatileStartRequested = false;
   let firmwareVersionStartRequested = false;
   let fanetIdStartRequested = false;
   let selfTestStartRequested = false;
@@ -353,14 +304,6 @@
 
   function setNotifyCommissioningCompleteIcon(status) {
     setTaskIcon(notifyCommissioningCompleteTaskIcon, status);
-  }
-
-  function setResetNonvolatileIcon(status) {
-    setTaskIcon(resetNonvolatileTaskIcon, status);
-  }
-
-  function setReconnectIcon(status) {
-    setTaskIcon(reconnectTaskIcon, status);
   }
 
   function setFirmwareVersionIcon(status) {
@@ -482,48 +425,6 @@
       discoveryDetailsGroup.hidden = true;
       clearInterval(discoveryPollTimer);
       discoveryPollTimer = null;
-    }
-  }
-
-  function applyResetNonvolatileTaskState(state) {
-    taskStatuses.resetNonvolatile = state.status;
-    updateCancelSetupTaskButton();
-    const resetStatus = state.reset_status || state.status;
-    const reconnectStatus = state.reconnect_status || "idle";
-    setResetNonvolatileIcon(resetStatus);
-    setReconnectIcon(reconnectStatus);
-
-    if (state.status === "success") {
-      resetNonvolatileDetails.textContent =
-        state.reset_details || "Nonvolatile memory reset command accepted.";
-      reconnectDetails.textContent = state.reconnect_details || "Device reconnected.";
-      reconnectDetailsGroup.hidden = false;
-      clearInterval(resetNonvolatilePollTimer);
-      resetNonvolatilePollTimer = null;
-    } else if (state.status === "running") {
-      resetNonvolatileDetails.textContent =
-        state.reset_details || "Resetting nonvolatile memory...";
-      reconnectDetails.textContent = state.reconnect_details || "Waiting for device to reconnect...";
-      resetNonvolatileDetails.hidden = resetStatus === "idle";
-      reconnectDetailsGroup.hidden = reconnectStatus === "idle";
-      if (!resetNonvolatilePollTimer) {
-        resetNonvolatilePollTimer = setInterval(refreshResetNonvolatileTaskState, 1000);
-      }
-    } else if (state.status === "failure") {
-      resetNonvolatileDetails.textContent =
-        state.reset_details || "Nonvolatile memory reset failed.";
-      reconnectDetails.textContent = state.reconnect_details || "Device did not reconnect.";
-      resetNonvolatileDetails.hidden = resetStatus === "idle";
-      reconnectDetailsGroup.hidden = reconnectStatus === "idle";
-      clearInterval(resetNonvolatilePollTimer);
-      resetNonvolatilePollTimer = null;
-    } else {
-      resetNonvolatileDetails.textContent = "";
-      resetNonvolatileDetails.hidden = true;
-      reconnectDetails.textContent = "";
-      reconnectDetailsGroup.hidden = true;
-      clearInterval(resetNonvolatilePollTimer);
-      resetNonvolatilePollTimer = null;
     }
   }
 
@@ -665,11 +566,6 @@
     applyFanetIdTaskState(await response.json());
   }
 
-  async function refreshResetNonvolatileTaskState() {
-    const response = await fetch("/api/setup/reset-nonvolatile-memory");
-    applyResetNonvolatileTaskState(await response.json());
-  }
-
   async function refreshSelfTestTaskState() {
     const response = await fetch("/api/setup/interactive-self-test");
     applySelfTestTaskState(await response.json());
@@ -713,21 +609,6 @@
 
     const response = await fetch("/api/setup/network-discovery", { method: "POST" });
     applyDiscoveryTaskState(await response.json());
-  }
-
-  async function startResetNonvolatileTask() {
-    if (setupCancellationRequested) return;
-    if (resetNonvolatileStartRequested) return;
-    resetNonvolatileStartRequested = true;
-    const currentResponse = await fetch("/api/setup/reset-nonvolatile-memory");
-    const currentState = await currentResponse.json();
-    if (currentState.status === "running" || currentState.status === "success") {
-      applyResetNonvolatileTaskState(currentState);
-      return;
-    }
-
-    const response = await fetch("/api/setup/reset-nonvolatile-memory", { method: "POST" });
-    applyResetNonvolatileTaskState(await response.json());
   }
 
   async function startFirmwareVersionTask() {
@@ -825,32 +706,6 @@
     }
   });
 
-  reconnectManualIpForm.addEventListener("submit", async (event) => {
-    event.preventDefault();
-    const ipAddress = reconnectManualIp.value.trim();
-    if (!ipAddress) return;
-
-    const submitButton = reconnectManualIpForm.querySelector("button");
-    submitButton.disabled = true;
-    reconnectDetails.textContent = `Checking ${ipAddress}...`;
-    reconnectDetailsGroup.hidden = false;
-    try {
-      const response = await selectManualNetworkDevice(ipAddress);
-      const payload = await response.json();
-      if (!response.ok) {
-        throw new Error(payload.detail || "Manual reconnect failed.");
-      }
-      reconnectDetails.textContent = `Manual IP accepted: ${payload.device.ip_address}:${payload.device.port}`;
-      reconnectDetailsGroup.hidden = false;
-      await refreshResetNonvolatileTaskState();
-    } catch (error) {
-      reconnectDetails.textContent = error.message || "Manual reconnect failed.";
-      reconnectDetailsGroup.hidden = false;
-    } finally {
-      submitButton.disabled = false;
-    }
-  });
-
   setupNotesConfirmed.addEventListener("change", async () => {
     if (!setupNotesConfirmed.checked) return;
 
@@ -894,7 +749,6 @@
     await Promise.all([
       refreshFlashTaskState(),
       refreshDiscoveryTaskState(),
-      refreshResetNonvolatileTaskState(),
       refreshFirmwareVersionTaskState(),
       refreshFanetIdTaskState(),
       refreshSelfTestTaskState(),
@@ -909,15 +763,6 @@
   discoveryTaskIcon.addEventListener("click", () => {
     discoveryDetailsGroup.hidden = false;
     discoveryManualIpForm.hidden = !discoveryManualIpForm.hidden;
-  });
-
-  resetNonvolatileTaskIcon.addEventListener("click", () => {
-    resetNonvolatileDetails.hidden = !resetNonvolatileDetails.hidden;
-  });
-
-  reconnectTaskIcon.addEventListener("click", () => {
-    reconnectDetailsGroup.hidden = false;
-    reconnectManualIpForm.hidden = !reconnectManualIpForm.hidden;
   });
 
   firmwareVersionTaskIcon.addEventListener("click", () => {
@@ -950,7 +795,6 @@
 
   refreshFlashTaskState();
   refreshDiscoveryTaskState();
-  refreshResetNonvolatileTaskState();
   refreshFirmwareVersionTaskState();
   refreshFanetIdTaskState();
   refreshSelfTestTaskState();

--- a/factory_interface/src/factory_interface/templates/setup_session.html
+++ b/factory_interface/src/factory_interface/templates/setup_session.html
@@ -83,34 +83,6 @@
     </div>
 
     <div class="checklist-item checklist-item-with-details">
-      <button class="task-icon task-icon-empty" id="reset-nonvolatile-task-icon" type="button" aria-label="Toggle nonvolatile memory reset details" disabled></button>
-      <span>Reset nonvolatile memory</span>
-      <p class="checklist-details" id="reset-nonvolatile-details" hidden></p>
-    </div>
-
-    <div class="checklist-item checklist-item-with-details">
-      <button class="task-icon task-icon-empty" id="reconnect-task-icon" type="button" aria-label="Toggle device reconnect details" disabled></button>
-      <span>Wait for device to reconnect</span>
-      <div class="checklist-details-group" id="reconnect-details-group" hidden>
-        <p class="checklist-details" id="reconnect-details"></p>
-        <form class="manual-ip-entry" id="reconnect-manual-ip-form" hidden>
-          <label for="reconnect-manual-ip">Device IP</label>
-          <div class="manual-ip-controls">
-            <input
-              id="reconnect-manual-ip"
-              type="text"
-              inputmode="decimal"
-              autocomplete="off"
-              placeholder="192.168.137.21"
-              value="{{ session.device.ip_address }}"
-            >
-            <button type="submit">Use IP</button>
-          </div>
-        </form>
-      </div>
-    </div>
-
-    <div class="checklist-item checklist-item-with-details">
       <button class="task-icon task-icon-empty" id="firmware-version-task-icon" type="button" aria-label="Toggle firmware version details" disabled></button>
       <span>Read firmware version</span>
       <p class="checklist-details" id="firmware-version-details" hidden></p>
@@ -163,9 +135,6 @@
   const discoveryDetailsGroup = document.querySelector("#discovery-details-group");
   const discoveryManualIpForm = document.querySelector("#discovery-manual-ip-form");
   const discoveryManualIp = document.querySelector("#discovery-manual-ip");
-  const reconnectDetailsGroup = document.querySelector("#reconnect-details-group");
-  const reconnectManualIpForm = document.querySelector("#reconnect-manual-ip-form");
-  const reconnectManualIp = document.querySelector("#reconnect-manual-ip");
   const pollUrl = `/api/setup/sessions/${encodeURIComponent(macAddress)}`;
   const discardUrl = `/api/setup/sessions/${encodeURIComponent(macAddress)}`;
   const manualDiscoveryUrl =
@@ -177,13 +146,6 @@
       icon: document.querySelector("#discovery-task-icon"),
       details: document.querySelector("#discovery-details"),
       detailsContainer: discoveryDetailsGroup,
-    },
-    reset_nonvolatile_memory: {
-      icon: document.querySelector("#reset-nonvolatile-task-icon"),
-      details: document.querySelector("#reset-nonvolatile-details"),
-      reconnectIcon: document.querySelector("#reconnect-task-icon"),
-      reconnectDetails: document.querySelector("#reconnect-details"),
-      reconnectDetailsContainer: reconnectDetailsGroup,
     },
     firmware_version: {
       icon: document.querySelector("#firmware-version-task-icon"),
@@ -284,25 +246,9 @@
     setDetails(control.details, task.details, task.status, control.detailsContainer || control.details);
   }
 
-  function applyResetState(task) {
-    const control = controls.reset_nonvolatile_memory;
-    const resetStatus = task.reset_status || task.status;
-    const reconnectStatus = task.reconnect_status || "idle";
-    setTaskIcon(control.icon, resetStatus);
-    setTaskIcon(control.reconnectIcon, reconnectStatus);
-    setDetails(control.details, task.reset_details || task.details, resetStatus);
-    setDetails(
-      control.reconnectDetails,
-      task.reconnect_details,
-      reconnectStatus,
-      control.reconnectDetailsContainer,
-    );
-  }
-
   function applySession(session) {
     summary.textContent = `${session.mac_address} - ${session.details}`;
     applyTaskState("network_discovery", session.tasks.network_discovery);
-    applyResetState(session.tasks.reset_nonvolatile_memory);
     applyTaskState("firmware_version", session.tasks.firmware_version);
     applyTaskState("fanet_id", session.tasks.fanet_id);
     applyTaskState("interactive_self_test", session.tasks.interactive_self_test);
@@ -377,16 +323,6 @@
     );
   });
 
-  reconnectManualIpForm.addEventListener("submit", async (event) => {
-    event.preventDefault();
-    await submitManualIp(
-      reconnectManualIpForm,
-      reconnectManualIp,
-      controls.reset_nonvolatile_memory.reconnectDetails,
-      "Manual reconnect failed.",
-    );
-  });
-
   flashTaskIcon.addEventListener("click", () => {
     flashConsole.hidden = !flashConsole.hidden;
   });
@@ -402,19 +338,6 @@
         control.details.hidden = !control.details.hidden;
       }
     });
-    if (control.reconnectIcon) {
-      control.reconnectIcon.addEventListener("click", () => {
-        const reconnectDetailsContainer =
-          control.reconnectDetailsContainer || control.reconnectDetails;
-        reconnectDetailsContainer.hidden = false;
-        if (control.reconnectDetailsContainer) {
-          const form = control.reconnectDetailsContainer.querySelector(".manual-ip-entry");
-          form.hidden = !form.hidden;
-        } else {
-          control.reconnectDetails.hidden = !control.reconnectDetails.hidden;
-        }
-      });
-    }
   });
 
   refreshSession();

--- a/src/vario/comms/factory_discovery.cpp
+++ b/src/vario/comms/factory_discovery.cpp
@@ -11,7 +11,7 @@
 
 namespace {
   constexpr uint16_t DISCOVERY_PORT = 7432;
-  constexpr uint16_t HTTP_PORT = 81;
+  constexpr uint16_t HTTP_PORT = 80;
   constexpr const char* REQUEST_PREFIX = "LEAF_DISCOVERY_REQUEST/1 ";
   constexpr size_t REQUEST_PREFIX_LEN = 25;
   constexpr const char* DIAGNOSTIC_NETWORK_SSID = "LeafDiagnostics";

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -36,6 +36,7 @@ namespace {
   String send_buffer = "";
   bool user_server_started = false;
   bool user_server_routes_configured = false;
+  bool commissioning_routes_configured = false;
   bool debug_routes_configured = false;
   bool user_app_enabled = false;
   bool user_app_using_leaf_wifi = false;
@@ -109,6 +110,14 @@ namespace {
   uint32_t web_request_sequence = 0;
 
   bool diagnosticsEnabled() { return settings.dev_mode; }
+
+  bool connectedToDiagnosticWifi() {
+    return WiFi.status() == WL_CONNECTED && WiFi.SSID() == "LeafDiagnostics";
+  }
+
+  bool commissioningHttpAllowed() {
+    return connectedToDiagnosticWifi() && !settings.commissioningComplete;
+  }
 
   void logWifiSetupTiming(const char* event) {
     if (!diagnosticsEnabled()) return;
@@ -2020,6 +2029,173 @@ load();
     sendDebugSessionStatus(target);
   }
 
+  bool requireCommissioningHttp(WebServer& target) {
+    if (commissioningHttpAllowed()) return true;
+
+    target.send(403, "application/json",
+                "{\"detail\":\"Commissioning endpoints are only available on the "
+                "LeafDiagnostics network before commissioning is complete.\"}");
+    return false;
+  }
+
+  void sendCommissioningMacAddress(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    String json = "{\"mac_address\":\"";
+    json += settings.getMacAddress();
+    json += "\"}";
+    target.send(200, "application/json", json);
+  }
+
+  void sendCommissioningFirmwareVersion(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    String json = "{\"firmware_version\":\"";
+    json += LeafVersionInfo::firmwareVersion();
+    json += "\"}";
+    target.send(200, "application/json", json);
+  }
+
+  void resetCommissioningSettings(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    const bool forceFormatSdCard =
+        extractJsonBoolValue(target.arg("plain"), "force_format_sd_card", false);
+    target.send(200, "application/json", "{\"reset_requested\":true}");
+    delay(250);
+    settings.factoryResetVario();
+    settings.beginCommissioning();
+    settings.setProductionTestForceFormatSdCard(forceFormatSdCard);
+    delay(50);
+    ESP.restart();
+  }
+
+  void saveCommissioningFanetAddress(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    String fanet_address = extractJsonStringValue(target.arg("plain"), "fanet_address");
+    fanet_address.trim();
+    fanet_address.toUpperCase();
+    if (!isValidFanetAddress(fanet_address)) {
+      target.send(400, "application/json",
+                  "{\"detail\":\"fanet_address must be a 6-character hexadecimal string.\"}");
+      return;
+    }
+
+    settings.fanet_address = fanet_address;
+    settings.save();
+
+    String json = "{\"fanet_address\":\"";
+    json += settings.fanet_address;
+    json += "\",\"saved\":true}";
+    target.send(200, "application/json", json);
+  }
+
+  void startCommissioningSelfTest(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    requestInteractiveSelfTest();
+    target.send(200, "application/json", selfTestSnapshotJson());
+  }
+
+  void sendCommissioningSelfTest(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    target.send(200, "application/json", selfTestSnapshotJson());
+  }
+
+  void sendCommissioningSelfTestDetails(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    sendLatestSelfTestDetails(target);
+  }
+
+  void clearCommissioningSelfTestResults(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    clearSelfTestDetailsFiles(target);
+  }
+
+  void formatCommissioningSdCard(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    if (selfTest.updateNeeded() || interactive_self_test_pending) {
+      target.send(409, "application/json", "{\"detail\":\"Self test is running or pending.\"}");
+      return;
+    }
+
+    if (!sdcard.isCardPresent()) {
+      target.send(404, "application/json", "{\"detail\":\"SD card is not present.\"}");
+      return;
+    }
+
+    if (!sdcard.format()) {
+      target.send(500, "application/json", "{\"formatted\":false}");
+      return;
+    }
+
+    if (!sdcard.setLabel()) {
+      target.send(500, "application/json", "{\"formatted\":true,\"label_set\":false}");
+      return;
+    }
+
+    target.send(200, "application/json", "{\"formatted\":true,\"label_set\":true}");
+  }
+
+  void markCommissioningComplete(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    settings.markCommissioningComplete();
+    selfTest.confirmCommissioningComplete();
+    target.send(200, "application/json",
+                "{\"commissioning_complete\":true,\"commissioning_pending\":false}");
+  }
+
+  void configureCommissioningRoutes() {
+    if (commissioning_routes_configured) return;
+
+    user_server.on("/mac-address", HTTP_GET, []() { sendCommissioningMacAddress(user_server); });
+    user_server.on("/firmware-version", HTTP_GET,
+                   []() { sendCommissioningFirmwareVersion(user_server); });
+    user_server.on("/settings/factory-reset", HTTP_POST,
+                   []() { resetCommissioningSettings(user_server); });
+    user_server.on("/settings/fanet-address", HTTP_POST,
+                   []() { saveCommissioningFanetAddress(user_server); });
+    user_server.on("/self-test/interactive", HTTP_POST,
+                   []() { startCommissioningSelfTest(user_server); });
+    user_server.on("/self-test", HTTP_GET, []() { sendCommissioningSelfTest(user_server); });
+    user_server.on("/self-test/details", HTTP_GET,
+                   []() { sendCommissioningSelfTestDetails(user_server); });
+    user_server.on("/self-test/results", HTTP_DELETE,
+                   []() { clearCommissioningSelfTestResults(user_server); });
+    user_server.on("/sd-card/format", HTTP_POST, []() { formatCommissioningSdCard(user_server); });
+    user_server.on("/commissioning/complete", HTTP_POST,
+                   []() { markCommissioningComplete(user_server); });
+
+    user_server.on("/api/debug/mac-address", HTTP_GET,
+                   []() { sendCommissioningMacAddress(user_server); });
+    user_server.on("/api/debug/firmware-version", HTTP_GET,
+                   []() { sendCommissioningFirmwareVersion(user_server); });
+    user_server.on("/api/debug/settings/factory-reset", HTTP_POST,
+                   []() { resetCommissioningSettings(user_server); });
+    user_server.on("/api/debug/settings/fanet-address", HTTP_POST,
+                   []() { saveCommissioningFanetAddress(user_server); });
+    user_server.on("/api/debug/self-test/interactive", HTTP_POST,
+                   []() { startCommissioningSelfTest(user_server); });
+    user_server.on("/api/debug/sd-card/format", HTTP_POST,
+                   []() { formatCommissioningSdCard(user_server); });
+    user_server.on("/api/debug/self-test/details", HTTP_GET,
+                   []() { sendCommissioningSelfTestDetails(user_server); });
+    user_server.on("/api/debug/self-test/results", HTTP_DELETE,
+                   []() { clearCommissioningSelfTestResults(user_server); });
+    user_server.on("/api/debug/self-test", HTTP_GET,
+                   []() { sendCommissioningSelfTest(user_server); });
+    user_server.on("/api/debug/commissioning/complete", HTTP_POST,
+                   []() { markCommissioningComplete(user_server); });
+
+    commissioning_routes_configured = true;
+  }
+
   void sendFirmwareUpdateStatus(WebServer& target) {
     if (!user_app_enabled) {
       target.send(404, "application/json", "{\"detail\":\"Leaf Web App is not active.\"}");
@@ -2425,7 +2601,7 @@ load();
   }
 
   void setupUserAppServer() {
-    if (user_server_started) return;
+    if (user_server_started && user_server_routes_configured) return;
 
     if (!user_server_routes_configured) {
       user_server.on("/", HTTP_GET, []() {
@@ -2567,8 +2743,10 @@ load();
     }
 
     webserver_setup();
-    user_server.begin();
-    user_server_started = true;
+    if (!user_server_started) {
+      user_server.begin();
+      user_server_started = true;
+    }
     Serial.printf("Leaf Web App started: %s\n", userAppUrl().c_str());
   }
 }  // namespace
@@ -2581,6 +2759,13 @@ void writeScreenshotBuffer(const char* buffer) {
 }
 
 void webserver_setup() {
+  configureCommissioningRoutes();
+  if (!user_server_started && commissioningHttpAllowed()) {
+    user_server.begin();
+    user_server_started = true;
+    Serial.println("Leaf commissioning webserver started");
+  }
+
   if (!settings.dev_mode) return;
   if (debug_routes_configured) return;
 
@@ -2721,99 +2906,9 @@ void webserver_setup() {
   user_server.on("/app/debug/memory", HTTP_GET,
                  []() { user_server.send(200, "text/plain", getMemoryUsage()); });
 
-  user_server.on("/api/debug/mac-address", HTTP_GET, []() {
-    String json = "{\"mac_address\":\"";
-    json += settings.getMacAddress();
-    json += "\"}";
-    user_server.send(200, "application/json", json);
-  });
-
-  user_server.on("/api/debug/firmware-version", HTTP_GET, []() {
-    String json = "{\"firmware_version\":\"";
-    json += LeafVersionInfo::firmwareVersion();
-    json += "\"}";
-    user_server.send(200, "application/json", json);
-  });
-
   user_server.on("/api/debug/discovery", HTTP_GET, []() {
     factoryDiscovery.update();
     user_server.send(200, "application/json", factoryDiscovery.statusJson());
-  });
-
-  user_server.on("/api/debug/settings/factory-reset", HTTP_POST, []() {
-    const bool forceFormatSdCard =
-        extractJsonBoolValue(user_server.arg("plain"), "force_format_sd_card", false);
-    settings.factoryResetVario();
-    settings.beginCommissioning();
-    settings.setProductionTestForceFormatSdCard(forceFormatSdCard);
-    user_server.send(200, "application/json", "{\"reset_requested\":true}");
-    delay(250);
-    ESP.restart();
-  });
-
-  user_server.on("/api/debug/settings/fanet-address", HTTP_POST, []() {
-    String fanet_address = extractJsonStringValue(user_server.arg("plain"), "fanet_address");
-    fanet_address.trim();
-    fanet_address.toUpperCase();
-    if (!isValidFanetAddress(fanet_address)) {
-      user_server.send(400, "application/json",
-                       "{\"detail\":\"fanet_address must be a 6-character hexadecimal string.\"}");
-      return;
-    }
-
-    settings.fanet_address = fanet_address;
-    settings.save();
-
-    String json = "{\"fanet_address\":\"";
-    json += settings.fanet_address;
-    json += "\",\"saved\":true}";
-    user_server.send(200, "application/json", json);
-  });
-
-  user_server.on("/api/debug/self-test/interactive", HTTP_POST, []() {
-    requestInteractiveSelfTest();
-    user_server.send(200, "application/json", selfTestSnapshotJson());
-  });
-
-  user_server.on("/api/debug/sd-card/format", HTTP_POST, []() {
-    if (selfTest.updateNeeded() || interactive_self_test_pending) {
-      user_server.send(409, "application/json",
-                       "{\"detail\":\"Self test is running or pending.\"}");
-      return;
-    }
-
-    if (!sdcard.isCardPresent()) {
-      user_server.send(404, "application/json", "{\"detail\":\"SD card is not present.\"}");
-      return;
-    }
-
-    if (!sdcard.format()) {
-      user_server.send(500, "application/json", "{\"formatted\":false}");
-      return;
-    }
-
-    if (!sdcard.setLabel()) {
-      user_server.send(500, "application/json", "{\"formatted\":true,\"label_set\":false}");
-      return;
-    }
-
-    user_server.send(200, "application/json", "{\"formatted\":true,\"label_set\":true}");
-  });
-
-  user_server.on("/api/debug/self-test/details", HTTP_GET,
-                 []() { sendLatestSelfTestDetails(user_server); });
-
-  user_server.on("/api/debug/self-test/results", HTTP_DELETE,
-                 []() { clearSelfTestDetailsFiles(user_server); });
-
-  user_server.on("/api/debug/self-test", HTTP_GET,
-                 []() { user_server.send(200, "application/json", selfTestSnapshotJson()); });
-
-  user_server.on("/api/debug/commissioning/complete", HTTP_POST, []() {
-    settings.markCommissioningComplete();
-    selfTest.confirmCommissioningComplete();
-    user_server.send(200, "application/json",
-                     "{\"commissioning_complete\":true,\"commissioning_pending\":false}");
   });
 
   debug_routes_configured = true;
@@ -2821,13 +2916,16 @@ void webserver_setup() {
 
 void webserver_loop() {
   if (WiFi.status() == WL_CONNECTED || user_app_enabled) {
+    if (user_server_started) {
+      user_server.handleClient();
+    }
+
     if (user_app_enabled) {
       if (diagnosticsEnabled()) user_app_loop_count++;
       updateUserAppStationPeak();
       if (user_app_provisioning) updateWifiNetworkScan();
       if (user_app_dns_started) dns_server.processNextRequest();
       if (diagnosticsEnabled()) user_app_handle_count++;
-      user_server.handleClient();
       if (user_app_provisioning) appendWifiSetupDiagnostics("loop");
       if (webserver_wifi_setup_ready_to_finish()) {
         appendWifiSetupDiagnostics("transition-start", true);


### PR DESCRIPTION
## Summary

- Restored factory commissioning compatibility with the new Leaf webserver by exposing commissioning-safe HTTP routes on the diagnostic network.
- Changed factory flashing to erase the NVS partition before writing firmware, so new and recommissioned units both boot into the same factory-ready state.
- Removed the redundant post-flash “Reset nonvolatile memory” and reconnect steps from the factory commissioning flow.
- Updated factory_interface styling to match the Leaf Web App palette with dark greys and hero green.
- Added a backlog note for future work to derive the NVS erase range from the partition table.

## Testing

- Successfully commissioned an already-erased Leaf test unit end-to-end.
- Successfully recommissioned a previously used Leaf after enabling pre-flash NVS erase.
- Verified factory_interface app import.
- Verified flash command builder emits NVS erase followed by normal firmware write.
- Ran `git diff --check`; only expected CRLF warnings appeared.