### PR TITLE
Add vario volume shortcut

### DIFF
--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -278,6 +278,7 @@ void flightTimer_start() {
 
   // start timer
   speaker.playSound(fx::enter);
+  settings.resetShortcutVolume();
   flight = &igcFlight;
 
   logbook.logStartedAt = millis() / 1000;
@@ -317,6 +318,7 @@ void flightTimer_stop(bool showSummary) {
   logbookEntry.reset();
   // TODO:  A much cooler end flight sound.  Perhaps even an easter egg?
   speaker.playSound(fx::confirm);
+  settings.resetShortcutVolume();
   flight = NULL;
   trackLogEnabledForFlight = false;
   logbook = FlightStats();  // Reset the flight stats

--- a/src/vario/ui/display/display_fields.cpp
+++ b/src/vario/ui/display/display_fields.cpp
@@ -1087,10 +1087,10 @@ void display_footer(bool timerSelected) {
   // Vario Beep Volume icon
   u8g2.setCursor(37, 191);
   u8g2.setFont(leaf_icons);
-  if (settings.vario_quietMode && !flightTimer_isRunning() && settings.vario_volume != 0) {
+  if (settings.vario_quietMode && !flightTimer_isRunning() && settings.shortcutVolumeLevel != 0) {
     u8g2.print((char)('I' + 4));
   } else {
-    u8g2.print((char)('I' + settings.vario_volume));
+    u8g2.print((char)('I' + settings.shortcutVolumeLevel));
   }
 
   // Timer in lower right corner

--- a/src/vario/ui/display/pages/menu/page_menu_vario.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.cpp
@@ -25,6 +25,7 @@ enum vario_menu_items {
   cursor_vario_climbstart,
   // cursor_vario_liftyair,
   cursor_vario_sinkalarm,
+  cursor_vario_volumeShortcut,
 };
 
 void VarioMenuPage::draw() {
@@ -34,11 +35,9 @@ void VarioMenuPage::draw() {
     menu_ui::drawTitle("Vario", menu_ui::GLYPH_VARIO);
 
     // Menu Items
-    uint8_t start_y = 29;
-    uint8_t y_spacing = 16;
     uint8_t setting_name_x = 2;
     uint8_t setting_choice_x = 68;
-    uint8_t menu_items_y[] = {190, 40, 55, 70, 95, 110 /*, 135, 150, 165*/};
+    uint8_t menu_items_y[] = {190, 40, 55, 70, 85, 100, 128 /*, 135, 150, 165*/};
 
     for (int i = 0; i <= cursor_max; i++) {
       const bool selected = i == cursor_position;
@@ -128,7 +127,7 @@ void VarioMenuPage::draw() {
           }
           // Print units for climb/sink thresholds
           u8g2.setFont(leaf_labels);
-          u8g2.setDrawColor(selected ? 0 : 1);
+          u8g2.setDrawColor(1);
           if (settings.units_climb) {
             u8g2.setCursor(u8g2.getCursorX() - 20, u8g2.getCursorY() + 12);
             u8g2.print("fpm");
@@ -139,11 +138,25 @@ void VarioMenuPage::draw() {
           u8g2.setFont(leaf_6x12);
           break;
 
+        case cursor_vario_volumeShortcut:
+          u8g2.setCursor(80, menu_items_y[i]);
+          menu_ui::printGlyph(settings.volumeShortcut ? menu_ui::ICON_ON : menu_ui::ICON_OFF);
+          break;
+
         case cursor_vario_back:
           menu_ui::drawBackIcon(setting_choice_x, menu_items_y[i]);
           break;
       }
       menu_ui::endRow();
+    }
+
+    if (settings.volumeShortcut) {
+      u8g2.drawRFrame(3, 129, 90, 44, 3);
+      u8g2.setFont(leaf_5x8);
+      u8g2.drawStr(10, 140, "Hold UP or DOWN");
+      u8g2.drawStr(7, 150, "on a vario page to");
+      u8g2.drawStr(6, 160, "temporarily change");
+      u8g2.drawStr(20, 170, "vario volume");
     }
   } while (u8g2.nextPage());
 }
@@ -178,6 +191,10 @@ void VarioMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count)
       break;
     case cursor_vario_sinkalarm:
       if (state == ButtonEvent::CLICKED) settings.adjustSinkAlarm(dir);
+      break;
+    case cursor_vario_volumeShortcut:
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolOnOff(&settings.volumeShortcut);
       break;
     case cursor_vario_back:
       if (state == ButtonEvent::CLICKED) {

--- a/src/vario/ui/display/pages/menu/page_menu_vario.h
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.h
@@ -10,7 +10,7 @@ class VarioMenuPage : public SettingsMenuPage {
  public:
   VarioMenuPage() {
     cursor_position = 0;
-    cursor_max = 5;
+    cursor_max = 6;
   }
   void draw();
 
@@ -19,7 +19,7 @@ class VarioMenuPage : public SettingsMenuPage {
   bool cursorUsesLeftButton() const override;
 
  private:
-  static constexpr char* labels[6] = {
+  static constexpr char* labels[7] = {
       "Back",
       "Beep Vol",
       /*"Tones",*/
@@ -29,6 +29,7 @@ class VarioMenuPage : public SettingsMenuPage {
       "ClimbStart",
       /*"LiftyAir",*/
       "SinkAlarm",
+      "Vol Shortcut",
   };
 };
 

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -502,6 +502,16 @@ void nav_cursor_move(Button button) {
   }
 }
 
+bool navigatePage_volumeShortcut(Button button, ButtonEvent state) {
+  if (!settings.volumeShortcut || (button != Button::UP && button != Button::DOWN) ||
+      state != ButtonEvent::INCREMENTED) {
+    return false;
+  }
+
+  if (!settings.adjustShortcutVolume(button)) buttons.consumeButton();
+  return true;
+}
+
 void navigatePage_button(Button button, ButtonEvent state, uint8_t count) {
   // reset cursor time out count if a button is pushed
   navigatePage_cursorTimeCount = 0;
@@ -511,7 +521,11 @@ void navigatePage_button(Button button, ButtonEvent state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == ButtonEvent::CLICKED) nav_cursor_move(button);
+          if (navigatePage_volumeShortcut(button, state)) {
+            break;
+          } else if (state == ButtonEvent::CLICKED) {
+            nav_cursor_move(button);
+          }
           break;
         case Button::RIGHT:
           if (state == ButtonEvent::CLICKED) {

--- a/src/vario/ui/display/pages/primary/page_simple.cpp
+++ b/src/vario/ui/display/pages/primary/page_simple.cpp
@@ -149,6 +149,16 @@ void simple_page_cursor_move(Button button) {
                                                                           : fx::click);
 }
 
+bool simplePage_volumeShortcut(Button button, ButtonEvent state) {
+  if (!settings.volumeShortcut || (button != Button::UP && button != Button::DOWN) ||
+      state != ButtonEvent::INCREMENTED) {
+    return false;
+  }
+
+  if (!settings.adjustShortcutVolume(button)) buttons.consumeButton();
+  return true;
+}
+
 void simplePage_button(Button button, ButtonEvent state, uint8_t count) {
   // reset cursor time out count if a button is pushed
   simple_page_cursor_timeCount = 0;
@@ -158,7 +168,11 @@ void simplePage_button(Button button, ButtonEvent state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == ButtonEvent::CLICKED) simple_page_cursor_move(button);
+          if (simplePage_volumeShortcut(button, state)) {
+            break;
+          } else if (state == ButtonEvent::CLICKED) {
+            simple_page_cursor_move(button);
+          }
           break;
         case Button::RIGHT:
           if (state == ButtonEvent::CLICKED) {

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -214,6 +214,16 @@ void thermal_page_cursor_move(Button button) {
                                                                             : fx::click);
 }
 
+bool thermalPage_volumeShortcut(Button button, ButtonEvent state) {
+  if (!settings.volumeShortcut || (button != Button::UP && button != Button::DOWN) ||
+      state != ButtonEvent::INCREMENTED) {
+    return false;
+  }
+
+  if (!settings.adjustShortcutVolume(button)) buttons.consumeButton();
+  return true;
+}
+
 void thermalPage_button(Button button, ButtonEvent state, uint8_t count) {
   // reset cursor time out count if a button is pushed
   thermal_page_cursor_timeCount = 0;
@@ -223,7 +233,11 @@ void thermalPage_button(Button button, ButtonEvent state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == ButtonEvent::CLICKED) thermal_page_cursor_move(button);
+          if (thermalPage_volumeShortcut(button, state)) {
+            break;
+          } else if (state == ButtonEvent::CLICKED) {
+            thermal_page_cursor_move(button);
+          }
           break;
         case Button::RIGHT:
           if (state == ButtonEvent::CLICKED) {

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -162,7 +162,8 @@ void Settings::loadDefaults() {
   vario_climbAvg = DEF_CLIMB_AVERAGE;
   vario_climbStart = DEF_CLIMB_START;
   vario_volume = DEF_VOLUME_VARIO;
-  speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)vario_volume);
+  volumeShortcut = DEF_VOLUME_SHORTCUT;
+  resetShortcutVolume();
   vario_quietMode = DEF_QUIET_MODE;
   vario_tones = DEF_VARIO_TONES;
   vario_liftyAir = DEF_LIFTY_AIR;
@@ -237,7 +238,8 @@ void Settings::retrieve() {
   vario_climbAvg = leafPrefs.getChar("CLIMB_AVERAGE");
   vario_climbStart = leafPrefs.getChar("CLIMB_START");
   vario_volume = leafPrefs.getChar("VOLUME_VARIO");
-  speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)vario_volume);
+  volumeShortcut = leafPrefs.getBool("VOL_SHORTCUT", DEF_VOLUME_SHORTCUT);
+  resetShortcutVolume();
   vario_quietMode = leafPrefs.getBool("QUIET_MODE");
   vario_tones = leafPrefs.getBool("VARIO_TONES");
   vario_liftyAir = leafPrefs.getChar("LIFTY_AIR");
@@ -325,6 +327,7 @@ void Settings::save() {
   leafPrefs.putChar("CLIMB_AVERAGE", vario_climbAvg);
   leafPrefs.putChar("CLIMB_START", vario_climbStart);
   leafPrefs.putChar("VOLUME_VARIO", vario_volume);
+  leafPrefs.putBool("VOL_SHORTCUT", volumeShortcut);
   leafPrefs.putBool("QUIET_MODE", vario_quietMode);
   leafPrefs.putBool("VARIO_TONES", vario_tones);
   leafPrefs.putChar("LIFTY_AIR", vario_liftyAir);
@@ -600,6 +603,32 @@ void Settings::adjustVolumeVario(Button dir) {
     speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)vario_volume);
   }
   speaker.playSound(sound);
+  resetShortcutVolume();
+}
+
+bool Settings::adjustShortcutVolume(Button dir) {
+  sound_t sound = fx::neutral;
+
+  if (dir == Button::UP) {
+    if (shortcutVolumeLevel >= VOLUME_MAX) return false;
+    shortcutVolumeLevel++;
+    sound = fx::increase;
+  } else if (dir == Button::DOWN) {
+    if (shortcutVolumeLevel <= 0) return false;
+    shortcutVolumeLevel--;
+    sound = shortcutVolumeLevel == 0 ? fx::cancel : fx::decrease;
+  } else {
+    return false;
+  }
+
+  speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)shortcutVolumeLevel);
+  speaker.playSound(sound);
+  return true;
+}
+
+void Settings::resetShortcutVolume() {
+  shortcutVolumeLevel = vario_volume;
+  speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)shortcutVolumeLevel);
 }
 
 void Settings::adjustVolumeSystem(Button dir) {

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -36,6 +36,7 @@
 #define DEF_CLIMB_START 5       // cm/s when climb note begins
 #define DEF_VOLUME_VARIO 2      // 0=off, 1=low, 2=med, 3=high
 #define DEF_QUIET_MODE 0        // 0 = off, 1 = on (ON means no beeping until flight recording)
+#define DEF_VOLUME_SHORTCUT 0   // 0 = disabled, 1 = enabled
 // 0 == linear pitch interpolation; 1 == major C-scale for climb, minor scale for descent
 #define DEF_VARIO_TONES 0
 // In units of 10 cm/s (a sink rate of only 30cm/s means the air itself is going up).  '0' is off.
@@ -120,6 +121,8 @@ class Settings {
   int8_t vario_climbAvg;
   int8_t vario_climbStart;
   int8_t vario_volume;
+  bool volumeShortcut;
+  int8_t shortcutVolumeLevel;
   bool vario_quietMode;
   bool vario_tones;
   int8_t vario_liftyAir;
@@ -224,6 +227,8 @@ setting | samples | time avg
   void adjustClimbStart(Button dir);
   void adjustLiftyAir(Button dir);
   void adjustVolumeVario(Button dir);
+  bool adjustShortcutVolume(Button dir);
+  void resetShortcutVolume(void);
   void adjustVolumeSystem(Button dir);
   void adjustTimeZone(Button dir);
   void adjustAutoOff(Button dir);


### PR DESCRIPTION
**Summary**
- Added a persistent `volumeShortcut` setting and runtime shortcut volume level.
- Added `Vol Shortcut` to the Vario menu with contextual helper text when enabled.
- Enabled UP/DOWN hold volume adjustment on Simple, Thermal, and Nav pages.
- Reset temporary shortcut volume at boot, flight start/stop, and persistent volume changes.
- Fixed SinkAlarm units draw color on the Vario menu.

**Testing**
- Built `leaf_3_2_6_release`.
- Tested to function as expected