### PR TITLE
Polish Leaf UI navigation

### DIFF
--- a/src/vario/ui/audio/sound_effects.h
+++ b/src/vario/ui/audio/sound_effects.h
@@ -12,7 +12,8 @@ namespace fx {
 
   constexpr note_t increase[] = {note::C4, note::G4, note::END};
   constexpr note_t decrease[] = {note::C4, note::F3, note::END};  // 110 140, END_OF_TONE};
-  constexpr note_t neutral[] = {note::C4, note::C4, note::END};   // 110, 110, END_OF_TONE};
+  constexpr note_t click[] = {note::C4, note::END};
+  constexpr note_t neutral[] = {note::C4, note::C4, note::END};  // 110, 110, END_OF_TONE};
   constexpr note_t neutralLong[] = {
       note::C4, note::C4, note::C4, note::C4, note::C4,
       note::C4, note::C4, note::C4, note::END};  //  {110, 110, 110, 110, 110, 110, 110, 110,10,

--- a/src/vario/ui/display/display.cpp
+++ b/src/vario/ui/display/display.cpp
@@ -134,6 +134,11 @@ MainPage Display::sanitizedMainPage(MainPage targetPage) {
   return firstVisiblePrimaryPage(targetPage);
 }
 
+bool Display::isScrollableMainPageVisible(MainPage targetPage) const {
+  return targetPage != MainPage::Menu && targetPage != MainPage::Charging &&
+         targetPage != MainPage::Blank && isMainPageVisible(targetPage);
+}
+
 void Display::turnPage(PageAction action) {
   MainPage tempPage = displayPage_;
 
@@ -142,17 +147,33 @@ void Display::turnPage(PageAction action) {
       displayPage_ = sanitizedMainPage(MainPage::Thermal);
       break;
 
-    case PageAction::Next:
-      do {
-        displayPage_++;
-      } while (!isMainPageVisible(displayPage_));
+    case PageAction::Next: {
+      MainPage nextPage = displayPage_;
+      for (int page = static_cast<int>(displayPage_) + 1; page <= static_cast<int>(MainPage::Menu);
+           page++) {
+        MainPage candidate = static_cast<MainPage>(page);
+        if (candidate == MainPage::Menu || isScrollableMainPageVisible(candidate)) {
+          nextPage = candidate;
+          break;
+        }
+      }
+      displayPage_ = nextPage;
       break;
+    }
 
-    case PageAction::Prev:
-      do {
-        displayPage_--;
-      } while (!isMainPageVisible(displayPage_));
+    case PageAction::Prev: {
+      MainPage nextPage = displayPage_;
+      for (int page = static_cast<int>(displayPage_) - 1; page >= static_cast<int>(MainPage::Debug);
+           page--) {
+        MainPage candidate = static_cast<MainPage>(page);
+        if (isScrollableMainPageVisible(candidate)) {
+          nextPage = candidate;
+          break;
+        }
+      }
+      displayPage_ = nextPage;
       break;
+    }
 
     case PageAction::Back:
       displayPage_ = sanitizedMainPage(displayPagePrior_);
@@ -251,6 +272,19 @@ void Display::clear() {
 void Display::clearPage() {
   clear();
   mainMenuPage.pop_all_pages();
+  mainMenuPage.resetCursor();
+  settingsMenuPage.resetCursor();
+  flightToolsMenuPage.resetCursor();
+  navDataMenuPage.backToNavDataMenu();
+  gpsMenuPage.resetCursor();
+  logMenuPage.backToLogMenu();
+  varioMenuPage.resetCursor();
+  altimeterMenuPage.resetCursor();
+  displayMenuPage.resetCursor();
+  unitsMenuPage.resetCursor();
+  systemMenuPage.backToSystemMenu();
+  developerMenuPage.resetCursor();
+  wifiMenuPage.resetCursor();
   displayPage_ = MainPage::Blank;
 }
 

--- a/src/vario/ui/display/display.h
+++ b/src/vario/ui/display/display.h
@@ -57,6 +57,7 @@ class Display {
  private:
   MainPage sanitizedMainPage(MainPage targetPage);
   MainPage firstVisiblePrimaryPage(MainPage preferredPage) const;
+  bool isScrollableMainPageVisible(MainPage targetPage) const;
 
   MainPage displayPage_ = MainPage::Thermal;
 

--- a/src/vario/ui/display/menu_page.cpp
+++ b/src/vario/ui/display/menu_page.cpp
@@ -1,6 +1,8 @@
 #include "ui/display/menu_page.h"
 
 #include "etl/array.h"
+#include "ui/audio/sound_effects.h"
+#include "ui/audio/speaker.h"
 #include "ui/display/display.h"
 #include "ui/display/display_fields.h"
 #include "ui/display/fonts.h"
@@ -70,16 +72,31 @@ void MenuPage::cursor_next() {
   if (cursor_position > cursor_max) cursor_position = cursor_min;
 }
 
+void MenuPage::playCursorMoveSound() const {
+  speaker.playSound(cursor_position == cursor_min ? fx::doubleClick : fx::click);
+}
+
 bool SettingsMenuPage::button_event(Button button, ButtonEvent state, uint8_t count) {
   switch (button) {
     case Button::UP:
-      if (state == ButtonEvent::CLICKED) cursor_prev();
+      if (state == ButtonEvent::CLICKED) {
+        cursor_prev();
+        playCursorMoveSound();
+      }
       break;
     case Button::DOWN:
-      if (state == ButtonEvent::CLICKED) cursor_next();
+      if (state == ButtonEvent::CLICKED) {
+        cursor_next();
+        playCursorMoveSound();
+      }
       break;
     case Button::LEFT:
-      setting_change(Button::LEFT, state, count);
+      if (state == ButtonEvent::CLICKED && cursor_position != CURSOR_BACK &&
+          !cursorUsesLeftButton()) {
+        leftButtonBackShortcut(state, count);
+      } else {
+        setting_change(Button::LEFT, state, count);
+      }
       break;
     case Button::RIGHT:
       setting_change(Button::RIGHT, state, count);
@@ -92,6 +109,13 @@ bool SettingsMenuPage::button_event(Button button, ButtonEvent state, uint8_t co
   if (button != Button::NONE) redraw = true;
   return redraw;  // update display after button push so that the UI reflects any changes
                   // immediately
+}
+
+void MenuPage::resetCursor() { cursor_position = cursor_min; }
+
+void SettingsMenuPage::leftButtonBackShortcut(ButtonEvent state, uint8_t count) {
+  cursor_position = cursor_min;
+  setting_change(Button::LEFT, state, count);
 }
 
 void MenuPage::push_page(MenuPage* page) {

--- a/src/vario/ui/display/menu_page.h
+++ b/src/vario/ui/display/menu_page.h
@@ -88,6 +88,8 @@ class MenuPage {
   // Assumes(?) the screen is already clear.
   virtual void draw() = 0;
 
+  virtual void resetCursor();
+
   // Returns the current modal page on the stack.
   // If there is no modal page, returns NULL.
   MenuPage* get_modal_page();
@@ -99,6 +101,7 @@ class MenuPage {
  protected:
   void cursor_prev();
   void cursor_next();
+  void playCursorMoveSound() const;
 
   // Pushes a new modal page onto the stack to receive draw events
   static void push_page(MenuPage* page);
@@ -131,6 +134,8 @@ class SettingsMenuPage : public MenuPage {
 
  protected:
   virtual void setting_change(Button dir, ButtonEvent state, uint8_t count) = 0;
+  virtual bool cursorUsesLeftButton() const { return false; }
+  void leftButtonBackShortcut(ButtonEvent state, uint8_t count);
 };
 
 // A simple helper class to handle simple menu items that draw things like

--- a/src/vario/ui/display/pages/dialogs/page_flight_summary.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_flight_summary.cpp
@@ -29,20 +29,15 @@ void PageFlightSummary::draw() {
     display_menuTitle("SUMMARY");
 
     u8g2.setFont(leaf_6x12);
-    if (deleted) {
-      u8g2.setCursor(0, 67);
-      u8g2.print("Log deleted");
-    } else {
-      logbook_card::drawFlightCard(summary);
+    logbook_card::drawFlightCard(summary);
 
-      menu_ui::beginRow(156, cursor_position == 0);
-      menu_ui::drawLabel(2, 156, "Delete");
-      if (cursor_position == 0) {
-        u8g2.setCursor(65, 156);
-        u8g2.print("HOLD");
-      }
-      menu_ui::endRow();
+    menu_ui::beginRow(156, cursor_position == 0);
+    menu_ui::drawLabel(2, 156, "Delete");
+    if (cursor_position == 0) {
+      u8g2.setCursor(65, 156);
+      u8g2.print("HOLD");
     }
+    menu_ui::endRow();
 
     if (deletePending) {
       uint8_t width =
@@ -67,14 +62,18 @@ void PageFlightSummary::setting_change(Button dir, ButtonEvent state, uint8_t co
     return;
   }
 
-  if (cursor_position == 0 && !deleted) {
-    if (state == ButtonEvent::INCREMENTED) {
+  if (cursor_position == 0) {
+    if (state == ButtonEvent::INCREMENTED && (dir == Button::CENTER || dir == Button::RIGHT)) {
       deletePending = count;
       if (count >= DELETE_HOLD_COUNT) {
         buttons.consumeButton();
-        deleted = LogbookEntryFile::deleteFiles(logbookPath, trackPath);
-        speaker.playSound(deleted ? fx::confirm : fx::bad);
         deletePending = 0;
+        if (LogbookEntryFile::deleteFiles(logbookPath, trackPath)) {
+          speaker.playSound(fx::confirm);
+          pop_page();
+        } else {
+          speaker.playSound(fx::bad);
+        }
       }
     } else if (state == ButtonEvent::RELEASED || state == ButtonEvent::CLICKED) {
       deletePending = 0;

--- a/src/vario/ui/display/pages/dialogs/page_flight_summary.h
+++ b/src/vario/ui/display/pages/dialogs/page_flight_summary.h
@@ -15,7 +15,6 @@ class PageFlightSummary : public SettingsMenuPage {
   void show(const FlightStats, const String& logbookPath, const String& trackPath) {
     this->logbookPath = logbookPath;
     this->trackPath = trackPath;
-    this->deleted = false;
     this->deletePending = 0;
     this->summary = LogbookEntrySummary();
     LogbookStore::readSummary(logbookPath, this->summary);
@@ -29,7 +28,6 @@ class PageFlightSummary : public SettingsMenuPage {
   String logbookPath;
   String trackPath;
   LogbookEntrySummary summary;
-  bool deleted = false;
   uint8_t deletePending = 0;
   static bool showing_;
 };

--- a/src/vario/ui/display/pages/dialogs/page_list_select.cpp
+++ b/src/vario/ui/display/pages/dialogs/page_list_select.cpp
@@ -32,6 +32,7 @@ void PageListSelect::setting_change(Button dir, ButtonEvent state, uint8_t count
   }
 
   callback(cursor_position);
+  speaker.playSound(fx::neutral);
   pop_page();
 }
 

--- a/src/vario/ui/display/pages/fanet/page_fanet.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet.cpp
@@ -24,6 +24,7 @@ void PageFanet::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case 0:
       // Ground Tracking Selection
+      speaker.playSound(fx::increase);
       PageFanetGroundSelect::show();
       break;
     case 1: {
@@ -40,15 +41,18 @@ void PageFanet::setting_change(Button dir, ButtonEvent state, uint8_t count) {
       };
 
       // Bring up a dialogue for the user to change the region
+      speaker.playSound(fx::increase);
       PageListSelect::show("Region", etl::array_view<const char*>(FanetRadioRegion::strings),
                            (int)settings.fanet_region, regionChanged);
     } break;
     case 2:
       // User selected statistics
+      speaker.playSound(fx::increase);
       PageFanetStats::show();
       break;
     case 3:
       // User wants to see neighbors
+      speaker.playSound(fx::increase);
       PageFanetNeighbors::show();
       break;
   }

--- a/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
+++ b/src/vario/ui/display/pages/fanet/page_fanet_ground.cpp
@@ -15,6 +15,7 @@
 void PageFanetGround::show(FanetGroundTrackingMode mode) {
   // If we're currently in a flight, show an error message
   if (flightTimer_isRunning()) {
+    speaker.playSound(fx::bad);
     PageMessage::show("ERROR",
                       "End flight Before\n"
                       "Tracking Ground\n"
@@ -23,6 +24,7 @@ void PageFanetGround::show(FanetGroundTrackingMode mode) {
   }
 
   if (settings.fanet_region == FanetRadioRegion::OFF) {
+    speaker.playSound(fx::bad);
     PageMessage::show("ERROR",
                       "Fanet Region\n"
                       "Not Set\n");
@@ -31,6 +33,7 @@ void PageFanetGround::show(FanetGroundTrackingMode mode) {
 
   // Show this page
   getInstance().mode = mode;
+  speaker.playSound(fx::increase);
   push_page(&getInstance());
 
   // Set our tracking mode to ground tracking.

--- a/src/vario/ui/display/pages/menu/page_gpx_file_select.cpp
+++ b/src/vario/ui/display/pages/menu/page_gpx_file_select.cpp
@@ -236,6 +236,7 @@ void PageGpxFileSelect::openSelectedFolder() {
   } else {
     return;
   }
+  speaker.playSound(fx::increase);
   refreshIndex();
 }
 
@@ -302,6 +303,7 @@ void PageGpxFileSelect::moveCursorDown() {
   }
 
   ensureCursorVisible();
+  playCursorMoveSound();
 }
 
 void PageGpxFileSelect::moveCursorUp() {
@@ -319,6 +321,7 @@ void PageGpxFileSelect::moveCursorUp() {
   }
 
   ensureCursorVisible();
+  playCursorMoveSound();
 }
 
 void PageGpxFileSelect::ensureCursorVisible() {

--- a/src/vario/ui/display/pages/menu/page_logbook.cpp
+++ b/src/vario/ui/display/pages/menu/page_logbook.cpp
@@ -101,6 +101,8 @@ void PageLogbook::deleteCurrent() {
   }
 }
 
+bool PageLogbook::cursorUsesLeftButton() const { return cursor_position == cursor_page; }
+
 void PageLogbook::draw() {
   u8g2.firstPage();
   do {
@@ -218,7 +220,7 @@ void PageLogbook::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   }
 
   if (cursor_position == cursor_delete) {
-    if (state == ButtonEvent::INCREMENTED) {
+    if (state == ButtonEvent::INCREMENTED && (dir == Button::CENTER || dir == Button::RIGHT)) {
       deletePending = count;
       if (count >= DELETE_HOLD_COUNT) {
         deleteCurrent();

--- a/src/vario/ui/display/pages/menu/page_logbook.h
+++ b/src/vario/ui/display/pages/menu/page_logbook.h
@@ -16,6 +16,7 @@ class PageLogbook : public SettingsMenuPage {
 
  protected:
   void setting_change(Button dir, ButtonEvent state, uint8_t count) override;
+  bool cursorUsesLeftButton() const override;
 
  private:
   enum Cursor : int8_t {

--- a/src/vario/ui/display/pages/menu/page_menu_altimeter.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_altimeter.cpp
@@ -174,8 +174,12 @@ void AltimeterMenuPage::setting_change(Button button, ButtonEvent state, uint8_t
       } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
-        mainMenuPage.quitMenu();
+        settingsMenuPage.quitMenu();
       }
       break;
   }
+}
+
+bool AltimeterMenuPage::cursorUsesLeftButton() const {
+  return cursor_position == cursor_altimeter_adjustSetting;
 }

--- a/src/vario/ui/display/pages/menu/page_menu_altimeter.h
+++ b/src/vario/ui/display/pages/menu/page_menu_altimeter.h
@@ -16,6 +16,7 @@ class AltimeterMenuPage : public SettingsMenuPage {
 
  protected:
   void setting_change(Button button, ButtonEvent state, uint8_t count);
+  bool cursorUsesLeftButton() const override;
 };
 
 #endif

--- a/src/vario/ui/display/pages/menu/page_menu_developer.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_developer.cpp
@@ -96,31 +96,34 @@ void DeveloperMenuPage::draw() {
 void DeveloperMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_developer_fanetReTx: {
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.dev_fanetFwd);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolOnOff(&settings.dev_fanetFwd);
       break;
     }
     case cursor_developer_showDebugPg: {
-      if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
         settings.toggleBoolOnOff(&settings.disp_showDebugPage);
       break;
     }
     case cursor_developer_runSelfTest: {
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         cursor_position = cursor_developer_back;
         selfTest.begin(false);  // start a self test (not the official production test)
       }
       break;
     }
     case cursor_developer_startupStart: {
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.dev_startLogAtBoot);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolOnOff(&settings.dev_startLogAtBoot);
       break;
     }
     case cursor_developer_startupDisconnect: {
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.dev_startDisconnected);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolOnOff(&settings.dev_startDisconnected);
       break;
     }
     case cursor_developer_busLogControl: {
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         if (!busLog.isLogging()) {
           if (busLog.startLog()) {
             speaker.playSound(fx::started);

--- a/src/vario/ui/display/pages/menu/page_menu_display.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_display.cpp
@@ -104,15 +104,15 @@ void DisplayMenuPage::draw() {
 void DisplayMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_display_show_simple:
-      if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
         togglePrimaryPageSetting(&settings.disp_showSimplePage);
       break;
     case cursor_display_show_thrm:
-      if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
         togglePrimaryPageSetting(&settings.disp_showThmPage);
       break;
     case cursor_display_show_nav:
-      if (state == ButtonEvent::CLICKED && dir == Button::CENTER)
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
         togglePrimaryPageSetting(&settings.disp_showNavPage);
       break;
     case cursor_display_contrast:
@@ -127,7 +127,11 @@ void DisplayMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t coun
       } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
-        mainMenuPage.quitMenu();
+        settingsMenuPage.quitMenu();
       }
   }
+}
+
+bool DisplayMenuPage::cursorUsesLeftButton() const {
+  return cursor_position == cursor_display_contrast;
 }

--- a/src/vario/ui/display/pages/menu/page_menu_display.h
+++ b/src/vario/ui/display/pages/menu/page_menu_display.h
@@ -16,6 +16,7 @@ class DisplayMenuPage : public SettingsMenuPage {
 
  protected:
   void setting_change(Button dir, ButtonEvent state, uint8_t count);
+  bool cursorUsesLeftButton() const override;
 
  private:
   static constexpr char* labels[6] = {"Back", "Basic", "User", "Navigate", "Contrast"};

--- a/src/vario/ui/display/pages/menu/page_menu_flight_tools.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_flight_tools.cpp
@@ -35,15 +35,25 @@ bool FlightToolsMenuPage::button_event(Button button, ButtonEvent state, uint8_t
       if (state == ButtonEvent::CLICKED) {
         cursor_prev();
         skip_hidden_backward();
+        playCursorMoveSound();
       }
       break;
     case Button::DOWN:
       if (state == ButtonEvent::CLICKED) {
         cursor_next();
         skip_hidden_forward();
+        playCursorMoveSound();
       }
       break;
     case Button::LEFT:
+      if (state == ButtonEvent::CLICKED && cursor_position != cursor_flight_tools_back &&
+          cursor_position != cursor_flight_tools_varioVolume) {
+        speaker.playSound(fx::cancel);
+        settings.save();
+        mainMenuPage.backToMainMenu();
+        break;
+      }
+      [[fallthrough]];
     case Button::RIGHT:
     case Button::CENTER:
       setting_change(button, state, count);
@@ -145,12 +155,13 @@ void FlightToolsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t 
 
   switch (cursor_position) {
     case cursor_flight_tools_profiles:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
         profileSelectPage.show();
       }
       break;
     case cursor_flight_tools_syncAlt:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         if (baro.syncToGPSAlt()) {
           speaker.playSound(fx::enter);
         } else {
@@ -164,7 +175,7 @@ void FlightToolsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t 
       }
       break;
     case cursor_flight_tools_savePoint:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         Waypoint savedWaypoint;
         String error;
         if (user_waypoints::appendCurrentPosition(savedWaypoint, error)) {
@@ -180,7 +191,7 @@ void FlightToolsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t 
       break;
     case cursor_flight_tools_resumeRoute:
     case cursor_flight_tools_resumePoint:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         if (navigator.resumeLastNav()) {
           speaker.playSound(fx::confirm);
         } else {
@@ -190,7 +201,7 @@ void FlightToolsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t 
       }
       break;
     case cursor_flight_tools_resetRoute:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         if (navigator.activeRouteIndex && navigator.activateRoute(navigator.activeRouteIndex)) {
           speaker.playSound(fx::confirm);
         } else {
@@ -200,7 +211,7 @@ void FlightToolsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t 
       }
       break;
     case cursor_flight_tools_restartRoute:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         if (navigator.restartLastRoute()) {
           speaker.playSound(fx::confirm);
         } else {
@@ -210,7 +221,7 @@ void FlightToolsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t 
       }
       break;
     case cursor_flight_tools_cancelNav:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         navigator.cancelNav();
         cursor_position = cursor_flight_tools_back;
       }

--- a/src/vario/ui/display/pages/menu/page_menu_log.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_log.cpp
@@ -99,15 +99,18 @@ void LogMenuPage::drawLogMenu() {
 void LogMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_log_saveLog: {
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.log_saveTrack);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolOnOff(&settings.log_saveTrack);
       break;
     }
     case cursor_log_autoStart: {
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.log_autoStart);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolOnOff(&settings.log_autoStart);
       break;
     }
     case cursor_log_autoStop: {
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.log_autoStop);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolOnOff(&settings.log_autoStop);
       break;
     }
     case cursor_log_back: {
@@ -118,7 +121,7 @@ void LogMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
       } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
-        mainMenuPage.quitMenu();
+        settingsMenuPage.quitMenu();
       }
       break;
     }

--- a/src/vario/ui/display/pages/menu/page_menu_nav_data.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_nav_data.cpp
@@ -38,15 +38,24 @@ bool NavDataMenuPage::button_event(Button button, ButtonEvent state, uint8_t cou
       if (state == ButtonEvent::CLICKED) {
         cursor_prev();
         skip_hidden_backward();
+        playCursorMoveSound();
       }
       break;
     case Button::DOWN:
       if (state == ButtonEvent::CLICKED) {
         cursor_next();
         skip_hidden_forward();
+        playCursorMoveSound();
       }
       break;
     case Button::LEFT:
+      if (state == ButtonEvent::CLICKED && cursor_position != cursor_nav_data_back) {
+        speaker.playSound(fx::cancel);
+        settings.save();
+        mainMenuPage.backToMainMenu();
+        break;
+      }
+      [[fallthrough]];
     case Button::RIGHT:
     case Button::CENTER:
       setting_change(button, state, count);
@@ -153,6 +162,7 @@ void NavDataMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t coun
       break;
     case cursor_nav_data_selectDest:
       if (state == ButtonEvent::CLICKED && (dir == Button::RIGHT || dir == Button::CENTER)) {
+        speaker.playSound(fx::increase);
         navDataSelectPage.show();
       } else if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);
@@ -160,6 +170,7 @@ void NavDataMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t coun
       break;
     case cursor_nav_data_loadFile:
       if (state == ButtonEvent::CLICKED && (dir == Button::RIGHT || dir == Button::CENTER)) {
+        speaker.playSound(fx::increase);
         gpxFileSelectPage.show();
       } else if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);

--- a/src/vario/ui/display/pages/menu/page_menu_settings.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_settings.cpp
@@ -54,9 +54,21 @@ namespace {
                                  menu_ui::GLYPH_FANET};
 }  // namespace
 
-void SettingsRootMenuPage::backToSettingsMenu() {
+void SettingsRootMenuPage::backToSettingsMenu() { settings_menu_page = page_menu_settings_root; }
+
+void SettingsRootMenuPage::resetCursor() {
   cursor_position = cursor_settings_back;
   settings_menu_page = page_menu_settings_root;
+}
+
+void SettingsRootMenuPage::exitToMainMenu() {
+  resetCursor();
+  mainMenuPage.backToMainMenu();
+}
+
+void SettingsRootMenuPage::quitMenu() {
+  resetCursor();
+  mainMenuPage.quitMenu();
 }
 
 void SettingsRootMenuPage::focusSystemUpdate() {
@@ -149,36 +161,60 @@ void SettingsRootMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t
       if (state == ButtonEvent::CLICKED) {
         speaker.playSound(fx::cancel);
         settings.save();
-        mainMenuPage.backToMainMenu();
+        exitToMainMenu();
       } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
-        mainMenuPage.quitMenu();
+        quitMenu();
       }
       break;
     case cursor_settings_vario:
-      if (state == ButtonEvent::CLICKED) settings_menu_page = page_menu_settings_vario;
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
+        settings_menu_page = page_menu_settings_vario;
+      }
       break;
     case cursor_settings_altimeter:
-      if (state == ButtonEvent::CLICKED) settings_menu_page = page_menu_settings_altimeter;
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
+        settings_menu_page = page_menu_settings_altimeter;
+      }
       break;
     case cursor_settings_display:
-      if (state == ButtonEvent::CLICKED) settings_menu_page = page_menu_settings_display;
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
+        settings_menu_page = page_menu_settings_display;
+      }
       break;
     case cursor_settings_units:
-      if (state == ButtonEvent::CLICKED) settings_menu_page = page_menu_settings_units;
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
+        settings_menu_page = page_menu_settings_units;
+      }
       break;
     case cursor_settings_logging:
-      if (state == ButtonEvent::CLICKED) settings_menu_page = page_menu_settings_logging;
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
+        settings_menu_page = page_menu_settings_logging;
+      }
       break;
     case cursor_settings_connect:
-      if (state == ButtonEvent::CLICKED) settings_menu_page = page_menu_settings_connect;
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
+        settings_menu_page = page_menu_settings_connect;
+      }
       break;
     case cursor_settings_system:
-      if (state == ButtonEvent::CLICKED) settings_menu_page = page_menu_settings_system;
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
+        settings_menu_page = page_menu_settings_system;
+      }
       break;
     case cursor_settings_fanet:
-      if (state == ButtonEvent::CLICKED) PageFanet::show();
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
+        PageFanet::show();
+      }
       break;
   }
 }
@@ -211,6 +247,7 @@ bool SettingsRootMenuPage::settingsRootButtonEvent(Button button, ButtonEvent st
       if (state == ButtonEvent::CLICKED) {
         cursor_prev();
         skip_hidden_backward();
+        playCursorMoveSound();
         redraw = true;
       }
       break;
@@ -218,10 +255,19 @@ bool SettingsRootMenuPage::settingsRootButtonEvent(Button button, ButtonEvent st
       if (state == ButtonEvent::CLICKED) {
         cursor_next();
         skip_hidden_forward();
+        playCursorMoveSound();
         redraw = true;
       }
       break;
     case Button::LEFT:
+      if (state == ButtonEvent::CLICKED && cursor_position != cursor_settings_back) {
+        speaker.playSound(fx::cancel);
+        settings.save();
+        exitToMainMenu();
+        redraw = true;
+        break;
+      }
+      [[fallthrough]];
     case Button::RIGHT:
     case Button::CENTER:
       if (state == ButtonEvent::CLICKED || state == ButtonEvent::HELD) {

--- a/src/vario/ui/display/pages/menu/page_menu_settings.h
+++ b/src/vario/ui/display/pages/menu/page_menu_settings.h
@@ -14,7 +14,10 @@ class SettingsRootMenuPage : public SettingsMenuPage {
   }
   void draw();
   bool button_event(Button button, ButtonEvent state, uint8_t count) override;
+  void resetCursor() override;
   void backToSettingsMenu();
+  void exitToMainMenu();
+  void quitMenu();
   void focusSystemUpdate();
 
  protected:

--- a/src/vario/ui/display/pages/menu/page_menu_system.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_system.cpp
@@ -169,10 +169,11 @@ void SystemMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count
       if (state == ButtonEvent::CLICKED) settings.adjustAutoOff(dir);
       break;
     case cursor_system_showWarning:
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.system_showWarning);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolOnOff(&settings.system_showWarning);
       break;
     case cursor_system_reset:
-      if (state == ButtonEvent::INCREMENTED) {
+      if (state == ButtonEvent::INCREMENTED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         resetPending = count * 8;
         if (count == 12) {
           buttons.consumeButton();
@@ -191,13 +192,15 @@ void SystemMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count
       } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
-        mainMenuPage.quitMenu();
+        settingsMenuPage.quitMenu();
       }
       break;
     case cursor_system_about:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
+        speaker.playSound(fx::increase);
         about_page.show();
-      } else if (state == ButtonEvent::INCREMENTED && count == 4) {
+      } else if (state == ButtonEvent::INCREMENTED && count == 4 &&
+                 (dir == Button::CENTER || dir == Button::RIGHT)) {
         // toggle developer mode
         settings.toggleBoolOnOff(&settings.dev_mode);
 
@@ -213,14 +216,21 @@ void SystemMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count
       }
       break;
     case cursor_system_updateFW:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         if (wifi_menu_ui::isConnectedToNamedNetwork()) {
+          speaker.playSound(fx::increase);
           wifiMenuPage.showFirmwareUpdate();
         } else {
           focusUpdate();
+          speaker.playSound(fx::increase);
           wifiMenuPage.showSetup();
         }
       }
       break;
   }
+}
+
+bool SystemMenuPage::cursorUsesLeftButton() const {
+  return cursor_position == cursor_system_timezone || cursor_position == cursor_system_volume ||
+         cursor_position == cursor_system_poweroff;
 }

--- a/src/vario/ui/display/pages/menu/page_menu_system.h
+++ b/src/vario/ui/display/pages/menu/page_menu_system.h
@@ -21,6 +21,7 @@ class SystemMenuPage : public SettingsMenuPage {
 
  protected:
   void setting_change(Button dir, ButtonEvent state, uint8_t count);
+  bool cursorUsesLeftButton() const override;
 
  private:
   void drawSystemMenu();

--- a/src/vario/ui/display/pages/menu/page_menu_units.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_units.cpp
@@ -96,29 +96,35 @@ void UnitsMenuPage::draw() {
 void UnitsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_units_alt:
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_alt);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolNeutral(&settings.units_alt);
       break;
     case cursor_units_climb:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         settings.toggleBoolNeutral(&settings.units_climb);  // change climb units as user reqested
         settings.adjustSinkAlarmUnits(
             settings.units_climb);  // and change sink-alarm units to match
       }
       break;
     case cursor_units_speed:
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_speed);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolNeutral(&settings.units_speed);
       break;
     case cursor_units_distance:
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_distance);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolNeutral(&settings.units_distance);
       break;
     case cursor_units_heading:
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_heading);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolNeutral(&settings.units_heading);
       break;
     case cursor_units_temp:
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_temp);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolNeutral(&settings.units_temp);
       break;
     case cursor_units_hours:
-      if (state == ButtonEvent::CLICKED) settings.toggleBoolNeutral(&settings.units_hours);
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolNeutral(&settings.units_hours);
       break;
     case cursor_units_back:
       if (state == ButtonEvent::CLICKED) {
@@ -128,7 +134,7 @@ void UnitsMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count)
       } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
-        mainMenuPage.quitMenu();
+        settingsMenuPage.quitMenu();
       }
       break;
   }

--- a/src/vario/ui/display/pages/menu/page_menu_vario.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.cpp
@@ -187,8 +187,13 @@ void VarioMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count)
       } else if (state == ButtonEvent::HELD) {
         speaker.playSound(fx::exit);
         settings.save();
-        mainMenuPage.quitMenu();
+        settingsMenuPage.quitMenu();
       }
       break;
   }
+}
+
+bool VarioMenuPage::cursorUsesLeftButton() const {
+  return cursor_position == cursor_vario_volume || cursor_position == cursor_vario_sensitive ||
+         cursor_position == cursor_vario_climbstart || cursor_position == cursor_vario_sinkalarm;
 }

--- a/src/vario/ui/display/pages/menu/page_menu_vario.h
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.h
@@ -16,6 +16,7 @@ class VarioMenuPage : public SettingsMenuPage {
 
  protected:
   void setting_change(Button dir, ButtonEvent state, uint8_t count);
+  bool cursorUsesLeftButton() const override;
 
  private:
   static constexpr char* labels[6] = {

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -172,7 +172,7 @@ void WifiMenuPage::draw() {
 void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) {
   switch (cursor_position) {
     case cursor_wifi_resetWifiSettings:
-      if (state == ButtonEvent::INCREMENTED) {
+      if (state == ButtonEvent::INCREMENTED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         resetPending = count;
         if (count >= RESET_HOLD_COUNT) {
           buttons.consumeButton();
@@ -187,7 +187,7 @@ void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) 
       }
       break;
     case cursor_wifi_bluetooth:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         speaker.playSound(fx::confirm);
         settings.system_bluetoothOn = !settings.system_bluetoothOn;
         if (settings.system_bluetoothOn) {
@@ -203,8 +203,9 @@ void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) 
       }
       break;
     case cursor_wifi_setup:
-      if (state == ButtonEvent::CLICKED) {
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT)) {
         heap_monitor::checkpoint("wifi-menu-setup-click");
+        speaker.playSound(fx::increase);
         showSetup();
       }
       break;
@@ -215,7 +216,7 @@ void WifiMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count) 
         settingsMenuPage.backToSettingsMenu();
         if (state == ButtonEvent::HELD) {
           speaker.playSound(fx::exit);
-          mainMenuPage.quitMenu();
+          settingsMenuPage.quitMenu();
         }
       }
       break;
@@ -359,6 +360,7 @@ void PageMenuSystemWifiWebApp::setting_change(Button dir, ButtonEvent state, uin
   if (using_leaf_wifi) return;
 
   if (cursor_position == 0) {
+    speaker.playSound(fx::increase);
     start(true);
     cursor_position = CURSOR_BACK;
     cursor_max = get_labels().size() - 1;

--- a/src/vario/ui/display/pages/menu/page_nav_data_select.cpp
+++ b/src/vario/ui/display/pages/menu/page_nav_data_select.cpp
@@ -122,6 +122,7 @@ void PageNavDataSelect::moveCursorDown() {
   }
 
   ensureCursorVisible();
+  playCursorMoveSound();
 }
 
 void PageNavDataSelect::moveCursorUp() {
@@ -140,6 +141,7 @@ void PageNavDataSelect::moveCursorUp() {
   }
 
   ensureCursorVisible();
+  playCursorMoveSound();
 }
 
 void PageNavDataSelect::ensureCursorVisible() {

--- a/src/vario/ui/display/pages/menu/page_profile_select.cpp
+++ b/src/vario/ui/display/pages/menu/page_profile_select.cpp
@@ -140,6 +140,7 @@ void PageProfileSelect::moveCursorDown() {
   }
 
   ensureCursorVisible();
+  playCursorMoveSound();
 }
 
 void PageProfileSelect::moveCursorUp() {
@@ -165,6 +166,7 @@ void PageProfileSelect::moveCursorUp() {
   }
 
   ensureCursorVisible();
+  playCursorMoveSound();
 }
 
 void PageProfileSelect::ensureCursorVisible() {

--- a/src/vario/ui/display/pages/primary/page_menu_main.cpp
+++ b/src/vario/ui/display/pages/primary/page_menu_main.cpp
@@ -39,15 +39,16 @@ enum display_menu_pages {
 // tracking which menu page we're on (we might move from the main menu page into a sub-meny)
 uint8_t menu_page = page_menu_main;
 
-void MainMenuPage::backToMainMenu() {
-  cursor_position = cursor_back;
-  menu_page = page_menu_main;
-}
+void MainMenuPage::backToMainMenu() { menu_page = page_menu_main; }
 
-void MainMenuPage::quitMenu() {
+void MainMenuPage::resetCursor() {
   cursor_position = cursor_back;
   menu_page = page_menu_main;
   firstOpened = true;
+}
+
+void MainMenuPage::quitMenu() {
+  resetCursor();
 #ifndef DEBUG_WIFI
   if (!webserver_user_app_always_on()) {
     wifi_menu_ui::disconnectFromNetwork();
@@ -126,37 +127,44 @@ void MainMenuPage::menu_item_action(Button button) {
       break;
     case cursor_settings:
       if (button == Button::RIGHT || button == Button::CENTER) {
+        speaker.playSound(fx::increase);
         settingsMenuPage.backToSettingsMenu();
         menu_page = page_menu_settings;
       }
       break;
     case cursor_flightTools:
       if (button == Button::RIGHT || button == Button::CENTER) {
+        speaker.playSound(fx::increase);
         menu_page = page_menu_flightTools;
       }
       break;
     case cursor_navData:
       if (button == Button::RIGHT || button == Button::CENTER) {
+        speaker.playSound(fx::increase);
         menu_page = page_menu_navData;
       }
       break;
     case cursor_gps:
       if (button == Button::RIGHT || button == Button::CENTER) {
+        speaker.playSound(fx::increase);
         menu_page = page_menu_gps;
       }
       break;
     case cursor_webApp:
       if (button == Button::RIGHT || button == Button::CENTER) {
+        speaker.playSound(fx::increase);
         wifiMenuPage.showWebApp();
       }
       break;
     case cursor_logbook:
       if (button == Button::RIGHT || button == Button::CENTER) {
+        speaker.playSound(fx::increase);
         logMenuPage.showLogbook();
       }
       break;
     case cursor_developer:
       if (button == Button::RIGHT || button == Button::CENTER) {
+        speaker.playSound(fx::increase);
         menu_page = page_menu_developer;
       }
       break;
@@ -184,6 +192,7 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonEvent state, uint8_t
       if (state == ButtonEvent::CLICKED) {
         cursor_prev();
         skip_hidden_backward();
+        playCursorMoveSound();
         redraw = true;
       }
       break;
@@ -191,10 +200,17 @@ bool MainMenuPage::mainMenuButtonEvent(Button button, ButtonEvent state, uint8_t
       if (state == ButtonEvent::CLICKED) {
         cursor_next();
         skip_hidden_forward();
+        playCursorMoveSound();
         redraw = true;
       }
       break;
     case Button::LEFT:
+      if (state == ButtonEvent::CLICKED) {
+        speaker.playSound(fx::exit);
+        quitMenu();
+        redraw = true;
+      }
+      break;
     case Button::RIGHT:
     case Button::CENTER:
       if (state == ButtonEvent::CLICKED) {

--- a/src/vario/ui/display/pages/primary/page_menu_main.h
+++ b/src/vario/ui/display/pages/primary/page_menu_main.h
@@ -14,6 +14,7 @@ class MainMenuPage : public MenuPage {
   }
   bool button_event(Button button, ButtonEvent state, uint8_t count);
   void draw();
+  void resetCursor() override;
   void backToMainMenu();
   void quitMenu();
 

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -482,6 +482,8 @@ void nav_cursor_move(Button button) {
     navigatePage_cursorPosition++;
     if (navigatePage_cursorPosition > navigatePage_cursorMax) navigatePage_cursorPosition = 0;
   }
+  speaker.playSound(navigatePage_cursorPosition == cursor_navigatePage_none ? fx::doubleClick
+                                                                            : fx::click);
 
   if (navigatePage_cursorPosition == cursor_navigatePage_waypoint) {
     if (navigator.navigating) {

--- a/src/vario/ui/display/pages/primary/page_simple.cpp
+++ b/src/vario/ui/display/pages/primary/page_simple.cpp
@@ -145,6 +145,8 @@ void simple_page_cursor_move(Button button) {
     simple_page_cursor_position++;
     if (simple_page_cursor_position > simple_page_cursor_max) simple_page_cursor_position = 0;
   }
+  speaker.playSound(simple_page_cursor_position == cursor_simplePage_none ? fx::doubleClick
+                                                                          : fx::click);
 }
 
 void simplePage_button(Button button, ButtonEvent state, uint8_t count) {

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -210,6 +210,8 @@ void thermal_page_cursor_move(Button button) {
     thermal_page_cursor_position++;
     if (thermal_page_cursor_position > thermal_page_cursor_max) thermal_page_cursor_position = 0;
   }
+  speaker.playSound(thermal_page_cursor_position == cursor_thermalPage_none ? fx::doubleClick
+                                                                            : fx::click);
 }
 
 void thermalPage_button(Button button, ButtonEvent state, uint8_t count) {

--- a/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_adv.cpp
@@ -114,6 +114,8 @@ void cursor_move(Button button) {
     if (thermalAdvPage_cursor_position > cursor_thermalAdvPage_cursor_max)
       thermalAdvPage_cursor_position = 0;
   }
+  speaker.playSound(thermalAdvPage_cursor_position == cursor_thermalAdvPage_none ? fx::doubleClick
+                                                                                 : fx::click);
 }
 
 void thermalPageAdv_button(Button button, ButtonEvent state, uint8_t count) {


### PR DESCRIPTION
## Summary

- Polished Leaf on-device UI navigation across main pages, menus, submenus, and dialogs.
- Prevented left-scroll wrapping from main vario pages back to Menu; Menu now remains reachable only by scrolling right.
- Added LEFT-as-back shortcut for menu rows that do not use LEFT for value adjustment.
- Preserved Main Menu and Settings cursor positions while navigating within their respective menu layers, then reset them when exiting those layers.
- Reset menu/page cursor state during shutdown so charge-mode wake behaves like a cold start.
- Simplified flight-summary log deletion so deleting closes the summary instead of showing an extra “Log Deleted” page.
- Added consistent UI sounds for cursor movement, wrapping, and entering deeper menu/modal layers.

## Verification

- Ran formatter: `powershell -ExecutionPolicy Bypass -File src\scripts\format_all_files.ps1`
- Built release firmware: `pio run -e leaf_3_2_6_release`
- Checked whitespace: `git diff --check` 

## Notes

- Cursor UP/DOWN now uses a short single-click sound.
- Cursor wrap to Back/none uses the double-click sound.
- Entering deeper menu/modal layers uses the same `increase` sound as entering Menu from a main vario page.