### PR TITLE
Defer FANET detection until hardware setup

### DIFF
--- a/src/vario/comms/fanet_radio.cpp
+++ b/src/vario/comms/fanet_radio.cpp
@@ -484,12 +484,16 @@ void FanetRadio::subscribe(etl::imessage_bus* bus) {
 }
 
 void FanetRadio::setup() {
-  logDetectionResult();
   heap_monitor::checkpoint("fanet-setup-start");
-  if (state == FanetRadioState::UNINSTALLED) {
+  if (!detectFanet()) {
+    state = FanetRadioState::UNINSTALLED;
+    logDetectionResult();
     heap_monitor::checkpoint("fanet-setup-skipped");
     return;
   }
+
+  state = FanetRadioState::UNINITIALIZED;
+  logDetectionResult();
 
   if (!probeFanetSpi()) {
     heap_monitor::checkpoint("fanet-setup-probe-failed");

--- a/src/vario/comms/fanet_radio.h
+++ b/src/vario/comms/fanet_radio.h
@@ -33,16 +33,9 @@ class FanetRadio : public etl::message_router<FanetRadio, GpsReading>,
   friend void webserver_setup();
 
  public:
-  // Singleton class
-  FanetRadio() : message_router(0) {
-    // Detect if FANET is installed on this device.  If not found,
-    // short circuit and place into an unsupported state
-    if (!detectFanet()) {
-      state = FanetRadioState::UNINSTALLED;
-      return;
-    }
-    state = FanetRadioState::UNINITIALIZED;
-  }
+  // Keep singleton construction free of hardware access. FANET detection runs from setup(),
+  // after Arduino and the shared SPI bus have been initialized.
+  FanetRadio() : message_router(0) {}
 
   // Sets up the FANET Radio connector
   uint32_t fanet_getTick() const override { return millis(); }


### PR DESCRIPTION
> Moves FANET hardware detection out of the global singleton constructor and into `FanetRadio::setup()`, after Arduino and the shared SPI bus are initialized. Units without a FANET module now enter the `UNINSTALLED` state and skip SPI probing, radio allocation, and task creation.
>
> Testing:
> - Formatted successfully
> - Built `leaf_3_2_6_release`
> - Built `leaf_3_2_7_release`
> - Successfully boot-tested a non-FANET unit
> - Flashed and verified multiple 3.2.7 units across both OTA slots