### PR TITLE
Enable dev-mode OTA updates from prereleases

### DIFF
--- a/src/vario/comms/ota.cpp
+++ b/src/vario/comms/ota.cpp
@@ -3,36 +3,149 @@
 #include <ArduinoJson.h>
 #include <HTTPClient.h>
 
+#include <string.h>
 #include <stdexcept>
 
 #include "diagnostics/heap_monitor.h"
 #include "system/version_info.h"
+#include "ui/audio/speaker.h"
 #include "ui/settings/settings.h"
 
-String getLatestTagVersion() {
-  heap_monitor::checkpoint("ota-version-start");
-  Serial.print("[OTA] Getting latest tag version from ");
-  Serial.println(LeafVersionInfo::otaVersionsUrl());
-  HTTPClient http;
-  http.begin(LeafVersionInfo::otaVersionsUrl());
-  http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
-  int httpCode = http.GET();
-  if (httpCode != HTTP_CODE_OK) {
-    heap_monitor::checkpoint("ota-version-http-fail");
-    throw std::runtime_error(((String) "HTTP GET failed " + httpCode).c_str());
+namespace {
+  int versionNumberAt(const String& version, int partIndex) {
+    int currentPart = 0;
+    int value = 0;
+    bool hasDigit = false;
+
+    for (size_t i = 0; i <= version.length(); i++) {
+      const char c = i < version.length() ? version[i] : '.';
+      if (c >= '0' && c <= '9') {
+        if (currentPart == partIndex) {
+          value = value * 10 + c - '0';
+          hasDigit = true;
+        }
+      } else {
+        if (currentPart == partIndex) return hasDigit ? value : 0;
+        if (c == '.') {
+          currentPart++;
+        } else {
+          return 0;
+        }
+      }
+    }
+
+    return 0;
   }
-  heap_monitor::checkpoint("ota-version-http-ok");
 
-  String payload = http.getString();
-  heap_monitor::checkpoint("ota-version-payload");
-  JsonDocument doc;
-  deserializeJson(doc, payload);
+  int compareTagVersions(const String& lhs, const String& rhs) {
+    for (int i = 0; i < 3; i++) {
+      const int lhsPart = versionNumberAt(lhs, i);
+      const int rhsPart = versionNumberAt(rhs, i);
+      if (lhsPart < rhsPart) return -1;
+      if (lhsPart > rhsPart) return 1;
+    }
+    return 0;
+  }
 
-  String tagVersion = doc["latest_tag_versions"][LeafVersionInfo::hardwareVariant()];
-  Serial.printf("[OTA] Latest tag version for %s is %s\n", LeafVersionInfo::hardwareVariant(),
-                tagVersion);
-  heap_monitor::checkpoint("ota-version-end");
-  return tagVersion;
+  String tagVersionFromReleaseTag(const char* releaseTag) {
+    if (releaseTag == nullptr || releaseTag[0] == '\0') return "";
+    if (releaseTag[0] == 'v' || releaseTag[0] == 'V') return String(releaseTag + 1);
+    return String(releaseTag);
+  }
+
+  String getLatestReleaseTagVersion() {
+    heap_monitor::checkpoint("ota-release-list-start");
+    Serial.print("[OTA] Getting latest release list from ");
+    Serial.println(LeafVersionInfo::otaReleasesApiUrl());
+
+    HTTPClient http;
+    http.begin(LeafVersionInfo::otaReleasesApiUrl());
+    http.addHeader("Accept", "application/vnd.github+json");
+    http.addHeader("User-Agent", "leaf-firmware-ota");
+    http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
+    int httpCode = http.GET();
+    if (httpCode != HTTP_CODE_OK) {
+      heap_monitor::checkpoint("ota-release-list-http-fail");
+      throw std::runtime_error(((String) "HTTP GET failed " + httpCode).c_str());
+    }
+    heap_monitor::checkpoint("ota-release-list-http-ok");
+
+    String payload = http.getString();
+    heap_monitor::checkpoint("ota-release-list-payload");
+    JsonDocument doc;
+    DeserializationError error = deserializeJson(doc, payload);
+    if (error) {
+      heap_monitor::checkpoint("ota-release-list-json-fail");
+      throw std::runtime_error(
+          ((String) "GitHub releases JSON parse failed: " + error.c_str()).c_str());
+    }
+    heap_monitor::checkpoint("ota-release-list-json-ok");
+
+    JsonArrayConst releases = doc.as<JsonArrayConst>();
+    if (!releases.isNull() && releases.size() > 0) {
+      String tagVersion = tagVersionFromReleaseTag(releases[0]["tag_name"]);
+      if (!tagVersion.isEmpty()) {
+        Serial.printf("[OTA] Latest release tag version is %s\n", tagVersion.c_str());
+        heap_monitor::checkpoint("ota-release-list-match");
+        return tagVersion;
+      }
+    }
+
+    heap_monitor::checkpoint("ota-release-list-no-match");
+    throw std::runtime_error("No GitHub release tag found.");
+  }
+
+  String getLatestStableTagVersion() {
+    heap_monitor::checkpoint("ota-version-start");
+    Serial.print("[OTA] Getting latest tag version from ");
+    Serial.println(LeafVersionInfo::otaVersionsUrl());
+    HTTPClient http;
+    http.begin(LeafVersionInfo::otaVersionsUrl());
+    http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
+    int httpCode = http.GET();
+    if (httpCode != HTTP_CODE_OK) {
+      heap_monitor::checkpoint("ota-version-http-fail");
+      throw std::runtime_error(((String) "HTTP GET failed " + httpCode).c_str());
+    }
+    heap_monitor::checkpoint("ota-version-http-ok");
+
+    String payload = http.getString();
+    heap_monitor::checkpoint("ota-version-payload");
+    JsonDocument doc;
+    DeserializationError error = deserializeJson(doc, payload);
+    if (error) {
+      heap_monitor::checkpoint("ota-version-json-fail");
+      throw std::runtime_error(((String) "Version JSON parse failed: " + error.c_str()).c_str());
+    }
+
+    String tagVersion = doc["latest_tag_versions"][LeafVersionInfo::hardwareVariant()];
+    Serial.printf("[OTA] Latest tag version for %s is %s\n", LeafVersionInfo::hardwareVariant(),
+                  tagVersion.c_str());
+    heap_monitor::checkpoint("ota-version-end");
+    return tagVersion;
+  }
+}  // namespace
+
+String getLatestTagVersion() {
+  if (settings.dev_mode) return getLatestReleaseTagVersion();
+  return getLatestStableTagVersion();
+}
+
+bool otaUpdateAvailable(const String& latestTagVersion) {
+  if (LeafVersionInfo::otaAlwaysUpdate()) {
+    return true;
+  }
+
+  const int tagComparison = compareTagVersions(latestTagVersion, LeafVersionInfo::tagVersion());
+  if (tagComparison > 0) return true;
+  if (tagComparison < 0) return false;
+
+  if (!settings.dev_mode || latestTagVersion != LeafVersionInfo::tagVersion()) return false;
+
+  const char* firmwareVersion = LeafVersionInfo::firmwareVersion();
+  const char* buildMetadata = strchr(firmwareVersion, '+');
+  const char* prerelease = strchr(firmwareVersion, '-');
+  return prerelease != nullptr && (buildMetadata == nullptr || prerelease < buildMetadata);
 }
 
 /*
@@ -43,6 +156,7 @@ String getLatestTagVersion() {
 */
 void PerformOTAUpdate(const char* tag) {
   heap_monitor::checkpoint("ota-update-start");
+  speaker.mute();
   char url[120];
   snprintf(url, sizeof(url), LeafVersionInfo::otaBinUrl(), tag);
   Serial.print("[OTA] Starting OTA from ");
@@ -53,6 +167,7 @@ void PerformOTAUpdate(const char* tag) {
   auto httpCode = http.GET();
   if (httpCode != HTTP_CODE_OK) {
     heap_monitor::checkpoint("ota-update-http-fail");
+    speaker.unMute();
     throw std::runtime_error(((String) "HTTP GET failed " + httpCode).c_str());
   }
   heap_monitor::checkpoint("ota-update-http-ok");
@@ -66,6 +181,7 @@ void PerformOTAUpdate(const char* tag) {
   heap_monitor::checkpoint("ota-update-begin");
   if (Update.writeStream(*payloadPtr) != binarySize) {
     heap_monitor::checkpoint("ota-update-write-fail");
+    speaker.unMute();
     throw std::runtime_error("Err writing bin->flash");
   }
   heap_monitor::checkpoint("ota-update-written");
@@ -80,6 +196,7 @@ void PerformOTAUpdate(const char* tag) {
     ESP.restart();
   } else {
     heap_monitor::checkpoint("ota-update-end-fail");
+    speaker.unMute();
     throw std::runtime_error("Err finishing update");
   }
 

--- a/src/vario/comms/ota.h
+++ b/src/vario/comms/ota.h
@@ -6,5 +6,8 @@
 // Gets the latest tag version for this hardware variant from latest release on Github
 String getLatestTagVersion();
 
+// Determines whether the latest OTA tag should be installed over the current firmware.
+bool otaUpdateAvailable(const String& latestTagVersion);
+
 // Performs an over the air update
 void PerformOTAUpdate(const char* tag);

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -2247,8 +2247,7 @@ load();
     heap_monitor::checkpoint("web-fw-check-start");
     try {
       String latestVersion = getLatestTagVersion();
-      const bool updateAvailable =
-          latestVersion != LeafVersionInfo::tagVersion() || LeafVersionInfo::otaAlwaysUpdate();
+      const bool updateAvailable = otaUpdateAvailable(latestVersion);
       heap_monitor::checkpoint(updateAvailable ? "web-fw-check-available" : "web-fw-check-current");
 
       String json = "{\"ok\":true,\"update_available\":";

--- a/src/vario/leaf_version.h
+++ b/src/vario/leaf_version.h
@@ -23,5 +23,7 @@
 #define OTA_VERSIONS_PATH OTA_ORG "/leaf/releases/latest/download/latest_versions.json"
 #define OTA_VERSIONS_URL "https://github.com/" OTA_VERSIONS_PATH
 
+#define OTA_RELEASES_API_URL "https://api.github.com/repos/" OTA_ORG "/leaf/releases?per_page=1"
+
 // If true, always perform OTA update regardless of whether already on latest version
 #define OTA_ALWAYS_UPDATE false

--- a/src/vario/system/version_info.cpp
+++ b/src/vario/system/version_info.cpp
@@ -56,6 +56,7 @@ const char* LeafVersionInfo::firmwareVersion() { return FIRMWARE_VERSION; }
 const char* LeafVersionInfo::hardwareVariant() { return HARDWARE_VARIANT; }
 const char* LeafVersionInfo::tagVersion() { return TAG_VERSION; }
 const char* LeafVersionInfo::otaVersionsUrl() { return OTA_VERSIONS_URL; }
+const char* LeafVersionInfo::otaReleasesApiUrl() { return OTA_RELEASES_API_URL; }
 const char* LeafVersionInfo::otaBinUrl() { return OTA_BIN_URL; }
 bool LeafVersionInfo::otaAlwaysUpdate() { return OTA_ALWAYS_UPDATE; }
 

--- a/src/vario/system/version_info.h
+++ b/src/vario/system/version_info.h
@@ -9,6 +9,7 @@ struct LeafVersionInfo {
   static const char* hardwareVariant();
   static const char* tagVersion();
   static const char* otaVersionsUrl();
+  static const char* otaReleasesApiUrl();
   static const char* otaBinUrl();
   static bool otaAlwaysUpdate();
 

--- a/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_wifi.cpp
@@ -567,7 +567,7 @@ void PageMenuSystemWifiUpdate::loop() {
         *wifi_state = WifiState::ERROR;
         break;
       }
-      if (latest_version_ == LeafVersionInfo::tagVersion() && !LeafVersionInfo::otaAlwaysUpdate()) {
+      if (!otaUpdateAvailable(latest_version_)) {
         log_lines.push_back("*YOU'RE UP TO DATE!");
         log_lines.push_back("*REBOOT REQUIRED");
         *wifi_state = WifiState::OTA_UP_TO_DATE;


### PR DESCRIPTION
**Summary**
- Allow dev-mode firmware update checks to use GitHub’s latest release, including prereleases.
- Keep normal user firmware checks on the existing latest official release manifest.
- Add OTA version comparison to prevent accidental downgrades.
- Mute the speaker during OTA download/install to avoid stuck tones.

**Details**
- In normal mode, Leaf still reads `latest_versions.json` from GitHub’s latest official release.
- In dev mode, Leaf queries the GitHub releases API for the newest release tag, strips a leading `v`, and uses the existing OTA binary URL format.
- OTA availability now compares numeric tag versions, so an older stable release like `0.1.7` is not treated as an update over `0.2.0`.
- Dev-mode dirty/prerelease builds with the same tag can still update into the clean release artifact for OTA validation.
- The firmware update screen and web app firmware status now share the same OTA availability helper.
- `PerformOTAUpdate()` mutes the speaker before starting the update and unmutes on failure paths.

**Verification**
- Ran formatter.
- Built successfully with `pio run -e leaf_3_2_6_release`.
- Flashed the resulting firmware to both OTA app slots on connected ESP32-S3/Leaf hardware; hashes verified.
- Manually confirmed OTA from dirty `0.2.0` derivative to clean `0.2.0` prerelease works.