### PR TITLE
Adjust gravity estimate limits, harden FANET SPI handling, and add gated vario diagnostics

### DIFF
--- a/docs/dev-references/backlog/vario-imu-gravity-performance.md
+++ b/docs/dev-references/backlog/vario-imu-gravity-performance.md
@@ -1,0 +1,75 @@
+---
+title: Vario IMU Gravity Performance Backlog
+description: Findings and future tuning notes for IMU gravity estimation and stationary climb-rate errors.
+---
+
+# Vario IMU Gravity Performance Backlog
+
+## Context
+
+Some test units report a persistent non-zero climb rate while sitting stationary. A diagnostic
+`vario.csv` log was captured from one affected unit after adding IMU/baro/gravity/Kalman diagnostic
+fields. The main test session included:
+
+- Leaf flat on a table, reporting about `0.1` to `0.3 m/s` climb.
+- Leaf pitched upright about 90 degrees, reporting reduced climb closer to `0.0` to `0.2 m/s`.
+- Leaf returned flat on the table, with the higher stationary climb returning.
+
+This suggests the accelerometer scale error is not equal across orthogonal axes.
+
+## Current Findings
+
+In the affected unit's flat orientation:
+
+- Device/world vertical acceleration was around `1.048g` to `1.052g`.
+- The gravity estimate was pinned at the current upper clamp of `1.020g`.
+- The remaining vertical acceleration residual was about `+0.03g`.
+- The Kalman/filter chain converted that residual into a persistent positive climb rate, commonly
+  around `+0.18 m/s`.
+
+In the upright orientation:
+
+- The axis aligned with gravity was closer to nominal, around `1.00g` to `1.02g`.
+- The gravity estimate was no longer stuck at the `1.020g` upper bound.
+- The vertical acceleration residual was much closer to zero.
+- The filtered climb rate dropped substantially.
+
+The barometer did not appear to be the primary cause in this log. Baro altitude drift was much
+smaller than the reported climb-rate bias, while the IMU vertical acceleration residual closely
+matched the sign and persistence of the climb-rate error.
+
+## Likely Cause
+
+The current gravity estimate clamp is too narrow for at least some IMU modules. A stationary IMU
+whose aligned accelerometer axis reads above `1.02g` cannot be learned correctly because the
+estimate is clamped before it reaches the observed resting value. The Kalman filter then sees a
+small constant upward acceleration even when Leaf is motionless.
+
+There is also a related gate: `GRAVITY_UPDATE_ACCEL_TOLERANCE_G` is currently `0.05g`. If we expect
+some stationary IMUs to read as much as 6% high or low, then stillness detection must accept at
+least that same error range. Otherwise, the samples needed to learn the corrected gravity value can
+be rejected before they update the estimate.
+
+## Proposed Future Changes
+
+- Expand the gravity estimate clamp from `[0.98g, 1.02g]` to `[0.94g, 1.06g]`.
+- Increase `GRAVITY_UPDATE_ACCEL_TOLERANCE_G` from `0.05g` to at least `0.06g`.
+- Consider using `0.065g` for the accel tolerance to avoid rejecting otherwise-stationary samples
+  at the edge due to noise and quantization.
+- Continue collecting `vario.csv` logs from additional units before implementing the change, so the
+  final bounds cover observed IMU variation without making the estimator too willing to learn during
+  real motion.
+- After changing bounds, repeat stationary flat/upright tests and confirm:
+  - `gravity_g` converges near the observed resting `awz_g`.
+  - `vertical_accel_g` is near zero when stationary.
+  - `climb_filtered_cms` settles near zero in multiple orientations.
+  - Real movement still produces responsive climb/sink values.
+
+## Open Questions
+
+- How wide is the actual accelerometer scale-error distribution across a larger sample of Leaf
+  units?
+- Are high/low errors axis-specific enough that per-axis calibration should eventually replace a
+  single gravity magnitude estimate?
+- Should the diagnostic self-test record resting `accel_total_g`, axis values, and gravity estimate
+  so manufacturing can identify outlier IMUs earlier?

--- a/src/vario/comms/fanet_radio.cpp
+++ b/src/vario/comms/fanet_radio.cpp
@@ -1,7 +1,7 @@
 #include "comms/fanet_radio.h"
 
-#include "FreeRTOS.h"
 #include <SPI.h>
+#include "FreeRTOS.h"
 #include "diagnostics/diagnostic_logs.h"
 #include "diagnostics/heap_monitor.h"
 #include "dispatch/message_types.h"
@@ -20,41 +20,39 @@
 FanetRadio fanetRadio;
 
 namespace {
-constexpr uint8_t SX1262_CMD_GET_STATUS = 0xC0;
-constexpr uint8_t SX1262_CMD_READ_REGISTER = 0x1D;
-constexpr uint8_t SX1262_CMD_SET_STANDBY = 0x80;
-constexpr uint8_t SX1262_CMD_NOP = 0x00;
-constexpr uint8_t SX1262_STANDBY_RC = 0x00;
-constexpr uint16_t SX1262_REG_VERSION_STRING = 0x0320;
-constexpr uint32_t FANET_SPI_PROBE_BUSY_TIMEOUT_MS = 100;
-constexpr uint32_t FANET_SPI_LOCK_TIMEOUT_MS = 25;
-constexpr uint32_t FANET_RADIO_SPI_CLOCK_HZ = 1000000;
+  constexpr uint8_t SX1262_CMD_GET_STATUS = 0xC0;
+  constexpr uint8_t SX1262_CMD_READ_REGISTER = 0x1D;
+  constexpr uint8_t SX1262_CMD_SET_STANDBY = 0x80;
+  constexpr uint8_t SX1262_CMD_NOP = 0x00;
+  constexpr uint8_t SX1262_STANDBY_RC = 0x00;
+  constexpr uint16_t SX1262_REG_VERSION_STRING = 0x0320;
+  constexpr uint32_t FANET_SPI_PROBE_BUSY_TIMEOUT_MS = 100;
+  constexpr uint32_t FANET_SPI_LOCK_TIMEOUT_MS = 25;
+  constexpr uint32_t FANET_RADIO_SPI_CLOCK_HZ = 1000000;
 
-bool sx1262StatusLooksValid(uint8_t status) {
-  return status != 0x00 && status != 0xFF;
-}
+  bool sx1262StatusLooksValid(uint8_t status) { return status != 0x00 && status != 0xFF; }
 
-bool sx126xVersionLooksValid(const char* version) {
-  return strncmp(version, "SX1261", 6) == 0 || strncmp(version, "SX1262", 6) == 0;
-}
-
-String sx1262VersionPrefixString(const char* version) {
-  String prefix;
-  for (size_t i = 0; i < 6; i++) {
-    const char c = version[i];
-    prefix += isPrintable(c) ? c : '.';
+  bool sx126xVersionLooksValid(const char* version) {
+    return strncmp(version, "SX1261", 6) == 0 || strncmp(version, "SX1262", 6) == 0;
   }
-  return prefix;
-}
 
-String sx1262VersionHexString(const char* version) {
-  char hex[18] = {0};
-  snprintf(hex, sizeof(hex), "%02X%02X%02X%02X%02X%02X",
-           static_cast<uint8_t>(version[0]), static_cast<uint8_t>(version[1]),
-           static_cast<uint8_t>(version[2]), static_cast<uint8_t>(version[3]),
-           static_cast<uint8_t>(version[4]), static_cast<uint8_t>(version[5]));
-  return String(hex);
-}
+  String sx1262VersionPrefixString(const char* version) {
+    String prefix;
+    for (size_t i = 0; i < 6; i++) {
+      const char c = version[i];
+      prefix += isPrintable(c) ? c : '.';
+    }
+    return prefix;
+  }
+
+  String sx1262VersionHexString(const char* version) {
+    char hex[18] = {0};
+    snprintf(hex, sizeof(hex), "%02X%02X%02X%02X%02X%02X", static_cast<uint8_t>(version[0]),
+             static_cast<uint8_t>(version[1]), static_cast<uint8_t>(version[2]),
+             static_cast<uint8_t>(version[3]), static_cast<uint8_t>(version[4]),
+             static_cast<uint8_t>(version[5]));
+    return String(hex);
+  }
 }  // namespace
 
 // Initial detection of Fanet module (hw3.2.6+)
@@ -171,16 +169,14 @@ bool FanetRadio::probeFanetSpi() {
     SPI.endTransaction();
   }
 
-  const uint8_t status =
-      sx1262StatusLooksValid(firstStatus) ? firstStatus : secondStatus;
+  const uint8_t status = sx1262StatusLooksValid(firstStatus) ? firstStatus : secondStatus;
   const String versionPrefix = sx1262VersionPrefixString(version);
   fanetSpiProbed_ = true;
   fanetSpiProbeOk_ = sx126xVersionLooksValid(version);
   probeStatus_ = status;
-  probeDetail_ = fanetSpiProbeOk_
-                     ? String("ok:") + versionPrefix
-                     : String("version:") + versionPrefix + ":hex:" +
-                           sx1262VersionHexString(version);
+  probeDetail_ = fanetSpiProbeOk_ ? String("ok:") + versionPrefix
+                                  : String("version:") + versionPrefix +
+                                        ":hex:" + sx1262VersionHexString(version);
   logEvent("probe-status", sx1262StatusLooksValid(status) ? "ok" : "invalid", "status", status,
            true);
   logEvent("probe-version", fanetSpiProbeOk_ ? String("ok:") + versionPrefix : versionPrefix);
@@ -199,9 +195,8 @@ bool FanetRadio::probeFanetSpi() {
 
 void FanetRadio::logDetectionResult() {
   if (!detectionResultLogged_ &&
-      diagnostic_logs::appendSystemEvent("fanet", "detect",
-                                         fanetDetected_ ? "present" : "missing", "cycles",
-                                         detectionCycles_, true)) {
+      diagnostic_logs::appendSystemEvent("fanet", "detect", fanetDetected_ ? "present" : "missing",
+                                         "cycles", detectionCycles_, true)) {
     detectionResultLogged_ = true;
   }
   logProbeResult();
@@ -210,8 +205,7 @@ void FanetRadio::logDetectionResult() {
 void FanetRadio::logProbeResult() {
   if (probeResultLogged_ || !fanetSpiProbed_) return;
   String detail = probeDetail_.isEmpty() ? (fanetSpiProbeOk_ ? "ok" : "failed") : probeDetail_;
-  if (diagnostic_logs::appendSystemEvent("fanet", "probe", detail, "status",
-                                         probeStatus_, true)) {
+  if (diagnostic_logs::appendSystemEvent("fanet", "probe", detail, "status", probeStatus_, true)) {
     probeResultLogged_ = true;
   }
 }
@@ -228,8 +222,7 @@ void FanetRadio::logEventCode(const char* event, const String& detail, const int
 }
 
 bool FanetRadio::radioUnavailable() const {
-  return state == FanetRadioState::UNINSTALLED ||
-         state == FanetRadioState::FAILED_RADIO_PROBE ||
+  return state == FanetRadioState::UNINSTALLED || state == FanetRadioState::FAILED_RADIO_PROBE ||
          state == FanetRadioState::FAILED_RADIO_INIT || state == FanetRadioState::FAILED_OTHER;
 }
 
@@ -340,9 +333,8 @@ void FanetRadio::processRxPacket() {
     }
 
     // A packet is able to be read
-    rxState = callRadio("rx-read", "readData", [&]() {
-      return radio.readData(buffer.data(), length);
-    });
+    rxState =
+        callRadio("rx-read", "readData", [&]() { return radio.readData(buffer.data(), length); });
   } else {
     logEvent("rx-read", "spi-lock-timeout");
     return;
@@ -454,9 +446,8 @@ bool FanetRadio::fanet_sendFrame(uint8_t codingRate, etl::span<const uint8_t> da
 
   // Send the frame out on the wire.
   logEvent("tx-start", "transmit", "bytes", data.size(), true);
-  auto txResult = callRadio("tx-result", "transmit", [&]() {
-    return radio->transmit(data.data(), data.size());
-  });
+  auto txResult = callRadio("tx-result", "transmit",
+                            [&]() { return radio->transmit(data.data(), data.size()); });
   if (txResult != RADIOLIB_ERR_NONE) {
     Serial.println("[FanetRadio] Failed to transmit");
     return false;
@@ -645,9 +636,8 @@ void FanetRadio::begin(const FanetRadioRegion& region) {
         return radio->begin(920.800f, 500.0f, 7U, 5U, 0xF1, 22U, 8U, 1.8f, false);
       });
       if (radioInitState == RADIOLIB_ERR_NONE) {
-        syncWordState = callRadio("begin-sync-word", "US", [&]() {
-          return radio->setSyncWord(0xF1, 0x44);
-        });
+        syncWordState =
+            callRadio("begin-sync-word", "US", [&]() { return radio->setSyncWord(0xF1, 0x44); });
       }
       break;
     case FanetRadioRegion::EUROPE:
@@ -656,9 +646,8 @@ void FanetRadio::begin(const FanetRadioRegion& region) {
         return radio->begin(868.200f, 250.0f, 7U, 5U, 0xF1, 22U, 8U, 1.8f, false);
       });
       if (radioInitState == RADIOLIB_ERR_NONE) {
-        syncWordState = callRadio("begin-sync-word", "EUROPE", [&]() {
-          return radio->setSyncWord(0xF1, 0x44);
-        });
+        syncWordState = callRadio("begin-sync-word", "EUROPE",
+                                  [&]() { return radio->setSyncWord(0xF1, 0x44); });
       }
       break;
   }
@@ -676,9 +665,8 @@ void FanetRadio::begin(const FanetRadioRegion& region) {
   Serial.println("[FanetRadio] Initialized");
 
   logEvent("begin-start-rx-start", "startReceive");
-  auto rxState = callRadio("begin-start-rx", "startReceive", [&]() {
-    return radio->startReceive();
-  });
+  auto rxState =
+      callRadio("begin-start-rx", "startReceive", [&]() { return radio->startReceive(); });
   if (rxState != RADIOLIB_ERR_NONE) {
     Serial.println("[FanetRadio] Radio->startReceive failed");
     state = FanetRadioState::FAILED_RADIO_INIT;
@@ -689,18 +677,16 @@ void FanetRadio::begin(const FanetRadioRegion& region) {
   // 1262 radio is different from the WaveShare breadboard modules.
   radio->setRfSwitchPins(SX1262_RF_SW, RADIOLIB_NC);
   logEvent("begin-dio2-rf-switch-start", "setDio2AsRfSwitch");
-  auto dio2State = callRadio("begin-dio2-rf-switch", "setDio2AsRfSwitch", [&]() {
-    return radio->setDio2AsRfSwitch();
-  });
+  auto dio2State = callRadio("begin-dio2-rf-switch", "setDio2AsRfSwitch",
+                             [&]() { return radio->setDio2AsRfSwitch(); });
   if (dio2State != RADIOLIB_ERR_NONE) {
     state = FanetRadioState::FAILED_RADIO_INIT;
     return;
   }
   // Try to get a few extra db
   logEvent("begin-rx-boost-start", "setRxBoostedGainMode");
-  auto boostedGainState = callRadio("begin-rx-boost", "setRxBoostedGainMode", [&]() {
-    return radio->setRxBoostedGainMode(true, true);
-  });
+  auto boostedGainState = callRadio("begin-rx-boost", "setRxBoostedGainMode",
+                                    [&]() { return radio->setRxBoostedGainMode(true, true); });
   if (boostedGainState != RADIOLIB_ERR_NONE) {
     state = FanetRadioState::FAILED_RADIO_INIT;
     return;

--- a/src/vario/comms/fanet_radio.cpp
+++ b/src/vario/comms/fanet_radio.cpp
@@ -1,6 +1,8 @@
 #include "comms/fanet_radio.h"
 
 #include "FreeRTOS.h"
+#include <SPI.h>
+#include "diagnostics/diagnostic_logs.h"
 #include "diagnostics/heap_monitor.h"
 #include "dispatch/message_types.h"
 #include "esp_mac.h"
@@ -16,6 +18,44 @@
 
 // Singleton instance declaration.
 FanetRadio fanetRadio;
+
+namespace {
+constexpr uint8_t SX1262_CMD_GET_STATUS = 0xC0;
+constexpr uint8_t SX1262_CMD_READ_REGISTER = 0x1D;
+constexpr uint8_t SX1262_CMD_SET_STANDBY = 0x80;
+constexpr uint8_t SX1262_CMD_NOP = 0x00;
+constexpr uint8_t SX1262_STANDBY_RC = 0x00;
+constexpr uint16_t SX1262_REG_VERSION_STRING = 0x0320;
+constexpr uint32_t FANET_SPI_PROBE_BUSY_TIMEOUT_MS = 100;
+constexpr uint32_t FANET_SPI_LOCK_TIMEOUT_MS = 25;
+constexpr uint32_t FANET_RADIO_SPI_CLOCK_HZ = 1000000;
+
+bool sx1262StatusLooksValid(uint8_t status) {
+  return status != 0x00 && status != 0xFF;
+}
+
+bool sx126xVersionLooksValid(const char* version) {
+  return strncmp(version, "SX1261", 6) == 0 || strncmp(version, "SX1262", 6) == 0;
+}
+
+String sx1262VersionPrefixString(const char* version) {
+  String prefix;
+  for (size_t i = 0; i < 6; i++) {
+    const char c = version[i];
+    prefix += isPrintable(c) ? c : '.';
+  }
+  return prefix;
+}
+
+String sx1262VersionHexString(const char* version) {
+  char hex[18] = {0};
+  snprintf(hex, sizeof(hex), "%02X%02X%02X%02X%02X%02X",
+           static_cast<uint8_t>(version[0]), static_cast<uint8_t>(version[1]),
+           static_cast<uint8_t>(version[2]), static_cast<uint8_t>(version[3]),
+           static_cast<uint8_t>(version[4]), static_cast<uint8_t>(version[5]));
+  return String(hex);
+}
+}  // namespace
 
 // Initial detection of Fanet module (hw3.2.6+)
 bool FanetRadio::detectFanet() {
@@ -34,10 +74,185 @@ bool FanetRadio::detectFanet() {
     }
     delay(10);
   }
+  fanetDetected_ = fanetReady;
+  detectionCycles_ = count;
   return fanetReady;
 #endif
   // If the module is not present, return false
+  fanetDetected_ = false;
+  detectionCycles_ = 0;
   return false;  // Module does not support Fanet
+}
+
+bool FanetRadio::waitFanetReady(uint32_t timeoutMs) const {
+#ifdef FANET_CAPABLE
+  const uint32_t startMs = millis();
+  while (digitalRead(SX1262_BUSY)) {
+    if (millis() - startMs >= timeoutMs) return false;
+    delay(1);
+  }
+  return true;
+#endif
+  return false;
+}
+
+bool FanetRadio::probeFanetSpi() {
+#if defined(FANET_CAPABLE) && defined(LORA_SX1262)
+  logEvent("probe-start", "version-string");
+
+  pinMode(SX1262_NSS, OUTPUT);
+  digitalWrite(SX1262_NSS, HIGH);
+  pinMode(SX1262_BUSY, INPUT_PULLUP);
+  pinMode(SX1262_RESET, OUTPUT);
+  digitalWrite(SX1262_RESET, LOW);
+  delay(1);
+  digitalWrite(SX1262_RESET, HIGH);
+
+  if (!waitFanetReady(FANET_SPI_PROBE_BUSY_TIMEOUT_MS)) {
+    state = FanetRadioState::FAILED_RADIO_PROBE;
+    fanetSpiProbed_ = true;
+    fanetSpiProbeOk_ = false;
+    probeStatus_ = 0;
+    probeDetail_ = "busy-timeout";
+    logEvent("probe", "busy-timeout");
+    logProbeResult();
+    return false;
+  }
+
+  uint8_t firstStatus = 0;
+  uint8_t secondStatus = 0;
+  char version[7] = {0};
+  {
+    SpiLockGuard spiLock(FANET_SPI_LOCK_TIMEOUT_MS, false);
+    if (!spiLock) {
+      state = FanetRadioState::FAILED_RADIO_PROBE;
+      fanetSpiProbed_ = true;
+      fanetSpiProbeOk_ = false;
+      probeStatus_ = 0;
+      probeDetail_ = "spi-lock-timeout";
+      logEvent("probe", "spi-lock-timeout");
+      logProbeResult();
+      return false;
+    }
+
+    SPI.beginTransaction(SPISettings(FANET_RADIO_SPI_CLOCK_HZ, MSBFIRST, SPI_MODE0));
+    digitalWrite(SX1262_NSS, LOW);
+    firstStatus = SPI.transfer(SX1262_CMD_GET_STATUS);
+    secondStatus = SPI.transfer(SX1262_CMD_NOP);
+    digitalWrite(SX1262_NSS, HIGH);
+
+    digitalWrite(SX1262_NSS, LOW);
+    SPI.transfer(SX1262_CMD_SET_STANDBY);
+    SPI.transfer(SX1262_STANDBY_RC);
+    digitalWrite(SX1262_NSS, HIGH);
+    SPI.endTransaction();
+
+    if (!waitFanetReady(FANET_SPI_PROBE_BUSY_TIMEOUT_MS)) {
+      state = FanetRadioState::FAILED_RADIO_PROBE;
+      fanetSpiProbed_ = true;
+      fanetSpiProbeOk_ = false;
+      probeStatus_ = sx1262StatusLooksValid(firstStatus) ? firstStatus : secondStatus;
+      probeDetail_ = "standby-timeout";
+      logEvent("probe", "standby-timeout");
+      logProbeResult();
+      return false;
+    }
+
+    SPI.beginTransaction(SPISettings(FANET_RADIO_SPI_CLOCK_HZ, MSBFIRST, SPI_MODE0));
+    digitalWrite(SX1262_NSS, LOW);
+    SPI.transfer(SX1262_CMD_READ_REGISTER);
+    SPI.transfer(static_cast<uint8_t>((SX1262_REG_VERSION_STRING >> 8) & 0xFF));
+    SPI.transfer(static_cast<uint8_t>(SX1262_REG_VERSION_STRING & 0xFF));
+    SPI.transfer(SX1262_CMD_NOP);  // status/dummy byte before register data
+    for (size_t i = 0; i < 6; i++) {
+      version[i] = static_cast<char>(SPI.transfer(SX1262_CMD_NOP));
+    }
+    digitalWrite(SX1262_NSS, HIGH);
+    SPI.endTransaction();
+  }
+
+  const uint8_t status =
+      sx1262StatusLooksValid(firstStatus) ? firstStatus : secondStatus;
+  const String versionPrefix = sx1262VersionPrefixString(version);
+  fanetSpiProbed_ = true;
+  fanetSpiProbeOk_ = sx126xVersionLooksValid(version);
+  probeStatus_ = status;
+  probeDetail_ = fanetSpiProbeOk_
+                     ? String("ok:") + versionPrefix
+                     : String("version:") + versionPrefix + ":hex:" +
+                           sx1262VersionHexString(version);
+  logEvent("probe-status", sx1262StatusLooksValid(status) ? "ok" : "invalid", "status", status,
+           true);
+  logEvent("probe-version", fanetSpiProbeOk_ ? String("ok:") + versionPrefix : versionPrefix);
+  logEvent("probe-version-hex", sx1262VersionHexString(version));
+  logProbeResult();
+
+  if (!fanetSpiProbeOk_) {
+    state = FanetRadioState::FAILED_RADIO_PROBE;
+    return false;
+  }
+
+  return true;
+#endif
+  return false;
+}
+
+void FanetRadio::logDetectionResult() {
+  if (!detectionResultLogged_ &&
+      diagnostic_logs::appendSystemEvent("fanet", "detect",
+                                         fanetDetected_ ? "present" : "missing", "cycles",
+                                         detectionCycles_, true)) {
+    detectionResultLogged_ = true;
+  }
+  logProbeResult();
+}
+
+void FanetRadio::logProbeResult() {
+  if (probeResultLogged_ || !fanetSpiProbed_) return;
+  String detail = probeDetail_.isEmpty() ? (fanetSpiProbeOk_ ? "ok" : "failed") : probeDetail_;
+  if (diagnostic_logs::appendSystemEvent("fanet", "probe", detail, "status",
+                                         probeStatus_, true)) {
+    probeResultLogged_ = true;
+  }
+}
+
+void FanetRadio::logEvent(const char* event, const String& detail, const char* key, int32_t value,
+                          bool hasValue) {
+  logDetectionResult();
+  if (state == FanetRadioState::UNINSTALLED) return;
+  diagnostic_logs::appendSystemEvent("fanet", event, detail, key, value, hasValue);
+}
+
+void FanetRadio::logEventCode(const char* event, const String& detail, const int16_t code) {
+  logEvent(event, detail, "code", code, true);
+}
+
+bool FanetRadio::radioUnavailable() const {
+  return state == FanetRadioState::UNINSTALLED ||
+         state == FanetRadioState::FAILED_RADIO_PROBE ||
+         state == FanetRadioState::FAILED_RADIO_INIT || state == FanetRadioState::FAILED_OTHER;
+}
+
+bool FanetRadio::shouldMarkRadioUnhealthy(int16_t code) const {
+  switch (code) {
+    case RADIOLIB_ERR_NONE:
+      return false;
+    case RADIOLIB_ERR_CHIP_NOT_FOUND:
+    case RADIOLIB_ERR_SPI_WRITE_FAILED:
+    case RADIOLIB_ERR_WRONG_MODEM:
+    case RADIOLIB_ERR_SPI_CMD_TIMEOUT:
+      return true;
+    default:
+      return false;
+  }
+}
+
+void FanetRadio::markRadioUnhealthy(const char* event, int16_t code) {
+  if (state == FanetRadioState::UNINSTALLED || state == FanetRadioState::FAILED_RADIO_PROBE) {
+    return;
+  }
+  state = FanetRadioState::FAILED_RADIO_INIT;
+  logEvent("radio-unhealthy", event, "code", code, true);
 }
 
 // Static initializers
@@ -108,11 +323,13 @@ void FanetRadio::taskRadioRx(void* pvParameters) {
 }
 
 void FanetRadio::processRxPacket() {
+  if (state != FanetRadioState::RUNNING) return;
+
   auto& radio = *FanetRadio::radio;
 
-  int16_t rxState;
+  int16_t rxState = RADIOLIB_ERR_UNKNOWN;
   size_t length;
-  if (auto lockGuard = SpiLockGuard()) {
+  if (auto lockGuard = SpiLockGuard(FANET_SPI_LOCK_TIMEOUT_MS, false)) {
     length = radio.getPacketLength();
 
     // If a 0 length packet is here, I'm guessing the "done" DIO pin was fired
@@ -123,7 +340,16 @@ void FanetRadio::processRxPacket() {
     }
 
     // A packet is able to be read
-    rxState = radio.readData(buffer.data(), length);
+    rxState = callRadio("rx-read", "readData", [&]() {
+      return radio.readData(buffer.data(), length);
+    });
+  } else {
+    logEvent("rx-read", "spi-lock-timeout");
+    return;
+  }
+
+  if (rxState != RADIOLIB_ERR_NONE) {
+    return;
   }
 
   if (rxState == RADIOLIB_ERR_NONE) {
@@ -181,14 +407,22 @@ void FanetRadio::taskRadioTx(void* pvParameters) {
     // The draw methods may take out a lock on the SPI bus while they're
     // requesting information from our Fanet Manager
     uint32_t sleepMs = 0;
-    if (auto spiLock = SpiLockGuard()) {
+    if (auto spiLock = SpiLockGuard(FANET_SPI_LOCK_TIMEOUT_MS, false)) {
       LockGuard lock(fanetRadio.x_fanet_manager_mutex);
+      if (!lock) {
+        fanetRadio.logEvent("tx-manager-lock", "failed");
+      } else {
+        // Process a TX.
+        // auto currentTime = millis();
+        sleepMs = fanetRadio.protocol->handleTx() - millis();
 
-      // Process a TX.
-      // auto currentTime = millis();
-      sleepMs = fanetRadio.protocol->handleTx() - millis();
-
-      radio.startReceive();  // Put the radio back into a receive state
+        fanetRadio.logEvent("tx-rx-restart-start", "startReceive");
+        fanetRadio.callRadio("tx-rx-restart", "startReceive", [&]() {
+          return radio.startReceive();  // Put the radio back into a receive state
+        });
+      }
+    } else {
+      fanetRadio.logEvent("tx-rx-restart", "spi-lock-timeout");
     }
 
     // Sleep until the next due TX time.
@@ -197,6 +431,10 @@ void FanetRadio::taskRadioTx(void* pvParameters) {
 }
 
 bool FanetRadio::fanet_sendFrame(uint8_t codingRate, etl::span<const uint8_t> data) {
+  if (state != FanetRadioState::RUNNING) {
+    return false;
+  }
+
   // For now, just flag this as a success
   if (frameSending) {
     // If we're already sending a frame, don't send another one
@@ -215,7 +453,10 @@ bool FanetRadio::fanet_sendFrame(uint8_t codingRate, etl::span<const uint8_t> da
   // Not sure why the above is locking up.
 
   // Send the frame out on the wire.
-  auto txResult = radio->transmit(data.data(), data.size());
+  logEvent("tx-start", "transmit", "bytes", data.size(), true);
+  auto txResult = callRadio("tx-result", "transmit", [&]() {
+    return radio->transmit(data.data(), data.size());
+  });
   if (txResult != RADIOLIB_ERR_NONE) {
     Serial.println("[FanetRadio] Failed to transmit");
     return false;
@@ -252,9 +493,15 @@ void FanetRadio::subscribe(etl::imessage_bus* bus) {
 }
 
 void FanetRadio::setup() {
+  logDetectionResult();
   heap_monitor::checkpoint("fanet-setup-start");
   if (state == FanetRadioState::UNINSTALLED) {
     heap_monitor::checkpoint("fanet-setup-skipped");
+    return;
+  }
+
+  if (!probeFanetSpi()) {
+    heap_monitor::checkpoint("fanet-setup-probe-failed");
     return;
   }
 
@@ -265,13 +512,11 @@ void FanetRadio::setup() {
   protocol = new FANET::Protocol(this);
   heap_monitor::checkpoint("fanet-protocol");
 
-  // Take out a lock on the SPI bus.
-  SpiLockGuard spiLock;
-
   // Create the mutex, lock it.
   x_fanet_manager_mutex = xSemaphoreCreateMutex();
   if (x_fanet_manager_mutex == NULL) {
     state = FanetRadioState::FAILED_OTHER;
+    logEvent("setup", "mutex-failed");
     return;
   }
 
@@ -295,6 +540,7 @@ void FanetRadio::setup() {
   if (taskCreateCode != pdPASS) {
     Serial.println((String) "Creating Tx task failed: " + taskCreateCode);
     state = FanetRadioState::FAILED_OTHER;
+    logEvent("setup-tx-task", "failed", "code", taskCreateCode, true);
     return;
   }
   heap_monitor::registerTask("fanet_tx", x_fanet_tx_task);
@@ -307,6 +553,7 @@ void FanetRadio::setup() {
   if (taskCreateCode != pdPASS) {
     Serial.print((String) "Creating Rx task failed: " + taskCreateCode);
     state = FanetRadioState::FAILED_OTHER;
+    logEvent("setup-rx-task", "failed", "code", taskCreateCode, true);
     return;
   }
   heap_monitor::registerTask("fanet_rx", x_fanet_rx_task);
@@ -319,7 +566,13 @@ void FanetRadio::setup() {
   //     xTaskCreate(taskRadioNameTx, "FanetNameTx", 4096, nullptr, 1, &x_fanet_tx_name_task);
 
   // Put the radio to sleep once it has been initialized.
-  radio->sleep();
+  logEvent("setup-sleep-start", "sleep");
+  if (auto spiLock = SpiLockGuard(FANET_SPI_LOCK_TIMEOUT_MS, false)) {
+    callRadio("setup-sleep", "sleep", [&]() { return radio->sleep(); });
+  } else {
+    state = FanetRadioState::FAILED_RADIO_INIT;
+    logEvent("setup-sleep", "spi-lock-timeout");
+  }
   heap_monitor::checkpoint("fanet-setup-end");
 }
 
@@ -328,13 +581,26 @@ void FanetRadio::begin(const FanetRadioRegion& region) {
   return;  // Model does not support Fanet
 #endif
 
+  logDetectionResult();
   if (state == FanetRadioState::UNINSTALLED) {
     return;  // Short circuit if the radio module is not installed
   }
 
   // Short circuit above taking any locks out (avoid deadlocks)
   if (region == FanetRadioRegion::OFF) {
+    logEvent("begin", "region-off");
     end();
+    return;
+  }
+
+  if (radioUnavailable()) {
+    logEvent("begin", "radio-unavailable");
+    return;
+  }
+
+  if (radio == nullptr || x_fanet_manager_mutex == nullptr) {
+    state = FanetRadioState::FAILED_OTHER;
+    logEvent("begin", "not-setup");
     return;
   }
 
@@ -342,13 +608,25 @@ void FanetRadio::begin(const FanetRadioRegion& region) {
   random.initialise(millis());
 
   heap_monitor::checkpoint("fanet-begin-start");
+  logEvent("begin-start", region.c_str());
   state = FanetRadioState::INITIALIZING;
   int16_t radioInitState = RADIOLIB_ERR_UNKNOWN;
+  int16_t syncWordState = RADIOLIB_ERR_UNKNOWN;
   // Always take the SPI lock out before the Fanet Manager lock
   // to avoid deadlocks with janky display modules locking the SPI
   // bus and making Fanet state changes or requests after.
-  SpiLockGuard spiLock;
+  SpiLockGuard spiLock(FANET_SPI_LOCK_TIMEOUT_MS, false);
+  if (!spiLock) {
+    state = FanetRadioState::FAILED_RADIO_INIT;
+    logEvent("begin", "spi-lock-timeout");
+    return;
+  }
   LockGuard lock(x_fanet_manager_mutex);
+  if (!lock) {
+    state = FanetRadioState::FAILED_OTHER;
+    logEvent("begin", "manager-lock-timeout");
+    return;
+  }
 
   Serial.println("[FanetRadio] Initializing");
 
@@ -362,12 +640,26 @@ void FanetRadio::begin(const FanetRadioRegion& region) {
 
   switch (region) {
     case FanetRadioRegion::US:
-      radioInitState = radio->begin(920.800f, 500.0f, 7U, 5U, 0xF1, 22U, 8U, 1.8f, false);
-      radio->setSyncWord(0xF1, 0x44);
+      logEvent("begin-radio-start", "US");
+      radioInitState = callRadio("begin-radio", "US", [&]() {
+        return radio->begin(920.800f, 500.0f, 7U, 5U, 0xF1, 22U, 8U, 1.8f, false);
+      });
+      if (radioInitState == RADIOLIB_ERR_NONE) {
+        syncWordState = callRadio("begin-sync-word", "US", [&]() {
+          return radio->setSyncWord(0xF1, 0x44);
+        });
+      }
       break;
     case FanetRadioRegion::EUROPE:
-      radioInitState = radio->begin(868.200f, 250.0f, 7U, 5U, 0xF1, 22U, 8U, 1.8f, false);
-      radio->setSyncWord(0xF1, 0x44);
+      logEvent("begin-radio-start", "EUROPE");
+      radioInitState = callRadio("begin-radio", "EUROPE", [&]() {
+        return radio->begin(868.200f, 250.0f, 7U, 5U, 0xF1, 22U, 8U, 1.8f, false);
+      });
+      if (radioInitState == RADIOLIB_ERR_NONE) {
+        syncWordState = callRadio("begin-sync-word", "EUROPE", [&]() {
+          return radio->setSyncWord(0xF1, 0x44);
+        });
+      }
       break;
   }
 
@@ -376,10 +668,17 @@ void FanetRadio::begin(const FanetRadioRegion& region) {
     state = FanetRadioState::FAILED_RADIO_INIT;
     return;
   }
+  if (syncWordState != RADIOLIB_ERR_NONE) {
+    state = FanetRadioState::FAILED_RADIO_INIT;
+    return;
+  }
 
   Serial.println("[FanetRadio] Initialized");
 
-  auto rxState = radio->startReceive();
+  logEvent("begin-start-rx-start", "startReceive");
+  auto rxState = callRadio("begin-start-rx", "startReceive", [&]() {
+    return radio->startReceive();
+  });
   if (rxState != RADIOLIB_ERR_NONE) {
     Serial.println("[FanetRadio] Radio->startReceive failed");
     state = FanetRadioState::FAILED_RADIO_INIT;
@@ -389,16 +688,28 @@ void FanetRadio::begin(const FanetRadioRegion& region) {
 #ifdef LORA_SX1262
   // 1262 radio is different from the WaveShare breadboard modules.
   radio->setRfSwitchPins(SX1262_RF_SW, RADIOLIB_NC);
-  if (radio->setDio2AsRfSwitch() != RADIOLIB_ERR_NONE) {
+  logEvent("begin-dio2-rf-switch-start", "setDio2AsRfSwitch");
+  auto dio2State = callRadio("begin-dio2-rf-switch", "setDio2AsRfSwitch", [&]() {
+    return radio->setDio2AsRfSwitch();
+  });
+  if (dio2State != RADIOLIB_ERR_NONE) {
     state = FanetRadioState::FAILED_RADIO_INIT;
     return;
   }
   // Try to get a few extra db
-  radio->setRxBoostedGainMode(true, true);
+  logEvent("begin-rx-boost-start", "setRxBoostedGainMode");
+  auto boostedGainState = callRadio("begin-rx-boost", "setRxBoostedGainMode", [&]() {
+    return radio->setRxBoostedGainMode(true, true);
+  });
+  if (boostedGainState != RADIOLIB_ERR_NONE) {
+    state = FanetRadioState::FAILED_RADIO_INIT;
+    return;
+  }
 #endif
 
   // We're finished, release the locks.
   state = FanetRadioState::RUNNING;
+  logEvent("begin-end", "running");
   heap_monitor::checkpoint("fanet-begin-end");
 }
 
@@ -407,16 +718,26 @@ void FanetRadio::end() {
   return;  // Model does not support Fanet
 #endif
 
+  logDetectionResult();
   // Short circuit unloading if the radio module is missing.
-  if (state == FanetRadioState::UNINSTALLED) {
+  if (state == FanetRadioState::UNINSTALLED || state == FanetRadioState::FAILED_RADIO_PROBE ||
+      state == FanetRadioState::FAILED_RADIO_INIT || state == FanetRadioState::FAILED_OTHER ||
+      radio == nullptr) {
+    logEvent("end", "radio-unavailable");
     return;
   }
 
-  SpiLockGuard spiLock;
+  SpiLockGuard spiLock(FANET_SPI_LOCK_TIMEOUT_MS, false);
+  if (!spiLock) {
+    logEvent("end", "spi-lock-timeout");
+    return;
+  }
   heap_monitor::checkpoint("fanet-end-start");
-  radio->sleep(false);
+  logEvent("end-sleep-start", "sleep");
+  callRadio("end-sleep", "sleep", [&]() { return radio->sleep(false); });
   state = FanetRadioState::UNINITIALIZED;
   trackingMode = etl::nullopt;  // Reset the tracking mode
+  logEvent("end", "uninitialized");
   heap_monitor::checkpoint("fanet-end-end");
 }
 
@@ -486,10 +807,14 @@ const FANET::Protocol::Stats FanetRadio::getStats() const {
   if (state != FanetRadioState::RUNNING) return {};
 
   LockGuard lock(x_fanet_manager_mutex);
+  if (!lock) return {};
   return protocol->stats();
 }
 
 const FanetNeighbors::NeighborMap& FanetRadio::getNeighborTable() const {
+  if (state != FanetRadioState::RUNNING || x_fanet_manager_mutex == nullptr) {
+    return neighbors.get();
+  }
   LockGuard lock(x_fanet_manager_mutex);
   return neighbors.get();
 }

--- a/src/vario/comms/fanet_radio.h
+++ b/src/vario/comms/fanet_radio.h
@@ -63,6 +63,9 @@ class FanetRadio : public etl::message_router<FanetRadio, GpsReading>,
   // Request to cleanly stop the radio module
   void end();
 
+  // Logs the cached boot-time detection result once system event logging is available.
+  void logDetectionResult();
+
   // Returns the current state of the radio module
   FanetRadioState getState();
 
@@ -100,8 +103,39 @@ class FanetRadio : public etl::message_router<FanetRadio, GpsReading>,
 
   // detect phyiscal presence of the FANET (LoRa SX1262) module
   bool detectFanet(void);
+  bool probeFanetSpi(void);
+  bool waitFanetReady(uint32_t timeoutMs) const;
+  bool radioUnavailable(void) const;
+  bool shouldMarkRadioUnhealthy(int16_t code) const;
+  void markRadioUnhealthy(const char* event, int16_t code);
+  void logProbeResult();
+  void logEvent(const char* event, const String& detail = String(), const char* key = nullptr,
+                int32_t value = 0, bool hasValue = false);
+  void logEventCode(const char* event, const String& detail, const int16_t code);
+  template <typename Fn>
+  int16_t callRadio(const char* event, const String& detail, Fn fn,
+                    bool markUnhealthyOnFailure = true) {
+    const uint32_t startMs = millis();
+    const int16_t result = fn();
+    const uint32_t elapsedMs = millis() - startMs;
+    logEventCode(event, result == RADIOLIB_ERR_NONE ? "ok" : detail, result);
+    const String durationEvent = String(event) + "-ms";
+    logEvent(durationEvent.c_str(), detail, "elapsed", static_cast<int32_t>(elapsedMs), true);
+    if (markUnhealthyOnFailure && shouldMarkRadioUnhealthy(result)) {
+      markRadioUnhealthy(event, result);
+    }
+    return result;
+  }
 
   FanetRadioState state = FanetRadioState::UNINITIALIZED;  // The current state of the radio module
+  bool fanetDetected_ = false;
+  bool detectionResultLogged_ = false;
+  uint8_t detectionCycles_ = 0;
+  bool fanetSpiProbed_ = false;
+  bool fanetSpiProbeOk_ = false;
+  bool probeResultLogged_ = false;
+  uint8_t probeStatus_ = 0;
+  String probeDetail_;
 
   // Delete copy constructor and copy assignment operator
   FanetRadio(const FanetRadio&) = delete;

--- a/src/vario/comms/fanet_radio_types.h
+++ b/src/vario/comms/fanet_radio_types.h
@@ -35,18 +35,23 @@ struct FanetRadioState {
     // Radio initialization failed (eg. SPI bus failure)
     FAILED_RADIO_INIT,
 
+    // The BUSY pin indicated a possible module, but a bounded SPI probe failed.
+    FAILED_RADIO_PROBE,
+
     // Failed for another reason (needs Serial debugging?)
     FAILED_OTHER,
 
     // Radio is running and ready to rx/tx messages
     RUNNING,
   };
-  static constexpr size_t size = 5;
+  static constexpr size_t size = 7;
 
   ETL_DECLARE_ENUM_TYPE(FanetRadioState, uint8_t)
+  ETL_ENUM_TYPE(UNINSTALLED, "UNINSTALLED")
   ETL_ENUM_TYPE(UNINITIALIZED, "UNINITIALIZED")
   ETL_ENUM_TYPE(INITIALIZING, "INITIALIZING")
   ETL_ENUM_TYPE(FAILED_RADIO_INIT, "FAILED_RADIO_INIT")
+  ETL_ENUM_TYPE(FAILED_RADIO_PROBE, "FAILED_RADIO_PROBE")
   ETL_ENUM_TYPE(FAILED_OTHER, "FAILED_OTHER")
   ETL_ENUM_TYPE(RUNNING, "RUNNING")
   ETL_END_ENUM_TYPE

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -107,7 +107,9 @@ namespace {
   size_t nav_upload_bytes = 0;
   uint32_t web_request_sequence = 0;
 
-  bool diagnosticsEnabled() { return diagnostic_logs::enabled(diagnostic_logs::Log::NetworkEvents); }
+  bool diagnosticsEnabled() {
+    return diagnostic_logs::enabled(diagnostic_logs::Log::NetworkEvents);
+  }
 
   bool webRequestDiagnosticsEnabled() {
     return diagnostic_logs::enabled(diagnostic_logs::Log::WebRequests);
@@ -310,13 +312,13 @@ namespace {
     printCsvString(file, ssid);
     file.print(',');
     printCsvString(file, wifi_setup_connect_error);
-    file.printf(",%lu,%lu,%lu,%d,%u,%lu,%lu,",
-                static_cast<unsigned long>(wifiSetupConnectedElapsedMs()),
-                static_cast<unsigned long>(wifi_setup_connect_started_ms),
-                static_cast<unsigned long>(wifi_setup_connected_ms),
-                static_cast<int>(wifi_setup_last_scan_result), leaf_wifi::diagnosticsAllowed() ? 1 : 0,
-                static_cast<unsigned long>(ESP.getFreeHeap()),
-                static_cast<unsigned long>(ESP.getMaxAllocHeap()));
+    file.printf(
+        ",%lu,%lu,%lu,%d,%u,%lu,%lu,", static_cast<unsigned long>(wifiSetupConnectedElapsedMs()),
+        static_cast<unsigned long>(wifi_setup_connect_started_ms),
+        static_cast<unsigned long>(wifi_setup_connected_ms),
+        static_cast<int>(wifi_setup_last_scan_result), leaf_wifi::diagnosticsAllowed() ? 1 : 0,
+        static_cast<unsigned long>(ESP.getFreeHeap()),
+        static_cast<unsigned long>(ESP.getMaxAllocHeap()));
     printCsvString(file, pcTaskGetName(NULL));
     file.println(",,,,,,,,,,,,,");
     file.close();
@@ -352,10 +354,9 @@ namespace {
     file.printf("%lu,", static_cast<unsigned long>(millis()));
     printCsvString(file, event ? String(event) : String(""));
     file.print(",webapp,,,,");
-    file.printf("%u,%u,%u,,,%d,%d,%d,%u,%u,",
-                user_app_enabled ? 1 : 0, user_app_using_leaf_wifi ? 1 : 0,
-                user_app_provisioning ? 1 : 0, static_cast<int>(WiFi.status()),
-                static_cast<int>(WiFi.getMode()), WiFi.RSSI(),
+    file.printf("%u,%u,%u,,,%d,%d,%d,%u,%u,", user_app_enabled ? 1 : 0,
+                user_app_using_leaf_wifi ? 1 : 0, user_app_provisioning ? 1 : 0,
+                static_cast<int>(WiFi.status()), static_cast<int>(WiFi.getMode()), WiFi.RSSI(),
                 static_cast<unsigned int>(WiFi.softAPgetStationNum()),
                 static_cast<unsigned int>(user_app_max_ap_stations));
     printCsvString(file, WiFi.localIP().toString());
@@ -2052,10 +2053,10 @@ load();
     user_app_always_on = extractJsonBoolValue(body, "always_on", user_app_always_on);
     user_app_keep_bluetooth_disabled =
         extractJsonBoolValue(body, "keep_bluetooth_disabled", user_app_keep_bluetooth_disabled);
-    settings.diag_systemEvents = extractJsonBoolValue(body, "diag_system_events",
-                                                      settings.diag_systemEvents);
-    settings.diag_networkEvents = extractJsonBoolValue(body, "diag_network_events",
-                                                       settings.diag_networkEvents);
+    settings.diag_systemEvents =
+        extractJsonBoolValue(body, "diag_system_events", settings.diag_systemEvents);
+    settings.diag_networkEvents =
+        extractJsonBoolValue(body, "diag_network_events", settings.diag_networkEvents);
     settings.diag_webRequests =
         extractJsonBoolValue(body, "diag_web_requests", settings.diag_webRequests);
     settings.diag_vario = extractJsonBoolValue(body, "diag_vario", settings.diag_vario);

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -14,6 +14,7 @@
 #include "comms/fanet_radio.h"
 #include "comms/ota.h"
 #include "comms/wifi_coordinator.h"
+#include "diagnostics/diagnostic_logs.h"
 #include "diagnostics/heap_monitor.h"
 #include "diagnostics/memory_report.h"
 #include "diagnostics/self_test/selfTest.h"
@@ -89,10 +90,6 @@ namespace {
   static constexpr const char* PROFILE_BACKUP_FILE = "/profiles/profiles.bak";
   static constexpr const char* WAYPOINTS_DIR = "/waypoints";
   static constexpr const char* NAV_UPLOAD_TEMP_FILE = "/waypoints/upload.tmp";
-  static constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
-  static constexpr const char* USER_APP_DIAGNOSTICS_FILE = "/diagnostics/webapp_requests.csv";
-  static constexpr const char* WEB_REQUEST_DIAGNOSTICS_FILE = "/diagnostics/web_requests.csv";
-  static constexpr const char* WIFI_SETUP_DIAGNOSTICS_FILE = "/diagnostics/wifi_setup.csv";
   static constexpr size_t WIFI_SETUP_NETWORKS_JSON_RESERVE = 896;
   static constexpr uint32_t WEB_REQUEST_SLOW_MS = 1000;
 
@@ -110,7 +107,11 @@ namespace {
   size_t nav_upload_bytes = 0;
   uint32_t web_request_sequence = 0;
 
-  bool diagnosticsEnabled() { return settings.dev_mode; }
+  bool diagnosticsEnabled() { return diagnostic_logs::enabled(diagnostic_logs::Log::NetworkEvents); }
+
+  bool webRequestDiagnosticsEnabled() {
+    return diagnostic_logs::enabled(diagnostic_logs::Log::WebRequests);
+  }
 
   bool connectedToDiagnosticWifi() {
     return WiFi.status() == WL_CONNECTED && WiFi.SSID() == "LeafDiagnostics";
@@ -175,6 +176,17 @@ namespace {
     file.print('"');
   }
 
+  void writeNetworkEventsHeaderIfNeeded(File& file, bool existed) {
+    if (existed && file.size() > 0) return;
+    file.println(
+        "millis,event,mode,cycle,attempt_index,saved_count,enabled,using_leaf_wifi,provisioning,"
+        "connecting,ready,wifi_status,wifi_mode,rssi,ap_stations,max_ap_stations,local_ip,ap_ip,"
+        "target_ssid,current_ssid,connect_error,elapsed_ms,connect_started_ms,connected_ms,"
+        "last_scan_result,diagnostics_allowed,free_heap,max_alloc_heap,current_task,loop_count,"
+        "handle_count,root,app,status,profiles_get,profiles_put,logbook,logbook_entry,"
+        "logbook_delete,waypoints_upload,routes_import,not_found");
+  }
+
   const char* httpMethodName(HTTPMethod method) {
     switch (method) {
       case HTTP_GET:
@@ -196,11 +208,11 @@ namespace {
 
   void appendWebRequestDiagnostics(const char* event, uint32_t sequence, const char* route,
                                    uint32_t startedMs, uint32_t durationMs) {
-    if (!diagnosticsEnabled()) return;
-    if (!SD_MMC.exists(DIAGNOSTICS_DIR)) SD_MMC.mkdir(DIAGNOSTICS_DIR);
+    if (!webRequestDiagnosticsEnabled()) return;
+    if (!diagnostic_logs::ensureDirectory()) return;
 
-    const bool existed = SD_MMC.exists(WEB_REQUEST_DIAGNOSTICS_FILE);
-    File file = SD_MMC.open(WEB_REQUEST_DIAGNOSTICS_FILE, "a", true);
+    const bool existed = SD_MMC.exists(diagnostic_logs::WEB_REQUESTS_PATH);
+    File file = SD_MMC.open(diagnostic_logs::WEB_REQUESTS_PATH, "a", true);
     if (!file) return;
 
     if (!existed || file.size() == 0) {
@@ -234,7 +246,7 @@ namespace {
 
   template <typename Handler>
   void handleUserRequest(const char* route, Handler handler) {
-    if (!diagnosticsEnabled()) {
+    if (!webRequestDiagnosticsEnabled()) {
       handler();
       return;
     }
@@ -273,41 +285,40 @@ namespace {
         static_cast<unsigned long>(wifiSetupConnectedElapsedMs()),
         wifi_setup_connect_error.c_str());
 
-    if (!SD_MMC.exists(DIAGNOSTICS_DIR)) SD_MMC.mkdir(DIAGNOSTICS_DIR);
-    const bool existed = SD_MMC.exists(WIFI_SETUP_DIAGNOSTICS_FILE);
-    File file = SD_MMC.open(WIFI_SETUP_DIAGNOSTICS_FILE, "a", true);
+    if (!diagnostic_logs::ensureDirectory()) return;
+    const bool existed = SD_MMC.exists(diagnostic_logs::NETWORK_EVENTS_PATH);
+    File file = SD_MMC.open(diagnostic_logs::NETWORK_EVENTS_PATH, "a", true);
     if (!file) return;
 
-    if (!existed || file.size() == 0) {
-      file.println(
-          "millis,event,cycle,enabled,using_leaf_wifi,provisioning,connecting,ready,wifi_status,"
-          "wifi_mode,ap_stations,local_ip,ap_ip,ssid,target_ssid,connect_error,"
-          "connect_started_ms,connected_ms,connected_elapsed_ms,last_scan_result,free_heap,"
-          "max_alloc_heap");
-    }
+    writeNetworkEventsHeaderIfNeeded(file, existed);
 
     file.printf("%lu,", static_cast<unsigned long>(now));
     printCsvString(file, event ? String(event) : String(""));
-    file.printf(",%lu,%u,%u,%u,%u,%u,%d,%d,%u,", static_cast<unsigned long>(wifi_setup_cycle),
-                user_app_enabled ? 1 : 0, user_app_using_leaf_wifi ? 1 : 0,
-                user_app_provisioning ? 1 : 0, wifi_setup_connecting ? 1 : 0, ready ? 1 : 0,
-                wifi_status, wifi_mode, static_cast<unsigned int>(ap_stations));
+    file.print(",wifi_setup");
+    file.printf(",%lu,,,%u,%u,%u,%u,%u,%d,%d,%d,%u,%u,",
+                static_cast<unsigned long>(wifi_setup_cycle), user_app_enabled ? 1 : 0,
+                user_app_using_leaf_wifi ? 1 : 0, user_app_provisioning ? 1 : 0,
+                wifi_setup_connecting ? 1 : 0, ready ? 1 : 0, wifi_status, wifi_mode, WiFi.RSSI(),
+                static_cast<unsigned int>(ap_stations),
+                static_cast<unsigned int>(user_app_max_ap_stations));
     printCsvString(file, local_ip);
     file.print(',');
     printCsvString(file, ap_ip);
     file.print(',');
-    printCsvString(file, ssid);
-    file.print(',');
     printCsvString(file, wifi_setup_connect_ssid);
     file.print(',');
+    printCsvString(file, ssid);
+    file.print(',');
     printCsvString(file, wifi_setup_connect_error);
-    file.printf(",%lu,%lu,%lu,%d,%lu,%lu\n",
+    file.printf(",%lu,%lu,%lu,%d,%u,%lu,%lu,",
+                static_cast<unsigned long>(wifiSetupConnectedElapsedMs()),
                 static_cast<unsigned long>(wifi_setup_connect_started_ms),
                 static_cast<unsigned long>(wifi_setup_connected_ms),
-                static_cast<unsigned long>(wifiSetupConnectedElapsedMs()),
-                static_cast<int>(wifi_setup_last_scan_result),
+                static_cast<int>(wifi_setup_last_scan_result), leaf_wifi::diagnosticsAllowed() ? 1 : 0,
                 static_cast<unsigned long>(ESP.getFreeHeap()),
                 static_cast<unsigned long>(ESP.getMaxAllocHeap()));
+    printCsvString(file, pcTaskGetName(NULL));
+    file.println(",,,,,,,,,,,,,");
     file.close();
   }
 
@@ -328,44 +339,47 @@ namespace {
 
   void dumpUserAppCounters(const char* event) {
     if (!diagnosticsEnabled()) return;
-    if (!SD_MMC.exists(DIAGNOSTICS_DIR)) SD_MMC.mkdir(DIAGNOSTICS_DIR);
+    if (!diagnostic_logs::ensureDirectory()) return;
 
-    const bool existed = SD_MMC.exists(USER_APP_DIAGNOSTICS_FILE);
-    File file = SD_MMC.open(USER_APP_DIAGNOSTICS_FILE, "a", true);
+    const bool existed = SD_MMC.exists(diagnostic_logs::NETWORK_EVENTS_PATH);
+    File file = SD_MMC.open(diagnostic_logs::NETWORK_EVENTS_PATH, "a", true);
     if (!file) return;
 
-    if (!existed || file.size() == 0) {
-      file.println(
-          "millis,event,enabled,using_leaf_wifi,user_server_started,debug_routes_configured,"
-          "ap_stations,max_ap_stations,wifi_status,free_heap,max_alloc_heap,loop_count,"
-          "handle_count,root,app,status,profiles_get,profiles_put,logbook,logbook_entry,"
-          "logbook_delete,waypoints_upload,routes_import,not_found,ap_ip");
-    }
+    writeNetworkEventsHeaderIfNeeded(file, existed);
 
     updateUserAppStationPeak();
     const String ap_ip = WiFi.softAPIP().toString();
-    file.printf(
-        "%lu,%s,%u,%u,%u,%u,%u,%u,%d,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%"
-        "s\n",
-        static_cast<unsigned long>(millis()), event ? event : "", user_app_enabled ? 1 : 0,
-        user_app_using_leaf_wifi ? 1 : 0, user_server_started ? 1 : 0,
-        debug_routes_configured ? 1 : 0, static_cast<unsigned int>(WiFi.softAPgetStationNum()),
-        static_cast<unsigned int>(user_app_max_ap_stations), static_cast<int>(WiFi.status()),
-        static_cast<unsigned long>(ESP.getFreeHeap()),
-        static_cast<unsigned long>(ESP.getMaxAllocHeap()),
-        static_cast<unsigned long>(user_app_loop_count),
-        static_cast<unsigned long>(user_app_handle_count),
-        static_cast<unsigned long>(user_app_route_root_count),
-        static_cast<unsigned long>(user_app_route_app_count),
-        static_cast<unsigned long>(user_app_route_status_count),
-        static_cast<unsigned long>(user_app_route_profiles_get_count),
-        static_cast<unsigned long>(user_app_route_profiles_put_count),
-        static_cast<unsigned long>(user_app_route_logbook_count),
-        static_cast<unsigned long>(user_app_route_logbook_entry_count),
-        static_cast<unsigned long>(user_app_route_logbook_delete_count),
-        static_cast<unsigned long>(user_app_route_waypoints_upload_count),
-        static_cast<unsigned long>(user_app_route_routes_import_count),
-        static_cast<unsigned long>(user_app_route_not_found_count), ap_ip.c_str());
+    file.printf("%lu,", static_cast<unsigned long>(millis()));
+    printCsvString(file, event ? String(event) : String(""));
+    file.print(",webapp,,,,");
+    file.printf("%u,%u,%u,,,%d,%d,%d,%u,%u,",
+                user_app_enabled ? 1 : 0, user_app_using_leaf_wifi ? 1 : 0,
+                user_app_provisioning ? 1 : 0, static_cast<int>(WiFi.status()),
+                static_cast<int>(WiFi.getMode()), WiFi.RSSI(),
+                static_cast<unsigned int>(WiFi.softAPgetStationNum()),
+                static_cast<unsigned int>(user_app_max_ap_stations));
+    printCsvString(file, WiFi.localIP().toString());
+    file.print(',');
+    printCsvString(file, ap_ip);
+    file.print(",,,,,,,");
+    file.printf("%u,%lu,%lu,", leaf_wifi::diagnosticsAllowed() ? 1 : 0,
+                static_cast<unsigned long>(ESP.getFreeHeap()),
+                static_cast<unsigned long>(ESP.getMaxAllocHeap()));
+    printCsvString(file, pcTaskGetName(NULL));
+    file.printf(",%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu\n",
+                static_cast<unsigned long>(user_app_loop_count),
+                static_cast<unsigned long>(user_app_handle_count),
+                static_cast<unsigned long>(user_app_route_root_count),
+                static_cast<unsigned long>(user_app_route_app_count),
+                static_cast<unsigned long>(user_app_route_status_count),
+                static_cast<unsigned long>(user_app_route_profiles_get_count),
+                static_cast<unsigned long>(user_app_route_profiles_put_count),
+                static_cast<unsigned long>(user_app_route_logbook_count),
+                static_cast<unsigned long>(user_app_route_logbook_entry_count),
+                static_cast<unsigned long>(user_app_route_logbook_delete_count),
+                static_cast<unsigned long>(user_app_route_waypoints_upload_count),
+                static_cast<unsigned long>(user_app_route_routes_import_count),
+                static_cast<unsigned long>(user_app_route_not_found_count));
     file.close();
   }
 
@@ -1937,10 +1951,10 @@ let s=el("section",{id:"developerCard"}),h=el("h2",{text:"Developer"}),status=el
 let shot=el("button",{class:"hero",id:"devScreenshot",text:"Screenshot"}),msc=el("button",{class:"secondary",id:"devMassStorage",text:"Mass Storage"}),mem=el("button",{class:"secondary",id:"devMemory",text:"Memory"}),fan=el("button",{class:"secondary",id:"devFanet",text:"FANET"});
 actions.style.flexWrap="wrap";
 actions.appendChild(shot);actions.appendChild(msc);actions.appendChild(mem);actions.appendChild(fan);
-s.appendChild(h);s.appendChild(status);s.appendChild(row("Keep web app on","devAlwaysOn"));s.appendChild(row("Keep Bluetooth disabled","devKeepBleDisabled"));s.appendChild(actions);s.appendChild(msgEl);main.appendChild(s);
-async function load(){try{let r=await Promise.all([fetch("/api/debug/session"),fetch("/api/user/status")]),d=await r[0].json(),u=await r[1].json();document.getElementById("devAlwaysOn").checked=!!d.always_on;document.getElementById("devKeepBleDisabled").checked=!!d.keep_bluetooth_disabled;status.textContent="web app: "+(d.web_app_active?"active":"off")+"\\nmode: "+(d.using_leaf_wifi?"Leaf AP":"network")+"\\nfirmware: "+(u.firmware_display_version||u.firmware_version||"")+"\\nmac: "+(u.mac_address||"")}catch(e){status.textContent="Developer controls unavailable."}}
-async function save(){msg("Saving...");try{let body={always_on:document.getElementById("devAlwaysOn").checked,keep_bluetooth_disabled:document.getElementById("devKeepBleDisabled").checked};await fetch("/api/debug/session",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});msg("Saved for this session.");load()}catch(e){msg("Unable to save developer settings.")}}
-document.getElementById("devAlwaysOn").onchange=save;document.getElementById("devKeepBleDisabled").onchange=save;
+s.appendChild(h);s.appendChild(status);s.appendChild(row("Keep web app on","devAlwaysOn"));s.appendChild(row("Keep Bluetooth disabled","devKeepBleDisabled"));s.appendChild(row("System events log","devDiagSystem"));s.appendChild(row("Network events log","devDiagNetwork"));s.appendChild(row("Web requests log","devDiagWeb"));s.appendChild(row("Vario log","devDiagVario"));s.appendChild(actions);s.appendChild(msgEl);main.appendChild(s);
+async function load(){try{let r=await Promise.all([fetch("/api/debug/session"),fetch("/api/user/status")]),d=await r[0].json(),u=await r[1].json();document.getElementById("devAlwaysOn").checked=!!d.always_on;document.getElementById("devKeepBleDisabled").checked=!!d.keep_bluetooth_disabled;document.getElementById("devDiagSystem").checked=!!d.diag_system_events;document.getElementById("devDiagNetwork").checked=!!d.diag_network_events;document.getElementById("devDiagWeb").checked=!!d.diag_web_requests;document.getElementById("devDiagVario").checked=!!d.diag_vario;status.textContent="web app: "+(d.web_app_active?"active":"off")+"\\nmode: "+(d.using_leaf_wifi?"Leaf AP":"network")+"\\nfirmware: "+(u.firmware_display_version||u.firmware_version||"")+"\\nmac: "+(u.mac_address||"")}catch(e){status.textContent="Developer controls unavailable."}}
+async function save(){msg("Saving...");try{let body={always_on:document.getElementById("devAlwaysOn").checked,keep_bluetooth_disabled:document.getElementById("devKeepBleDisabled").checked,diag_system_events:document.getElementById("devDiagSystem").checked,diag_network_events:document.getElementById("devDiagNetwork").checked,diag_web_requests:document.getElementById("devDiagWeb").checked,diag_vario:document.getElementById("devDiagVario").checked};await fetch("/api/debug/session",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});msg("Saved.");load()}catch(e){msg("Unable to save developer settings.")}}
+["devAlwaysOn","devKeepBleDisabled","devDiagSystem","devDiagNetwork","devDiagWeb","devDiagVario"].forEach(id=>document.getElementById(id).onchange=save);
 shot.onclick=()=>window.open("/app/debug/screenshot","_blank","noopener");
 mem.onclick=()=>window.open("/app/debug/memory","_blank","noopener");
 fan.onclick=()=>window.open("/app/debug/fanet","_blank","noopener");
@@ -2020,6 +2034,14 @@ load();
     json += user_app_enabled ? "true" : "false";
     json += ",\"using_leaf_wifi\":";
     json += user_app_using_leaf_wifi ? "true" : "false";
+    json += ",\"diag_system_events\":";
+    json += settings.diag_systemEvents ? "true" : "false";
+    json += ",\"diag_network_events\":";
+    json += settings.diag_networkEvents ? "true" : "false";
+    json += ",\"diag_web_requests\":";
+    json += settings.diag_webRequests ? "true" : "false";
+    json += ",\"diag_vario\":";
+    json += settings.diag_vario ? "true" : "false";
     json += "}";
     sendNoStoreHeaders(target);
     target.send(200, "application/json", json);
@@ -2030,6 +2052,14 @@ load();
     user_app_always_on = extractJsonBoolValue(body, "always_on", user_app_always_on);
     user_app_keep_bluetooth_disabled =
         extractJsonBoolValue(body, "keep_bluetooth_disabled", user_app_keep_bluetooth_disabled);
+    settings.diag_systemEvents = extractJsonBoolValue(body, "diag_system_events",
+                                                      settings.diag_systemEvents);
+    settings.diag_networkEvents = extractJsonBoolValue(body, "diag_network_events",
+                                                       settings.diag_networkEvents);
+    settings.diag_webRequests =
+        extractJsonBoolValue(body, "diag_web_requests", settings.diag_webRequests);
+    settings.diag_vario = extractJsonBoolValue(body, "diag_vario", settings.diag_vario);
+    settings.save();
     sendDebugSessionStatus(target);
   }
 

--- a/src/vario/comms/wifi_coordinator.cpp
+++ b/src/vario/comms/wifi_coordinator.cpp
@@ -8,6 +8,7 @@
 #include <esp_wifi.h>
 #include <cstring>
 
+#include "diagnostics/diagnostic_logs.h"
 #include "ui/settings/settings.h"
 
 namespace leaf_wifi {
@@ -40,14 +41,14 @@ namespace leaf_wifi {
     constexpr uint32_t SAVED_NETWORK_CONNECT_MS = 5000;
     constexpr uint8_t SAVED_NETWORK_SCHEMA_VERSION = 1;
     constexpr const char* WIFI_CREDENTIALS_NAMESPACE = "leafWifi";
-    constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
-    constexpr const char* WIFI_AUTOCONNECT_DIAGNOSTICS_FILE = "/diagnostics/wifi_autoconnect.csv";
 
     void settleWifi() { delay(WIFI_SETTLE_MS); }
 
     void hardSettleWifi() { delay(WIFI_HARD_RESET_SETTLE_MS); }
 
-    bool diagnosticsEnabled() { return settings.dev_mode; }
+    bool diagnosticsEnabled() {
+      return diagnostic_logs::enabled(diagnostic_logs::Log::NetworkEvents);
+    }
 
     void printCsvString(File& file, const String& value) {
       file.print('"');
@@ -61,17 +62,21 @@ namespace leaf_wifi {
     void appendAutoConnectDiagnostics(const char* event, const String& target_ssid = String(),
                                       uint8_t saved_count = saved_network_count) {
       if (!diagnosticsEnabled()) return;
-      if (!SD_MMC.exists(DIAGNOSTICS_DIR)) SD_MMC.mkdir(DIAGNOSTICS_DIR);
+      if (!diagnostic_logs::ensureDirectory()) return;
 
-      const bool existed = SD_MMC.exists(WIFI_AUTOCONNECT_DIAGNOSTICS_FILE);
-      File file = SD_MMC.open(WIFI_AUTOCONNECT_DIAGNOSTICS_FILE, "a", true);
+      const bool existed = SD_MMC.exists(diagnostic_logs::NETWORK_EVENTS_PATH);
+      File file = SD_MMC.open(diagnostic_logs::NETWORK_EVENTS_PATH, "a", true);
       if (!file) return;
 
       if (!existed || file.size() == 0) {
         file.println(
-            "millis,event,cycle,attempt_index,saved_count,elapsed_ms,target_ssid,current_ssid,"
-            "wifi_status,wifi_mode,rssi,local_ip,diagnostics_allowed,free_heap,max_alloc_heap,"
-            "current_task");
+            "millis,event,mode,cycle,attempt_index,saved_count,enabled,using_leaf_wifi,"
+            "provisioning,connecting,ready,wifi_status,wifi_mode,rssi,ap_stations,"
+            "max_ap_stations,local_ip,ap_ip,target_ssid,current_ssid,connect_error,elapsed_ms,"
+            "connect_started_ms,connected_ms,last_scan_result,diagnostics_allowed,free_heap,"
+            "max_alloc_heap,current_task,loop_count,handle_count,root,app,status,profiles_get,"
+            "profiles_put,logbook,logbook_entry,logbook_delete,waypoints_upload,routes_import,"
+            "not_found");
       }
 
       const uint32_t now = millis();
@@ -81,20 +86,27 @@ namespace leaf_wifi {
 
       file.printf("%lu,", static_cast<unsigned long>(now));
       printCsvString(file, event ? String(event) : String(""));
-      file.printf(",%lu,%u,%u,%lu,", static_cast<unsigned long>(saved_network_cycle),
+      file.printf(",wifi_autoconnect,%lu,%u,%u,,,,,,%d,%d,%d,,,",
+                  static_cast<unsigned long>(saved_network_cycle),
                   static_cast<unsigned int>(saved_network_connect_index),
-                  static_cast<unsigned int>(saved_count), static_cast<unsigned long>(elapsed));
+                  static_cast<unsigned int>(saved_count), static_cast<int>(WiFi.status()),
+                  static_cast<int>(WiFi.getMode()), rssi);
+      printCsvString(file, WiFi.localIP().toString());
+      file.print(',');
+      printCsvString(file, String(""));
+      file.print(',');
       printCsvString(file, target_ssid);
       file.print(',');
       printCsvString(file, WiFi.SSID());
-      file.printf(",%d,%d,%d,", static_cast<int>(WiFi.status()), static_cast<int>(WiFi.getMode()),
-                  rssi);
-      printCsvString(file, WiFi.localIP().toString());
-      file.printf(",%u,%lu,%lu,", diagnosticsAllowed() ? 1 : 0,
+      file.print(',');
+      printCsvString(file, String(""));
+      file.printf(",%lu,%lu,,,%u,%lu,%lu,", static_cast<unsigned long>(elapsed),
+                  static_cast<unsigned long>(saved_network_connect_started_ms),
+                  diagnosticsAllowed() ? 1 : 0,
                   static_cast<unsigned long>(ESP.getFreeHeap()),
                   static_cast<unsigned long>(ESP.getMaxAllocHeap()));
       printCsvString(file, pcTaskGetName(NULL));
-      file.println();
+      file.println(",,,,,,,,,,,,,");
       file.close();
     }
 

--- a/src/vario/comms/wifi_coordinator.cpp
+++ b/src/vario/comms/wifi_coordinator.cpp
@@ -102,8 +102,7 @@ namespace leaf_wifi {
       printCsvString(file, String(""));
       file.printf(",%lu,%lu,,,%u,%lu,%lu,", static_cast<unsigned long>(elapsed),
                   static_cast<unsigned long>(saved_network_connect_started_ms),
-                  diagnosticsAllowed() ? 1 : 0,
-                  static_cast<unsigned long>(ESP.getFreeHeap()),
+                  diagnosticsAllowed() ? 1 : 0, static_cast<unsigned long>(ESP.getFreeHeap()),
                   static_cast<unsigned long>(ESP.getMaxAllocHeap()));
       printCsvString(file, pcTaskGetName(NULL));
       file.println(",,,,,,,,,,,,,");

--- a/src/vario/diagnostics/boot_diagnostics.cpp
+++ b/src/vario/diagnostics/boot_diagnostics.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <SD_MMC.h>
 
+#include "diagnostics/diagnostic_logs.h"
 #include "diagnostics/heap_monitor.h"
 #include "esp_system.h"
 #include "navigation/gpx.h"
@@ -10,9 +11,6 @@
 
 namespace boot_diagnostics {
   namespace {
-    constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
-    constexpr const char* BOOT_REPORT_PATH = "/diagnostics/boot_report.csv";
-
     esp_reset_reason_t resetReason = ESP_RST_UNKNOWN;
     bool resetReasonCaptured = false;
     bool reportsWritten = false;
@@ -55,20 +53,20 @@ namespace boot_diagnostics {
       }
     }
 
-    bool ensureDiagnosticsDirectory() {
-      if (SD_MMC.exists(DIAGNOSTICS_DIR)) return true;
-      return SD_MMC.mkdir(DIAGNOSTICS_DIR);
-    }
-
     void writeHeaderIfNeeded(File& file, bool existed) {
       if (existed && file.size() > 0) return;
-      file.println("millis,section,key,value,detail");
+      file.println(
+          "millis,source,event,detail,key,value,free_heap,min_free_heap,largest_free_block,"
+          "max_alloc_heap,internal_free,internal_largest,psram_free,psram_largest,current_task,"
+          "stack_high_water,loop_stack_high_water,ble_stack_high_water,"
+          "fanet_tx_stack_high_water,fanet_rx_stack_high_water");
     }
 
     void writeRow(File& file, const char* section, const char* key, size_t value,
                   const char* detail) {
-      file.printf("%lu,%s,%s,%lu,%s\n", static_cast<unsigned long>(millis()), section, key,
-                  static_cast<unsigned long>(value), detail ? detail : "");
+      file.printf("%lu,boot,%s,", static_cast<unsigned long>(millis()), section);
+      diagnostic_logs::printCsvString(file, detail ? String(detail) : String(""));
+      file.printf(",%s,%lu,,,,,,,,,,,,,,\n", key, static_cast<unsigned long>(value));
     }
 
     void writeNavSizeReport(File& file) {
@@ -110,10 +108,12 @@ namespace boot_diagnostics {
   }
 
   void writeReportsToSd() {
-    if (!settings.dev_mode || reportsWritten || !ensureDiagnosticsDirectory()) return;
+    if (!diagnostic_logs::enabled(diagnostic_logs::Log::SystemEvents) || reportsWritten ||
+        !diagnostic_logs::ensureDirectory())
+      return;
 
-    const bool existed = SD_MMC.exists(BOOT_REPORT_PATH);
-    File file = SD_MMC.open(BOOT_REPORT_PATH, "a", true);
+    const bool existed = SD_MMC.exists(diagnostic_logs::SYSTEM_EVENTS_PATH);
+    File file = SD_MMC.open(diagnostic_logs::SYSTEM_EVENTS_PATH, "a", true);
     if (!file) return;
 
     writeHeaderIfNeeded(file, existed);

--- a/src/vario/diagnostics/diagnostic_logs.cpp
+++ b/src/vario/diagnostics/diagnostic_logs.cpp
@@ -1,0 +1,39 @@
+#include "diagnostics/diagnostic_logs.h"
+
+#include <SD_MMC.h>
+
+#include "ui/settings/settings.h"
+
+namespace diagnostic_logs {
+
+  bool enabled(Log log) {
+    if (!settings.dev_mode) return false;
+
+    switch (log) {
+      case Log::SystemEvents:
+        return settings.diag_systemEvents;
+      case Log::NetworkEvents:
+        return settings.diag_networkEvents;
+      case Log::WebRequests:
+        return settings.diag_webRequests;
+      case Log::Vario:
+        return settings.diag_vario;
+    }
+    return false;
+  }
+
+  bool ensureDirectory() {
+    if (SD_MMC.exists(DIAGNOSTICS_DIR)) return true;
+    return SD_MMC.mkdir(DIAGNOSTICS_DIR);
+  }
+
+  void printCsvString(File& file, const String& value) {
+    file.print('"');
+    for (size_t i = 0; i < value.length(); i++) {
+      if (value[i] == '"') file.print('"');
+      file.print(value[i]);
+    }
+    file.print('"');
+  }
+
+}  // namespace diagnostic_logs

--- a/src/vario/diagnostics/diagnostic_logs.cpp
+++ b/src/vario/diagnostics/diagnostic_logs.cpp
@@ -27,6 +27,15 @@ namespace diagnostic_logs {
     return SD_MMC.mkdir(DIAGNOSTICS_DIR);
   }
 
+  void writeSystemEventsHeaderIfNeeded(File& file, bool existed) {
+    if (existed && file.size() > 0) return;
+    file.println(
+        "millis,source,event,detail,key,value,free_heap,min_free_heap,largest_free_block,"
+        "max_alloc_heap,internal_free,internal_largest,psram_free,psram_largest,current_task,"
+        "stack_high_water,loop_stack_high_water,ble_stack_high_water,"
+        "fanet_tx_stack_high_water,fanet_rx_stack_high_water");
+  }
+
   void printCsvString(File& file, const String& value) {
     file.print('"');
     for (size_t i = 0; i < value.length(); i++) {
@@ -34,6 +43,33 @@ namespace diagnostic_logs {
       file.print(value[i]);
     }
     file.print('"');
+  }
+
+  bool appendSystemEvent(const char* source, const char* event, const String& detail,
+                         const char* key, int32_t value, bool hasValue) {
+    if (!enabled(Log::SystemEvents)) return false;
+    if (!ensureDirectory()) return false;
+
+    const bool existed = SD_MMC.exists(SYSTEM_EVENTS_PATH);
+    File file = SD_MMC.open(SYSTEM_EVENTS_PATH, "a", true);
+    if (!file) return false;
+
+    writeSystemEventsHeaderIfNeeded(file, existed);
+    file.printf("%lu,", static_cast<unsigned long>(millis()));
+    printCsvString(file, source ? String(source) : String(""));
+    file.print(',');
+    printCsvString(file, event ? String(event) : String(""));
+    file.print(',');
+    printCsvString(file, detail);
+    file.print(',');
+    printCsvString(file, key ? String(key) : String(""));
+    file.print(',');
+    if (hasValue) {
+      file.print(value);
+    }
+    file.println(",,,,,,,,,,,,,,");
+    file.close();
+    return true;
   }
 
 }  // namespace diagnostic_logs

--- a/src/vario/diagnostics/diagnostic_logs.h
+++ b/src/vario/diagnostics/diagnostic_logs.h
@@ -16,8 +16,7 @@ namespace diagnostic_logs {
   bool enabled(Log log);
   bool ensureDirectory();
   void printCsvString(File& file, const String& value);
-  bool appendSystemEvent(const char* source, const char* event,
-                         const String& detail = String(), const char* key = nullptr,
-                         int32_t value = 0, bool hasValue = false);
+  bool appendSystemEvent(const char* source, const char* event, const String& detail = String(),
+                         const char* key = nullptr, int32_t value = 0, bool hasValue = false);
 
 }  // namespace diagnostic_logs

--- a/src/vario/diagnostics/diagnostic_logs.h
+++ b/src/vario/diagnostics/diagnostic_logs.h
@@ -16,5 +16,8 @@ namespace diagnostic_logs {
   bool enabled(Log log);
   bool ensureDirectory();
   void printCsvString(File& file, const String& value);
+  bool appendSystemEvent(const char* source, const char* event,
+                         const String& detail = String(), const char* key = nullptr,
+                         int32_t value = 0, bool hasValue = false);
 
 }  // namespace diagnostic_logs

--- a/src/vario/diagnostics/diagnostic_logs.h
+++ b/src/vario/diagnostics/diagnostic_logs.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <Arduino.h>
+#include <FS.h>
+
+namespace diagnostic_logs {
+
+  enum class Log : uint8_t { SystemEvents, NetworkEvents, WebRequests, Vario };
+
+  constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
+  constexpr const char* SYSTEM_EVENTS_PATH = "/diagnostics/system_events.csv";
+  constexpr const char* NETWORK_EVENTS_PATH = "/diagnostics/network_events.csv";
+  constexpr const char* WEB_REQUESTS_PATH = "/diagnostics/web_requests.csv";
+  constexpr const char* VARIO_PATH = "/diagnostics/vario.csv";
+
+  bool enabled(Log log);
+  bool ensureDirectory();
+  void printCsvString(File& file, const String& value);
+
+}  // namespace diagnostic_logs

--- a/src/vario/diagnostics/heap_monitor.cpp
+++ b/src/vario/diagnostics/heap_monitor.cpp
@@ -4,11 +4,11 @@
 #include <SD_MMC.h>
 #include <string.h>
 
+#include "diagnostics/diagnostic_logs.h"
 #include "esp_heap_caps.h"
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "diagnostics/diagnostic_logs.h"
 #include "ui/settings/settings.h"
 
 namespace heap_monitor {
@@ -77,7 +77,8 @@ namespace heap_monitor {
     void writeHeaderIfNeeded(File& file, const char* path) {
       if (SD_MMC.exists(path) && file.size() > 0) return;
       file.println(
-          "millis,source,event,detail,key,value,free_heap,min_free_heap,largest_free_block,max_alloc_heap,"
+          "millis,source,event,detail,key,value,free_heap,min_free_heap,largest_free_block,max_"
+          "alloc_heap,"
           "internal_free,internal_largest,psram_free,psram_largest,current_task,"
           "stack_high_water,loop_stack_high_water,ble_stack_high_water,"
           "fanet_tx_stack_high_water,fanet_rx_stack_high_water");
@@ -104,8 +105,7 @@ namespace heap_monitor {
 
     void writeSample(File& file, const char* source, const Sample& sample) {
       file.printf("%lu,%s,%s,,,,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%s,%lu,%lu,%lu,%lu,%lu\n",
-                  static_cast<unsigned long>(sample.millis), source ? source : "heap",
-                  sample.event,
+                  static_cast<unsigned long>(sample.millis), source ? source : "heap", sample.event,
                   static_cast<unsigned long>(sample.freeHeap),
                   static_cast<unsigned long>(sample.minFreeHeap),
                   static_cast<unsigned long>(sample.largestFreeBlock),
@@ -147,7 +147,8 @@ namespace heap_monitor {
     const bool existed = SD_MMC.exists(diagnostic_logs::SYSTEM_EVENTS_PATH);
     File file = SD_MMC.open(diagnostic_logs::SYSTEM_EVENTS_PATH, "a", true);
     if (!file) return;
-    if (!existed || file.size() == 0) writeHeaderIfNeeded(file, diagnostic_logs::SYSTEM_EVENTS_PATH);
+    if (!existed || file.size() == 0)
+      writeHeaderIfNeeded(file, diagnostic_logs::SYSTEM_EVENTS_PATH);
     writeSample(file, "heap", sample);
     file.close();
   }

--- a/src/vario/diagnostics/heap_monitor.cpp
+++ b/src/vario/diagnostics/heap_monitor.cpp
@@ -8,6 +8,7 @@
 #include "esp_system.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "diagnostics/diagnostic_logs.h"
 #include "ui/settings/settings.h"
 
 namespace heap_monitor {
@@ -16,9 +17,6 @@ namespace heap_monitor {
     constexpr size_t EVENT_LENGTH = 28;
     constexpr size_t TASK_NAME_LENGTH = 12;
     constexpr size_t REGISTERED_TASK_COUNT = 4;
-    constexpr const char* DIAGNOSTICS_DIR = "/diagnostics";
-    constexpr const char* LIFECYCLE_PATH = "/diagnostics/heap_lifecycle.csv";
-
     struct Sample {
       uint32_t millis;
       char event[EVENT_LENGTH];
@@ -76,15 +74,10 @@ namespace heap_monitor {
       return 0;
     }
 
-    bool ensureDiagnosticsDirectory() {
-      if (SD_MMC.exists(DIAGNOSTICS_DIR)) return true;
-      return SD_MMC.mkdir(DIAGNOSTICS_DIR);
-    }
-
     void writeHeaderIfNeeded(File& file, const char* path) {
       if (SD_MMC.exists(path) && file.size() > 0) return;
       file.println(
-          "millis,event,free_heap,min_free_heap,largest_free_block,max_alloc_heap,"
+          "millis,source,event,detail,key,value,free_heap,min_free_heap,largest_free_block,max_alloc_heap,"
           "internal_free,internal_largest,psram_free,psram_largest,current_task,"
           "stack_high_water,loop_stack_high_water,ble_stack_high_water,"
           "fanet_tx_stack_high_water,fanet_rx_stack_high_water");
@@ -109,9 +102,10 @@ namespace heap_monitor {
       copyTaskName(sample.currentTask, pcTaskGetName(NULL));
     }
 
-    void writeSample(File& file, const Sample& sample) {
-      file.printf("%lu,%s,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%s,%lu,%lu,%lu,%lu,%lu\n",
-                  static_cast<unsigned long>(sample.millis), sample.event,
+    void writeSample(File& file, const char* source, const Sample& sample) {
+      file.printf("%lu,%s,%s,,,,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%s,%lu,%lu,%lu,%lu,%lu\n",
+                  static_cast<unsigned long>(sample.millis), source ? source : "heap",
+                  sample.event,
                   static_cast<unsigned long>(sample.freeHeap),
                   static_cast<unsigned long>(sample.minFreeHeap),
                   static_cast<unsigned long>(sample.largestFreeBlock),
@@ -130,7 +124,7 @@ namespace heap_monitor {
   }  // namespace
 
   void record(const char* event) {
-    if (!settings.dev_mode) return;
+    if (!diagnostic_logs::enabled(diagnostic_logs::Log::SystemEvents)) return;
     Sample& sample = samples[nextSample];
     captureSample(sample, event);
 
@@ -139,7 +133,7 @@ namespace heap_monitor {
   }
 
   void checkpoint(const char* event) {
-    if (!settings.dev_mode) return;
+    if (!diagnostic_logs::enabled(diagnostic_logs::Log::SystemEvents)) return;
 
     Sample sample;
     captureSample(sample, event);
@@ -148,13 +142,13 @@ namespace heap_monitor {
     nextSample = (nextSample + 1) % SAMPLE_COUNT;
     if (sampleTotal < SAMPLE_COUNT) sampleTotal++;
 
-    if (!sdLoggingEnabled || !ensureDiagnosticsDirectory()) return;
+    if (!sdLoggingEnabled || !diagnostic_logs::ensureDirectory()) return;
 
-    const bool existed = SD_MMC.exists(LIFECYCLE_PATH);
-    File file = SD_MMC.open(LIFECYCLE_PATH, "a", true);
+    const bool existed = SD_MMC.exists(diagnostic_logs::SYSTEM_EVENTS_PATH);
+    File file = SD_MMC.open(diagnostic_logs::SYSTEM_EVENTS_PATH, "a", true);
     if (!file) return;
-    if (!existed || file.size() == 0) writeHeaderIfNeeded(file, LIFECYCLE_PATH);
-    writeSample(file, sample);
+    if (!existed || file.size() == 0) writeHeaderIfNeeded(file, diagnostic_logs::SYSTEM_EVENTS_PATH);
+    writeSample(file, "heap", sample);
     file.close();
   }
 
@@ -182,28 +176,29 @@ namespace heap_monitor {
   void setSdLoggingEnabled(bool enabled) { sdLoggingEnabled = enabled; }
 
   bool dumpToSd(const char* path) {
-    if (!settings.dev_mode) return false;
+    if (!diagnostic_logs::enabled(diagnostic_logs::Log::SystemEvents)) return false;
     if (!path || path[0] == '\0') return false;
     if (!sdLoggingEnabled) return false;
-    if (!ensureDiagnosticsDirectory()) return false;
+    if (!diagnostic_logs::ensureDirectory()) return false;
 
-    const bool existed = SD_MMC.exists(path);
-    File file = SD_MMC.open(path, "a", true);
+    const char* outputPath = diagnostic_logs::SYSTEM_EVENTS_PATH;
+    const bool existed = SD_MMC.exists(outputPath);
+    File file = SD_MMC.open(outputPath, "a", true);
     if (!file) return false;
 
-    if (!existed || file.size() == 0) writeHeaderIfNeeded(file, path);
+    if (!existed || file.size() == 0) writeHeaderIfNeeded(file, outputPath);
 
     const size_t start = sampleTotal < SAMPLE_COUNT ? 0 : nextSample;
     for (size_t i = 0; i < sampleTotal; i++) {
       const Sample& sample = samples[(start + i) % SAMPLE_COUNT];
-      writeSample(file, sample);
+      writeSample(file, "heap_snapshot", sample);
     }
     file.close();
     return true;
   }
 
   void clear() {
-    if (!settings.dev_mode) return;
+    if (!diagnostic_logs::enabled(diagnostic_logs::Log::SystemEvents)) return;
     nextSample = 0;
     sampleTotal = 0;
   }

--- a/src/vario/diagnostics/heap_monitor.h
+++ b/src/vario/diagnostics/heap_monitor.h
@@ -9,7 +9,7 @@ namespace heap_monitor {
   void checkpoint(const char* event);
   void registerTask(const char* name, TaskHandle_t handle);
   void setSdLoggingEnabled(bool enabled);
-  bool dumpToSd(const char* path = "/diagnostics/heap_monitor.csv");
+  bool dumpToSd(const char* path = "/diagnostics/system_events.csv");
   void clear();
 
 }  // namespace heap_monitor

--- a/src/vario/hardware/Leaf_SPI.h
+++ b/src/vario/hardware/Leaf_SPI.h
@@ -30,6 +30,8 @@ class SpiLockGuard : public LockGuard {
 
  public:
   SpiLockGuard() : LockGuard(spiMutex) {}
+  explicit SpiLockGuard(uint32_t timeoutMs, bool fatalOnTimeout = true)
+      : LockGuard(spiMutex, pdMS_TO_TICKS(timeoutMs), fatalOnTimeout) {}
 
  private:
   static SemaphoreHandle_t spiMutex;

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -365,15 +365,15 @@ void Barometer::filterClimb() {
     }
   }
 
-  if (diagnostic_logs::enabled(diagnostic_logs::Log::Vario) &&
-      diagnostic_logs::ensureDirectory()) {
+  if (diagnostic_logs::enabled(diagnostic_logs::Log::Vario) && diagnostic_logs::ensureDirectory()) {
     const bool existed = SD_MMC.exists(diagnostic_logs::VARIO_PATH);
     File file = SD_MMC.open(diagnostic_logs::VARIO_PATH, "a", true);
     if (file) {
       writeVarioHeaderIfNeeded(file, existed);
       file.printf(
           "%lu,%lu,%ld,%.6f,%ld,%.6f,%.6f,%.6f,%.6f,%.8f,%.8f,%.8f,%.6f,%.6f,%.6f,"
-          "%.6f,%.6f,%.6f,%u,%.6f,%.6f,%.6f,%.6f,%ld,%.6f,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu\n",
+          "%.6f,%.6f,%.6f,%u,%.6f,%.6f,%.6f,%.6f,%ld,%.6f,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%"
+          "lu\n",
           static_cast<unsigned long>(millis()), static_cast<unsigned long>(imu.lastMotionTime()),
           static_cast<long>(pressure_), altF(), static_cast<long>(altAdjusted()), imu.getAccel(),
           imu.lastDeviceAccelX(), imu.lastDeviceAccelY(), imu.lastDeviceAccelZ(), imu.lastQuatX(),

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -4,6 +4,9 @@
  */
 #include "instruments/baro.h"
 
+#include <SD_MMC.h>
+
+#include "diagnostics/diagnostic_logs.h"
 #include "diagnostics/fatal_error.h"
 #include "hardware/Leaf_I2C.h"
 #include "hardware/ms5611.h"
@@ -33,6 +36,20 @@ constexpr size_t BARO_STARTUP_DISCARD_SAMPLES = 20;
 
 // Singleton barometer instance for device
 Barometer baro;
+
+namespace {
+  void writeVarioHeaderIfNeeded(File& file, bool existed) {
+    if (existed && file.size() > 0) return;
+    file.println(
+        "millis,motion_millis,pressure,baro_alt_m,baro_alt_adjusted_cm,accel_total_g,"
+        "ax_g,ay_g,az_g,qx,qy,qz,awx_g,awy_g,awz_g,gravity_g,vertical_accel_g,"
+        "kalman_accel_input_g,kalman_valid,kalman_position_m,kalman_velocity_mps,"
+        "kalman_acceleration_mps2,climb_raw_mps,climb_filtered_cms,climb_average_cms,"
+        "gravity_candidates,gravity_accepted,gravity_reject_accel,gravity_reject_vertical,"
+        "gravity_reject_time,gravity_reject_plausibility,gravity_slew_limited,"
+        "kalman_updates,motion_samples,motion_reject_quat");
+  }
+}  // namespace
 
 void Barometer::adjustAltSetting(int8_t dir, uint8_t count) {
   // TODO(#192): check whether settings is initialized before reading/using
@@ -345,6 +362,37 @@ void Barometer::filterClimb() {
       fatalError(
           "climbRateAverage in Barometer::filterClimb was %g after incorporating climbRateFiltered",
           climbRateAverage_);
+    }
+  }
+
+  if (diagnostic_logs::enabled(diagnostic_logs::Log::Vario) &&
+      diagnostic_logs::ensureDirectory()) {
+    const bool existed = SD_MMC.exists(diagnostic_logs::VARIO_PATH);
+    File file = SD_MMC.open(diagnostic_logs::VARIO_PATH, "a", true);
+    if (file) {
+      writeVarioHeaderIfNeeded(file, existed);
+      file.printf(
+          "%lu,%lu,%ld,%.6f,%ld,%.6f,%.6f,%.6f,%.6f,%.8f,%.8f,%.8f,%.6f,%.6f,%.6f,"
+          "%.6f,%.6f,%.6f,%u,%.6f,%.6f,%.6f,%.6f,%ld,%.6f,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu\n",
+          static_cast<unsigned long>(millis()), static_cast<unsigned long>(imu.lastMotionTime()),
+          static_cast<long>(pressure_), altF(), static_cast<long>(altAdjusted()), imu.getAccel(),
+          imu.lastDeviceAccelX(), imu.lastDeviceAccelY(), imu.lastDeviceAccelZ(), imu.lastQuatX(),
+          imu.lastQuatY(), imu.lastQuatZ(), imu.lastWorldAccelX(), imu.lastWorldAccelY(),
+          imu.lastWorldVerticalAccel(), imu.gravityEstimate(), imu.verticalAccel(),
+          imu.kalmanAccelInput(), imu.kalmanValid() ? 1 : 0, imu.kalmanPosition(),
+          imu.kalmanVelocity(), imu.kalmanAcceleration(), climbRateRaw_,
+          static_cast<long>(climbRateFiltered_), climbRateAverage_,
+          static_cast<unsigned long>(imu.gravityUpdateCandidateCount()),
+          static_cast<unsigned long>(imu.gravityUpdateAcceptedCount()),
+          static_cast<unsigned long>(imu.gravityUpdateRejectedAccelCount()),
+          static_cast<unsigned long>(imu.gravityUpdateRejectedVerticalCount()),
+          static_cast<unsigned long>(imu.gravityUpdateRejectedTimeCount()),
+          static_cast<unsigned long>(imu.gravityUpdateRejectedPlausibilityCount()),
+          static_cast<unsigned long>(imu.gravityUpdateSlewLimitedCount()),
+          static_cast<unsigned long>(imu.kalmanUpdateSampleCount()),
+          static_cast<unsigned long>(imu.motionSampleCount()),
+          static_cast<unsigned long>(imu.motionSampleRejectedQuaternionCount()));
+      file.close();
     }
   }
 }

--- a/src/vario/instruments/imu.cpp
+++ b/src/vario/instruments/imu.cpp
@@ -28,9 +28,9 @@ namespace {
 
   constexpr double MIN_GRAVITY_G = 0.9;
   constexpr double MAX_GRAVITY_G = 1.1;
-  constexpr double MIN_GRAVITY_ESTIMATE_G = 0.98;
-  constexpr double MAX_GRAVITY_ESTIMATE_G = 1.02;
-  constexpr double GRAVITY_UPDATE_ACCEL_TOLERANCE_G = 0.05;
+  constexpr double MIN_GRAVITY_ESTIMATE_G = 0.94;
+  constexpr double MAX_GRAVITY_ESTIMATE_G = 1.06;
+  constexpr double GRAVITY_UPDATE_ACCEL_TOLERANCE_G = 0.065;
   constexpr double GRAVITY_UPDATE_VERTICAL_TOLERANCE_G = 0.10;
   constexpr double GRAVITY_UPDATE_MAX_SLEW_G_PER_S = 0.05;
   constexpr uint8_t IMU_SAMPLE_RATE = 20;  // Hz
@@ -119,6 +119,10 @@ void IMU::processMotion(const MotionUpdate& m) {
     return;
   }
   motionSampleProcessedCount_++;
+  lastMotionTime_ = m.t;
+  lastQuatX_ = qx;
+  lastQuatY_ = qy;
+  lastQuatZ_ = qz;
 
   bool needComma = false;
   bool needNewline = false;
@@ -138,6 +142,9 @@ void IMU::processMotion(const MotionUpdate& m) {
 
   accelTot_ = sqrt(m.ax * m.ax + m.ay * m.ay + m.az * m.az);
   validAccelTot_ = true;
+  lastDeviceAccelX_ = m.ax;
+  lastDeviceAccelY_ = m.ay;
+  lastDeviceAccelZ_ = m.az;
 
 #ifdef SHOW_DEVICE_ACCEL
   if (needComma) {
@@ -161,6 +168,8 @@ void IMU::processMotion(const MotionUpdate& m) {
         m.ay, m.az, qw, qx, qy, qz, awx, awy, awz);
     fatalError("IMU awz was invalid");
   }
+  lastWorldAccelX_ = awx;
+  lastWorldAccelY_ = awy;
   lastWorldVerticalAccel_ = awz;
   validLastWorldVerticalAccel_ = true;
 
@@ -331,6 +340,42 @@ float IMU::getVelocity() {
 uint16_t IMU::gravityInitSamplesRemaining() const { return 0; }
 
 float IMU::gravityEstimate() const { return (float)gravity_; }
+
+float IMU::verticalAccel() const { return (float)accelVert_; }
+
+float IMU::kalmanAccelInput() const { return (float)kalmanAccelVert_; }
+
+bool IMU::kalmanValid() const { return kalmanvert_.initialized(); }
+
+float IMU::kalmanPosition() const {
+  return kalmanvert_.initialized() ? (float)kalmanvert_.getPosition() : 0.0f;
+}
+
+float IMU::kalmanVelocity() const {
+  return kalmanvert_.initialized() ? (float)kalmanvert_.getVelocity() : 0.0f;
+}
+
+float IMU::kalmanAcceleration() const {
+  return kalmanvert_.initialized() ? (float)kalmanvert_.getAcceleration() : 0.0f;
+}
+
+unsigned long IMU::lastMotionTime() const { return lastMotionTime_; }
+
+float IMU::lastDeviceAccelX() const { return (float)lastDeviceAccelX_; }
+
+float IMU::lastDeviceAccelY() const { return (float)lastDeviceAccelY_; }
+
+float IMU::lastDeviceAccelZ() const { return (float)lastDeviceAccelZ_; }
+
+float IMU::lastQuatX() const { return (float)lastQuatX_; }
+
+float IMU::lastQuatY() const { return (float)lastQuatY_; }
+
+float IMU::lastQuatZ() const { return (float)lastQuatZ_; }
+
+float IMU::lastWorldAccelX() const { return (float)lastWorldAccelX_; }
+
+float IMU::lastWorldAccelY() const { return (float)lastWorldAccelY_; }
 
 float IMU::lastWorldVerticalAccel() const { return (float)lastWorldVerticalAccel_; }
 

--- a/src/vario/instruments/imu.h
+++ b/src/vario/instruments/imu.h
@@ -32,6 +32,21 @@ class IMU : public MessageSink<IMU, MotionUpdate>, public IMessageSource {
 
   uint16_t gravityInitSamplesRemaining() const;
   float gravityEstimate() const;
+  float verticalAccel() const;
+  float kalmanAccelInput() const;
+  bool kalmanValid() const;
+  float kalmanPosition() const;
+  float kalmanVelocity() const;
+  float kalmanAcceleration() const;
+  unsigned long lastMotionTime() const;
+  float lastDeviceAccelX() const;
+  float lastDeviceAccelY() const;
+  float lastDeviceAccelZ() const;
+  float lastQuatX() const;
+  float lastQuatY() const;
+  float lastQuatZ() const;
+  float lastWorldAccelX() const;
+  float lastWorldAccelY() const;
   float lastWorldVerticalAccel() const;
   bool worldVerticalAccelValid() const;
   uint16_t gravityInitResetCount() const;
@@ -75,6 +90,15 @@ class IMU : public MessageSink<IMU, MotionUpdate>, public IMessageSource {
   double gravity_ = 1.0;
 
   double lastWorldVerticalAccel_ = 0.0;
+  double lastWorldAccelX_ = 0.0;
+  double lastWorldAccelY_ = 0.0;
+  double lastDeviceAccelX_ = 0.0;
+  double lastDeviceAccelY_ = 0.0;
+  double lastDeviceAccelZ_ = 0.0;
+  double lastQuatX_ = 0.0;
+  double lastQuatY_ = 0.0;
+  double lastQuatZ_ = 0.0;
+  unsigned long lastMotionTime_ = 0;
   bool validLastWorldVerticalAccel_ = false;
   double lastRejectedGravity_ = 0.0;
   uint16_t gravityInitResetCount_ = 0;

--- a/src/vario/math/kalman.cpp
+++ b/src/vario/math/kalman.cpp
@@ -18,15 +18,15 @@ void KalmanFilterPA::init(double initialTime, double initialPosition, double ini
   initialized_ = true;
 }
 
-double KalmanFilterPA::getPosition() {
+double KalmanFilterPA::getPosition() const {
   if (!initialized_) fatalError("KalmanFilter::getPosition before initialized");
   return p_;
 }
-double KalmanFilterPA::getVelocity() {
+double KalmanFilterPA::getVelocity() const {
   if (!initialized_) fatalError("KalmanFilter::getVelocity before initialized");
   return v_;
 }
-double KalmanFilterPA::getAcceleration() {
+double KalmanFilterPA::getAcceleration() const {
   if (!initialized_) fatalError("KalmanFilter::getAcceleration before initialized");
   return a_;
 }

--- a/src/vario/math/kalman.h
+++ b/src/vario/math/kalman.h
@@ -8,10 +8,10 @@ class KalmanFilterPA {
 
   void update(double measuredTime, double measuredPosition, double measuredAcceleration);
 
-  bool initialized() { return initialized_; }
-  double getPosition();
-  double getVelocity();
-  double getAcceleration();
+  bool initialized() const { return initialized_; }
+  double getPosition() const;
+  double getVelocity() const;
+  double getAcceleration() const;
 
  private:
   void init(double initialTime, double initialPosition, double initialAcceleration);

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -7,6 +7,7 @@
 
 #include "comms/ble.h"
 #include "comms/factory_discovery.h"
+#include "comms/fanet_radio.h"
 #include "diagnostics/diagnostic_network/diagnostic_network.h"
 #include "diagnostics/heap_monitor.h"
 #include "diagnostics/self_test/selfTest.h"
@@ -115,6 +116,9 @@ void TaskManager::init() {
   // turn on and handle all device initialization
   heap_monitor::checkpoint("taskman-power-start");
   power.bootUp();
+#ifdef FANET_CAPABLE
+  fanetRadio.logDetectionResult();
+#endif
   heap_monitor::checkpoint("taskman-power-end");
 
   if (!timerISRsSetup.exchange(false, std::memory_order_acq_rel)) {

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -73,7 +73,8 @@ void Display::init(void) {
 }
 
 void Display::setContrast(uint8_t contrast) {
-  SpiLockGuard spiLock;
+  SpiLockGuard spiLock(25, false);
+  if (!spiLock) return;
 #ifndef WO256X128  // if not using older hardware, use the latest hardware contrast setting:
   // user can select levels of contrast from 0-20; but display needs values of 115-135.
   u8g2.setContrast(contrast + 115);
@@ -183,7 +184,8 @@ void Display::update() {
     return;
   }
 
-  SpiLockGuard spiLock;  // Take out an SPI lock for the rending of the page
+  SpiLockGuard spiLock(25, false);  // Take out an SPI lock for the rending of the page
+  if (!spiLock) return;
 
   if (displayPage_ == MainPage::Charging) {
     chargingPage_draw();
@@ -241,7 +243,8 @@ void Display::update() {
 }
 
 void Display::clear() {
-  SpiLockGuard spiLock;
+  SpiLockGuard spiLock(25, false);
+  if (!spiLock) return;
   u8g2.clear();
 }
 

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -801,6 +801,11 @@ void display_fanet_icon(const uint8_t& x, const uint8_t& y) {
       u8g2.print(char(0x56 + offset));
       break;
     }
+    case FanetRadioState::FAILED_RADIO_PROBE:
+    case FanetRadioState::FAILED_RADIO_INIT:
+    case FanetRadioState::FAILED_OTHER:
+      u8g2.print(char(96));  // Failed FANET icon
+      break;
     default:
       u8g2.print(char(0x60));  // Radio error icon
       break;

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -194,6 +194,10 @@ void Settings::loadDefaults() {
   dev_startLogAtBoot = DEF_DEV_START_LOG_AT_BOOT;
   dev_startDisconnected = DEF_DEV_START_DISCONNECTED;
   dev_fanetFwd = DEF_DEV_FANET_FWD;
+  diag_systemEvents = DEF_DIAG_SYSTEM_EVENTS;
+  diag_networkEvents = DEF_DIAG_NETWORK_EVENTS;
+  diag_webRequests = DEF_DIAG_WEB_REQUESTS;
+  diag_vario = DEF_DIAG_VARIO;
 
   // Boot Flags
   boot_enterBootloader = DEF_ENTER_BOOTLOAD;
@@ -267,6 +271,10 @@ void Settings::retrieve() {
   dev_startLogAtBoot = leafPrefs.getBool("DEV_STARTLOG");
   dev_startDisconnected = leafPrefs.getBool("DEV_STARTDISCON");
   dev_fanetFwd = leafPrefs.getBool("DEV_FANET_FWD", DEF_DEV_FANET_FWD);
+  diag_systemEvents = leafPrefs.getBool("DIAG_SYSTEM", DEF_DIAG_SYSTEM_EVENTS);
+  diag_networkEvents = leafPrefs.getBool("DIAG_NETWORK", DEF_DIAG_NETWORK_EVENTS);
+  diag_webRequests = leafPrefs.getBool("DIAG_WEB_REQ", DEF_DIAG_WEB_REQUESTS);
+  diag_vario = leafPrefs.getBool("DIAG_VARIO", DEF_DIAG_VARIO);
 
   // Boot Flags
   boot_enterBootloader = leafPrefs.getBool("ENTER_BOOTLOAD");
@@ -345,6 +353,10 @@ void Settings::save() {
   leafPrefs.putBool("DEV_STARTLOG", dev_startLogAtBoot);
   leafPrefs.putBool("DEV_STARTDISCON", dev_startDisconnected);
   leafPrefs.putBool("DEV_FANET_FWD", dev_fanetFwd);
+  leafPrefs.putBool("DIAG_SYSTEM", diag_systemEvents);
+  leafPrefs.putBool("DIAG_NETWORK", diag_networkEvents);
+  leafPrefs.putBool("DIAG_WEB_REQ", diag_webRequests);
+  leafPrefs.putBool("DIAG_VARIO", diag_vario);
   // Boot Flags
   leafPrefs.putBool("ENTER_BOOTLOAD", boot_enterBootloader);
   leafPrefs.putBool("BOOT_TO_ON", boot_toOnState);

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -76,7 +76,7 @@
 #define DEF_DIAG_NETWORK_EVENTS 0
 #define DEF_DIAG_WEB_REQUESTS 0
 #define DEF_DIAG_VARIO 0
-#define DEF_ECO_MODE 0                // default off to allow reprogramming easier
+#define DEF_ECO_MODE 0  // default off to allow reprogramming easier
 
 // Boot Flags
 // Boot-to-ON Flag (when resetting from system updates,

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -72,6 +72,10 @@
 #define DEF_DEV_START_LOG_AT_BOOT 0   // default do not start log at boot
 #define DEF_DEV_START_DISCONNECTED 0  // default do not disconnect hardware at boot
 #define DEF_DEV_FANET_FWD 0           //  DO rebroadcast Fanet packets (turn off for range testing)
+#define DEF_DIAG_SYSTEM_EVENTS 0
+#define DEF_DIAG_NETWORK_EVENTS 0
+#define DEF_DIAG_WEB_REQUESTS 0
+#define DEF_DIAG_VARIO 0
 #define DEF_ECO_MODE 0                // default off to allow reprogramming easier
 
 // Boot Flags
@@ -159,6 +163,10 @@ setting | samples | time avg
   bool dev_startLogAtBoot;
   bool dev_startDisconnected;
   bool dev_fanetFwd;
+  bool diag_systemEvents;
+  bool diag_networkEvents;
+  bool diag_webRequests;
+  bool diag_vario;
 
   // Boot Flags
   bool boot_enterBootloader;

--- a/src/vario/utils/lock_guard.cpp
+++ b/src/vario/utils/lock_guard.cpp
@@ -4,9 +4,13 @@
 
 #include "diagnostics/fatal_error.h"
 
-LockGuard::LockGuard(SemaphoreHandle_t mutex) : mutex_(mutex) {
+LockGuard::LockGuard(SemaphoreHandle_t mutex, TickType_t timeoutTicks, bool fatalOnTimeout)
+    : mutex_(mutex) {
   // Try to take the lock out
-  if (xSemaphoreTake(mutex_, pdMS_TO_TICKS(10000)) == pdTRUE) return;
+  if (mutex_ != NULL && xSemaphoreTake(mutex_, timeoutTicks) == pdTRUE) {
+    valid_ = true;
+    return;
+  }
 
-  fatalError("Lock acquisition failed in LockGuard constructor");
+  if (fatalOnTimeout) fatalError("Lock acquisition failed in LockGuard constructor");
 }

--- a/src/vario/utils/lock_guard.h
+++ b/src/vario/utils/lock_guard.h
@@ -5,12 +5,15 @@
 /// @brief Simple FreeRTOS locking guard to lock a mutex in scope
 class LockGuard {
  public:
-  explicit LockGuard(SemaphoreHandle_t mutex);
+  explicit LockGuard(SemaphoreHandle_t mutex, TickType_t timeoutTicks = pdMS_TO_TICKS(10000),
+                     bool fatalOnTimeout = true);
 
-  ~LockGuard() { xSemaphoreGive(mutex_); }
+  ~LockGuard() {
+    if (valid_) xSemaphoreGive(mutex_);
+  }
 
   // Allow this to be used in if statements
-  explicit operator bool() const { return true; }
+  explicit operator bool() const { return valid_; }
 
   // Prevent copying
   LockGuard(const LockGuard&) = delete;
@@ -18,4 +21,5 @@ class LockGuard {
 
  private:
   SemaphoreHandle_t mutex_;
+  bool valid_ = false;
 };


### PR DESCRIPTION
**Summary**
This branch improves two areas that came out of recent hardware diagnostics:

- Adds gated diagnostic logging under `/diagnostics` on the SD card, controlled by Developer settings and superseded by `dev_mode`.
- Adds a new `vario.csv` diagnostic log with IMU, gravity estimate, barometer, Kalman, altitude, and climb-rate fields for diagnosing stationary climb bias.
- Tunes the IMU gravity estimator for observed accelerometer module variation:
  - Gravity clamp changed from `[0.98g, 1.02g]` to `[0.94g, 1.06g]`.
  - Gravity update accel tolerance changed from `0.05g` to `0.065g`.
- Adds a backlog note documenting current vario/IMU/gravity findings and remaining diagnostic questions.
- Hardens FANET/SX1262 startup and SPI behavior:
  - Adds an explicit SPI probe/readback path before full radio setup.
  - Adds bounded SPI lock acquisition for FANET operations.
  - Tracks probe/init failures as radio states instead of continuing through broken hardware paths.
  - Logs FANET detection/probe/radio errors into system diagnostics.
  - Avoids FANET RX/TX work when the radio is unavailable or unhealthy.
  - Shows failed FANET states with the display error icon.

**Testing**
- `pio run -e leaf_3_2_7_release` passed.
- Vario diagnostic logs were reviewed from multiple units:
  - One unit showed stationary climb caused by accel readings above the old gravity clamp.
  - One unit showed a saturated IMU accel axis, confirming that the clamp/tolerance change is not intended to mask hard IMU failures.

**Notes / Risk**
- Diagnostic logs default to off and require `dev_mode`, so normal users should not incur SD logging overhead.
- The wider gravity bounds should help units with moderate accelerometer scale error, but true saturated/broken IMU modules still need separate fault handling.
- FANET SPI failures should now fail quieter and earlier, with diagnostic breadcrumbs instead of repeated unsafe radio operations.