### PR TITLE
Factory interface improvements

### DIFF
--- a/factory_interface/src/factory_interface/app.py
+++ b/factory_interface/src/factory_interface/app.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from urllib.parse import parse_qs
 
@@ -84,7 +85,15 @@ from factory_interface.settings import (
     refresh_github_releases,
     save_settings,
 )
-from factory_interface.serial_ports import available_serial_ports
+from factory_interface.pending_setup_runs import (
+    PendingSetupRun,
+    create_pending_setup_run,
+    get_pending_setup_run,
+    latest_running_pending_setup_run,
+    list_pending_setup_runs,
+    remove_pending_setup_run,
+)
+from factory_interface.serial_ports import available_serial_ports, eligible_serial_ports
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 
@@ -176,6 +185,119 @@ def reset_setup_tasks_if_complete() -> None:
     reset_self_test_details_task()
 
 
+def setup_preflight(settings: FactoryInterfaceSettings) -> dict:
+    return {
+        "application_firmware_label": describe_application_firmware_source(
+            settings.application_firmware_source,
+            settings,
+        ),
+        "non_application_binaries_label": describe_non_application_binary_path(
+            settings.non_application_firmware_path,
+        ),
+        "firmware_files": firmware_file_sources(settings),
+        "force_format_sd_card": settings.force_format_sd_card_during_commissioning,
+        "notes": settings.setup_notes,
+        "flash": get_flash_task().snapshot(),
+    }
+
+
+def commissioning_session_summaries() -> list[dict]:
+    sessions = []
+    for run in list_pending_setup_runs():
+        sessions.append(run.snapshot())
+    for session in list_commissioning_sessions():
+        sessions.append(
+            {
+                "kind": "device",
+                "label": session.mac_address,
+                "url": f"/setup/{session.mac_address}",
+                "status": session.status,
+                "details": session.details,
+                "created_at": session.created_at.isoformat(),
+                "updated_at": session.updated_at.isoformat(),
+            }
+        )
+    return sorted(sessions, key=lambda item: item["created_at"], reverse=True)
+
+
+def promote_pending_setup_run(
+    run: PendingSetupRun,
+    device,
+):
+    mac_address = device.mac_address or device.device_id
+    if not mac_address:
+        raise RuntimeError("Discovery response did not include a MAC address.")
+
+    existing_session = get_commissioning_session(mac_address)
+    if existing_session is None:
+        existing_session = active_commissioning_session_for_device(device)
+    if existing_session is not None and existing_session.status == "running":
+        remove_pending_setup_run(run.run_id)
+        return existing_session
+
+    preflight = dict(run.preflight)
+    preflight["flash"] = get_flash_task().snapshot()
+    session = create_commissioning_session(
+        mac_address=mac_address,
+        operator=run.operator,
+        notes=run.notes,
+        device=device,
+        preflight=preflight,
+    )
+    remove_pending_setup_run(run.run_id)
+    return session
+
+
+async def monitor_pending_setup_run(run: PendingSetupRun) -> None:
+    try:
+        while get_pending_setup_run(run.run_id) is run:
+            flash_task = get_flash_task()
+            discovery_task = get_find_device_task()
+
+            if discovery_task.status == "success" and discovery_task.device is not None:
+                try:
+                    promote_pending_setup_run(run, discovery_task.device)
+                except Exception as exc:
+                    run.status = "failure"
+                    run.details = f"{type(exc).__name__}: {exc}"
+                    run.touch()
+                return
+
+            if flash_task.status == "failure":
+                run.status = "failure"
+                run.details = "Firmware flashing failed."
+                run.touch()
+                return
+
+            if discovery_task.status == "failure":
+                run.status = "failure"
+                run.details = discovery_task.error or "Network discovery failed."
+                run.touch()
+                return
+
+            if flash_task.status == "running":
+                details = "Flashing firmware."
+            elif discovery_task.status == "running":
+                details = "Searching for the newly flashed device."
+            else:
+                details = "Preparing commissioning."
+            if run.details != details:
+                run.details = details
+                run.touch()
+            await asyncio.sleep(0.25)
+    except asyncio.CancelledError:
+        return
+    finally:
+        if run.monitor_task is asyncio.current_task():
+            run.monitor_task = None
+
+
+def start_pending_setup_monitor(run: PendingSetupRun) -> None:
+    if run.monitor_task is not None:
+        run.monitor_task.cancel()
+    run.monitor_task = asyncio.create_task(monitor_pending_setup_run(run))
+
+
 def settings_template_context(
     request: Request,
     settings: FactoryInterfaceSettings,
@@ -261,9 +383,7 @@ async def setup_sessions(request: Request) -> HTMLResponse:
             request,
             {
                 "title": "Commissioning sessions",
-                "sessions": [
-                    session.snapshot() for session in list_commissioning_sessions()
-                ],
+                "sessions": commissioning_session_summaries(),
             },
         ),
     )
@@ -271,7 +391,15 @@ async def setup_sessions(request: Request) -> HTMLResponse:
 
 @app.get("/setup", response_class=HTMLResponse)
 async def setup_device(request: Request) -> HTMLResponse:
-    reset_setup_tasks_if_complete()
+    run_id = request.query_params.get("run_id", "").strip()
+    pending_run = get_pending_setup_run(run_id) if run_id else None
+    if run_id and pending_run is None:
+        return RedirectResponse(url="/", status_code=303)
+    if pending_run is None:
+        running_pending_run = latest_running_pending_setup_run()
+        if running_pending_run is not None:
+            return RedirectResponse(url=running_pending_run.snapshot()["url"], status_code=303)
+        reset_setup_tasks_if_complete()
     settings = load_settings()
     return templates.TemplateResponse(
         request,
@@ -292,6 +420,7 @@ async def setup_device(request: Request) -> HTMLResponse:
                     settings.force_format_sd_card_during_commissioning
                 ),
                 "serial_ports": available_serial_ports(),
+                "pending_run_id": pending_run.run_id if pending_run else None,
             },
         ),
     )
@@ -449,47 +578,36 @@ async def handoff_setup_session(request: Request) -> JSONResponse:
     if existing_session is not None and existing_session.status == "running":
         return JSONResponse(
             {
-                "detail": (
-                    "Discovered device already has an active commissioning session: "
-                    f"{existing_session.mac_address}."
-                )
-            },
-            status_code=409,
+                "session": existing_session.snapshot(),
+                "url": f"/setup/{existing_session.mac_address}",
+            }
         )
     active_session = active_commissioning_session_for_device(device)
     if active_session is not None:
         return JSONResponse(
             {
-                "detail": (
-                    "Discovered device already has an active commissioning session: "
-                    f"{active_session.mac_address}."
-                )
-            },
-            status_code=409,
+                "session": active_session.snapshot(),
+                "url": f"/setup/{active_session.mac_address}",
+            }
         )
 
-    operator_name = get_operator_name(request) or "unknown"
-    settings = load_settings()
-    preflight = {
-        "application_firmware_label": describe_application_firmware_source(
-            settings.application_firmware_source,
-            settings,
-        ),
-        "non_application_binaries_label": describe_non_application_binary_path(
-            settings.non_application_firmware_path,
-        ),
-        "firmware_files": firmware_file_sources(settings),
-        "force_format_sd_card": settings.force_format_sd_card_during_commissioning,
-        "notes": settings.setup_notes,
-        "flash": get_flash_task().snapshot(),
-    }
-    session = create_commissioning_session(
-        mac_address=mac_address,
-        operator=operator_name,
-        notes=settings.setup_notes,
-        device=device,
-        preflight=preflight,
-    )
+    run_id = request.query_params.get("run_id", "").strip()
+    pending_run = get_pending_setup_run(run_id) if run_id else None
+    if pending_run is None:
+        pending_run = latest_running_pending_setup_run()
+
+    if pending_run is not None:
+        session = promote_pending_setup_run(pending_run, device)
+    else:
+        operator_name = get_operator_name(request) or "unknown"
+        settings = load_settings()
+        session = create_commissioning_session(
+            mac_address=mac_address,
+            operator=operator_name,
+            notes=settings.setup_notes,
+            device=device,
+            preflight=setup_preflight(settings),
+        )
     return JSONResponse(
         {
             "session": session.snapshot(),
@@ -503,6 +621,11 @@ async def get_setup_sessions() -> JSONResponse:
     return JSONResponse(
         {"sessions": [session.snapshot() for session in list_commissioning_sessions()]}
     )
+
+
+@app.get("/api/setup/session-summaries", response_class=JSONResponse)
+async def get_setup_session_summaries() -> JSONResponse:
+    return JSONResponse({"sessions": commissioning_session_summaries()})
 
 
 @app.get("/api/setup/sessions/{mac_address}", response_class=JSONResponse)
@@ -639,9 +762,41 @@ async def cancel_setup_task() -> JSONResponse:
 
 
 @app.post("/api/setup/flash", response_class=JSONResponse)
-async def start_flash_firmware_task() -> JSONResponse:
-    task = start_flash_firmware()
-    return JSONResponse(task.snapshot())
+async def start_flash_firmware_task(request: Request) -> JSONResponse:
+    run_id = request.query_params.get("run_id", "").strip()
+    pending_run = get_pending_setup_run(run_id) if run_id else None
+    if pending_run is None:
+        pending_run = latest_running_pending_setup_run()
+    pending_run_was_running = pending_run is not None and pending_run.status == "running"
+
+    settings = load_settings()
+    if pending_run is None:
+        pending_run = create_pending_setup_run(
+            operator=get_operator_name(request) or "unknown",
+            notes=settings.setup_notes,
+            preflight=setup_preflight(settings),
+            serial_ports=eligible_serial_ports(),
+        )
+    elif pending_run.status != "running":
+        pending_run.status = "running"
+        pending_run.details = "Preparing to flash firmware."
+        pending_run.preflight = setup_preflight(settings)
+        pending_run.serial_ports = eligible_serial_ports()
+        pending_run.touch()
+
+    flash_task = get_flash_task()
+    discovery_task = get_find_device_task()
+    setup_already_running = pending_run_was_running and (
+        flash_task.status == "running"
+        or discovery_task.status in {"running", "success"}
+    )
+    if not setup_already_running:
+        flash_task = start_flash_firmware()
+    start_pending_setup_monitor(pending_run)
+
+    payload = flash_task.snapshot()
+    payload["pending_run_id"] = pending_run.run_id
+    return JSONResponse(payload)
 
 
 @app.get("/api/setup/flash", response_class=JSONResponse)

--- a/factory_interface/src/factory_interface/app.py
+++ b/factory_interface/src/factory_interface/app.py
@@ -16,6 +16,10 @@ from factory_interface.commissioning_sessions import (
     get_commissioning_session,
     list_commissioning_sessions,
     manually_rediscover_session_device,
+    restart_commissioning_device,
+    retry_commissioning_format,
+    retry_commissioning_mount,
+    retry_commissioning_self_test,
 )
 from factory_interface.commissioning_tasks import (
     cancel_flash_task,
@@ -80,6 +84,7 @@ from factory_interface.settings import (
     refresh_github_releases,
     save_settings,
 )
+from factory_interface.serial_ports import available_serial_ports
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 
@@ -91,6 +96,13 @@ app.mount(
 )
 
 templates = Jinja2Templates(directory=PACKAGE_DIR / "templates")
+
+
+def static_asset_version(filename: str) -> int:
+    return (PACKAGE_DIR / "static" / filename).stat().st_mtime_ns
+
+
+templates.env.globals["static_asset_version"] = static_asset_version
 
 OPERATOR_COOKIE_NAME = "factory_interface_operator_name"
 
@@ -279,6 +291,7 @@ async def setup_device(request: Request) -> HTMLResponse:
                 "force_format_sd_card_during_commissioning": (
                     settings.force_format_sd_card_during_commissioning
                 ),
+                "serial_ports": available_serial_ports(),
             },
         ),
     )
@@ -387,6 +400,33 @@ async def save_setup_notes(request: Request) -> JSONResponse:
     settings.setup_notes = notes
     save_settings(settings)
     return JSONResponse({"setup_notes": settings.setup_notes})
+
+
+@app.get("/api/setup/serial-ports", response_class=JSONResponse)
+async def get_serial_ports() -> JSONResponse:
+    return JSONResponse({"ports": available_serial_ports()})
+
+
+@app.post("/api/setup/serial-ports/ignore", response_class=JSONResponse)
+async def set_serial_port_ignored(request: Request) -> JSONResponse:
+    payload = await request.json()
+    device = payload.get("device")
+    ignored = payload.get("ignored")
+    if not isinstance(device, str) or not device.strip():
+        return JSONResponse({"detail": "Serial port is required."}, status_code=400)
+    if not isinstance(ignored, bool):
+        return JSONResponse({"detail": "Ignored must be true or false."}, status_code=400)
+
+    device = device.strip()
+    settings = load_settings()
+    ignored_ports = set(settings.ignored_serial_ports)
+    if ignored:
+        ignored_ports.add(device)
+    else:
+        ignored_ports.discard(device)
+    settings.ignored_serial_ports = sorted(ignored_ports, key=str.lower)
+    save_settings(settings)
+    return JSONResponse({"ports": available_serial_ports()})
 
 
 @app.post("/api/setup/handoff", response_class=JSONResponse)
@@ -504,6 +544,66 @@ async def cancel_setup_session(mac_address: str) -> JSONResponse:
     session = cancel_commissioning_session(mac_address)
     if session is None:
         return JSONResponse({"detail": "Commissioning session not found."}, status_code=404)
+    return JSONResponse(session.snapshot())
+
+
+@app.post(
+    "/api/setup/sessions/{mac_address}/retry-format",
+    response_class=JSONResponse,
+)
+async def retry_setup_session_format(mac_address: str) -> JSONResponse:
+    session = get_commissioning_session(mac_address)
+    if session is None:
+        return JSONResponse({"detail": "Commissioning session not found."}, status_code=404)
+    try:
+        retry_commissioning_format(session)
+    except RuntimeError as exc:
+        return JSONResponse({"detail": str(exc)}, status_code=409)
+    return JSONResponse(session.snapshot())
+
+
+@app.post(
+    "/api/setup/sessions/{mac_address}/retry-mount",
+    response_class=JSONResponse,
+)
+async def retry_setup_session_mount(mac_address: str) -> JSONResponse:
+    session = get_commissioning_session(mac_address)
+    if session is None:
+        return JSONResponse({"detail": "Commissioning session not found."}, status_code=404)
+    try:
+        retry_commissioning_mount(session)
+    except RuntimeError as exc:
+        return JSONResponse({"detail": str(exc)}, status_code=409)
+    return JSONResponse(session.snapshot())
+
+
+@app.post(
+    "/api/setup/sessions/{mac_address}/restart-device",
+    response_class=JSONResponse,
+)
+async def restart_setup_session_device(mac_address: str) -> JSONResponse:
+    session = get_commissioning_session(mac_address)
+    if session is None:
+        return JSONResponse({"detail": "Commissioning session not found."}, status_code=404)
+    try:
+        restart_commissioning_device(session)
+    except RuntimeError as exc:
+        return JSONResponse({"detail": str(exc)}, status_code=409)
+    return JSONResponse(session.snapshot())
+
+
+@app.post(
+    "/api/setup/sessions/{mac_address}/retry-self-test",
+    response_class=JSONResponse,
+)
+async def retry_setup_session_self_test(mac_address: str) -> JSONResponse:
+    session = get_commissioning_session(mac_address)
+    if session is None:
+        return JSONResponse({"detail": "Commissioning session not found."}, status_code=404)
+    try:
+        retry_commissioning_self_test(session)
+    except RuntimeError as exc:
+        return JSONResponse({"detail": str(exc)}, status_code=409)
     return JSONResponse(session.snapshot())
 
 

--- a/factory_interface/src/factory_interface/commissioning_sessions.py
+++ b/factory_interface/src/factory_interface/commissioning_sessions.py
@@ -47,6 +47,10 @@ HTTP_TIMEOUT_SECONDS = DEFAULT_HTTP_TIMEOUT_SECONDS
 SELF_TEST_POLL_SECONDS = 1.0
 SELF_TEST_HTTP_TIMEOUT_SECONDS = 20.0
 SELF_TEST_COMMUNICATION_GRACE_SECONDS = 180.0
+SD_FORMAT_HTTP_TIMEOUT_SECONDS = 180.0
+REBOOT_GRACE_SECONDS = 2.0
+RECONNECT_POLL_SECONDS = 1.0
+RECONNECT_TIMEOUT_SECONDS = 120.0
 
 
 def idle_task(details: str = "") -> dict:
@@ -82,6 +86,7 @@ class CommissioningSession:
                 "details": f"IP address: {self.device.ip_address}:{self.device.port}",
                 "device": self.device.snapshot(),
             },
+            "prepare_sd_card": idle_task(),
             "firmware_version": idle_task(),
             "fanet_id": idle_task(),
             "interactive_self_test": idle_task(),
@@ -164,7 +169,12 @@ def fetch_text(
         raise RuntimeError(f"HTTP {exc.code} from {url}: {detail}") from exc
 
 
-def post_json(url: str, payload: dict) -> dict:
+def post_json(
+    url: str,
+    payload: dict,
+    *,
+    timeout: float = HTTP_TIMEOUT_SECONDS,
+) -> dict:
     data = json.dumps(payload).encode("utf-8")
     request = Request(
         url,
@@ -175,7 +185,7 @@ def post_json(url: str, payload: dict) -> dict:
     try:
         with urlopen_with_timeout_retries(
             request,
-            timeout=HTTP_TIMEOUT_SECONDS,
+            timeout=timeout,
         ) as response:
             return json.loads(response.read().decode("utf-8"))
     except HTTPError as exc:
@@ -227,6 +237,122 @@ async def read_session_mac_address(session: CommissioningSession) -> str:
             f"Device MAC address changed from {session.mac_address} to {mac_address}."
         )
     return mac_address
+
+
+def sd_preparation_details(payload: dict) -> str:
+    stage = str(payload.get("stage", "unknown"))
+    attempts = int(payload.get("mount_attempts", 0))
+    error = str(payload.get("esp_error", "unknown"))
+    return f"stage={stage}; mount attempts={attempts}; ESP error={error}"
+
+
+async def prepare_session_sd_card(session: CommissioningSession) -> None:
+    task = session.tasks["prepare_sd_card"]
+    if not session.preflight.get("force_format_sd_card", False):
+        task.update({"status": "success", "details": "SD card formatting disabled."})
+        session.touch()
+        return
+
+    task.update({"status": "running", "details": "Formatting SD card..."})
+    session.touch()
+    payload = await asyncio.to_thread(
+        post_json,
+        f"{device_base_url(session)}/sd-card/format",
+        {},
+        timeout=SD_FORMAT_HTTP_TIMEOUT_SECONDS,
+    )
+    task["result"] = payload
+    details = sd_preparation_details(payload)
+    if not payload.get("formatted", False):
+        raise RuntimeError(
+            f"SD card format failed ({details})."
+        )
+    if not payload.get("mounted", False):
+        raise RuntimeError(f"SD card formatted but did not remount ({details}).")
+    if not payload.get("label_set", False):
+        raise RuntimeError(f"SD card remounted but its label could not be set ({details}).")
+
+    task.update(
+        {
+            "status": "success",
+            "details": "SD card formatted and remounted.",
+        }
+    )
+    session.touch()
+
+
+async def remount_session_sd_card(session: CommissioningSession) -> None:
+    task = session.tasks["prepare_sd_card"]
+    task.update({"status": "running", "details": "Retrying SD card mount..."})
+    session.touch()
+    payload = await asyncio.to_thread(
+        post_json,
+        f"{device_base_url(session)}/sd-card/remount",
+        {},
+        timeout=SD_FORMAT_HTTP_TIMEOUT_SECONDS,
+    )
+    task["result"] = payload
+    details = sd_preparation_details(payload)
+    if not payload.get("mounted", False):
+        raise RuntimeError(f"SD card still did not mount ({details}).")
+    if not payload.get("label_set", False):
+        raise RuntimeError(f"SD card mounted but its label could not be set ({details}).")
+    task.update({"status": "success", "details": "SD card mounted successfully."})
+    session.touch()
+
+
+async def wait_for_session_device(session: CommissioningSession) -> None:
+    deadline = time.monotonic() + RECONNECT_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            await read_session_mac_address(session)
+            return
+        except (OSError, URLError, TimeoutError, RuntimeError):
+            pass
+
+        try:
+            responses = await probe_ip_once(session.device.ip_address)
+            for response in responses:
+                if response_matches_session(response, session):
+                    session.device = response
+                    await read_session_mac_address(session)
+                    return
+        except (OSError, URLError, TimeoutError, RuntimeError):
+            pass
+        await asyncio.sleep(RECONNECT_POLL_SECONDS)
+
+    raise TimeoutError("Timed out waiting for the device to reconnect.")
+
+
+async def restart_and_resume_session(session: CommissioningSession) -> None:
+    task = session.tasks["prepare_sd_card"]
+    try:
+        task.update({"status": "running", "details": "Restarting Leaf..."})
+        session.touch()
+        payload = await asyncio.to_thread(
+            post_json,
+            f"{device_base_url(session)}/restart",
+            {},
+        )
+        if not payload.get("restart_requested", False):
+            raise RuntimeError("Device did not acknowledge the restart request.")
+        await asyncio.sleep(REBOOT_GRACE_SECONDS)
+        task["details"] = "Waiting for Leaf to reconnect..."
+        session.touch()
+        await wait_for_session_device(session)
+        await remount_session_sd_card(session)
+        await run_commissioning_session(session, sd_preparation="skip")
+    except asyncio.CancelledError:
+        mark_running_task_failed(session, "Commissioning session was cancelled.")
+        session.status = "failure"
+        session.details = "Commissioning session was cancelled."
+    except Exception as exc:
+        mark_running_task_failed(session, f"{type(exc).__name__}: {exc}")
+        session.status = "failure"
+        session.details = f"{type(exc).__name__}: {exc}"
+    finally:
+        session.worker_task = None
+        session.touch()
 
 
 def active_fanet_ids(except_mac_address: str | None = None) -> set[int]:
@@ -471,7 +597,11 @@ def persist_configuration_event(session: CommissioningSession) -> int:
         return event.id or 0
 
 
-async def run_commissioning_session(session: CommissioningSession) -> None:
+async def run_commissioning_session(
+    session: CommissioningSession,
+    *,
+    sd_preparation: str = "format",
+) -> None:
     try:
         mac_address = await read_session_mac_address(session)
         session.mac_address = mac_address
@@ -479,6 +609,11 @@ async def run_commissioning_session(session: CommissioningSession) -> None:
             f"IP address: {session.device.ip_address}:{session.device.port}; "
             f"MAC address: {mac_address}"
         )
+
+        if sd_preparation == "format":
+            await prepare_session_sd_card(session)
+        elif sd_preparation == "remount":
+            await remount_session_sd_card(session)
 
         firmware_task = session.tasks["firmware_version"]
         firmware_task.update({"status": "running", "details": "Reading firmware version..."})
@@ -722,6 +857,90 @@ def create_commissioning_session(
     commissioning_sessions[key] = session
     session.worker_task = asyncio.create_task(run_commissioning_session(session))
     return session
+
+
+def retry_commissioning_format(session: CommissioningSession) -> CommissioningSession:
+    if session.worker_task is not None:
+        raise RuntimeError("Commissioning session is still running.")
+    if session.tasks["prepare_sd_card"].get("status") != "failure":
+        raise RuntimeError("SD card formatting has not failed.")
+    result = session.tasks["prepare_sd_card"].get("result", {})
+    if result.get("formatted", False):
+        raise RuntimeError("The SD card is already formatted; retry mounting instead.")
+
+    reset_session_tasks_from(session, "prepare_sd_card")
+    session.status = "running"
+    session.details = "Retrying SD card formatting."
+    session.worker_task = asyncio.create_task(run_commissioning_session(session))
+    session.touch()
+    return session
+
+
+def retry_commissioning_self_test(session: CommissioningSession) -> CommissioningSession:
+    if session.worker_task is not None:
+        raise RuntimeError("Commissioning session is still running.")
+    if session.tasks["interactive_self_test"].get("status") != "failure":
+        raise RuntimeError("Verification tests have not failed.")
+
+    reset_session_tasks_from(session, "interactive_self_test")
+    session.self_test_result = None
+    session.self_test_details = None
+    session.status = "running"
+    session.details = "Restarting verification tests."
+    session.worker_task = asyncio.create_task(
+        run_commissioning_session(session, sd_preparation="skip")
+    )
+    session.touch()
+    return session
+
+
+def retry_commissioning_mount(session: CommissioningSession) -> CommissioningSession:
+    validate_remount_recovery(session)
+    reset_session_tasks_from(session, "prepare_sd_card")
+    session.status = "running"
+    session.details = "Retrying SD card mount."
+    session.worker_task = asyncio.create_task(
+        run_commissioning_session(session, sd_preparation="remount")
+    )
+    session.touch()
+    return session
+
+
+def restart_commissioning_device(session: CommissioningSession) -> CommissioningSession:
+    validate_remount_recovery(session)
+    reset_session_tasks_from(session, "prepare_sd_card")
+    session.status = "running"
+    session.details = "Restarting Leaf to recover the SD card."
+    session.worker_task = asyncio.create_task(restart_and_resume_session(session))
+    session.touch()
+    return session
+
+
+def validate_remount_recovery(session: CommissioningSession) -> None:
+    if session.worker_task is not None:
+        raise RuntimeError("Commissioning session is still running.")
+    task = session.tasks["prepare_sd_card"]
+    result = task.get("result", {})
+    if task.get("status") != "failure" or not result.get("formatted", False):
+        raise RuntimeError("The SD card does not have a recoverable remount failure.")
+    if result.get("mounted", False):
+        raise RuntimeError("The SD card is already mounted.")
+
+
+def reset_session_tasks_from(session: CommissioningSession, task_name: str) -> None:
+    task_order = [
+        "prepare_sd_card",
+        "firmware_version",
+        "interactive_self_test",
+        "retrieve_test_details",
+        "fanet_id",
+        "persist_results",
+        "clear_self_test_results",
+        "notify_commissioning_complete",
+    ]
+    start_index = task_order.index(task_name)
+    for name in task_order[start_index:]:
+        session.tasks[name] = idle_task()
 
 
 def get_commissioning_session(mac_address: str) -> CommissioningSession | None:

--- a/factory_interface/src/factory_interface/commissioning_tasks.py
+++ b/factory_interface/src/factory_interface/commissioning_tasks.py
@@ -16,6 +16,7 @@ from factory_interface.network_discovery import (
     stop_preflash_monitor,
 )
 from factory_interface.settings import load_settings, resolve_application_firmware_file
+from factory_interface.serial_ports import eligible_serial_ports
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -271,12 +272,20 @@ def build_flash_firmware_commands() -> tuple[list[list[str]], Path]:
 
     upload_flash_mode = platformio_upload_flash_mode(flash_mode)
     upload_flash_freq = normalize_frequency(flash_freq)
+    serial_ports = eligible_serial_ports()
+    if not serial_ports:
+        raise FlashCommandError(
+            "No eligible serial ports are available. Connect a device or allow a port."
+        )
+    selected_port = serial_ports[0] if len(serial_ports) == 1 else None
+    port_arguments = ["--port", selected_port] if selected_port is not None else []
 
     erase_nvs_command = [
         sys.executable,
         str(esptool_path),
         "--chip",
         "esp32s3",
+        *port_arguments,
         "--baud",
         str(upload_speed),
         "--before",
@@ -293,6 +302,7 @@ def build_flash_firmware_commands() -> tuple[list[list[str]], Path]:
         str(esptool_path),
         "--chip",
         "esp32s3",
+        *port_arguments,
         "--baud",
         str(upload_speed),
         "--before",

--- a/factory_interface/src/factory_interface/nonvolatile_memory_task.py
+++ b/factory_interface/src/factory_interface/nonvolatile_memory_task.py
@@ -15,6 +15,7 @@ from factory_interface.settings import load_settings
 HTTP_TIMEOUT_SECONDS = DEFAULT_HTTP_TIMEOUT_SECONDS
 RESET_REBOOT_GRACE_SECONDS = 2.0
 RESET_RECONNECT_POLL_SECONDS = 1.0
+SD_FORMAT_HTTP_TIMEOUT_SECONDS = 180.0
 
 
 @dataclass
@@ -92,7 +93,12 @@ def fetch_json(url: str, *, method: str = "GET") -> dict:
         return json.loads(response.read().decode("utf-8"))
 
 
-def post_json(url: str, payload: dict) -> dict:
+def post_json(
+    url: str,
+    payload: dict,
+    *,
+    timeout: float = HTTP_TIMEOUT_SECONDS,
+) -> dict:
     data = json.dumps(payload).encode("utf-8")
     request = Request(
         url,
@@ -103,7 +109,7 @@ def post_json(url: str, payload: dict) -> dict:
     try:
         with urlopen_with_timeout_retries(
             request,
-            timeout=HTTP_TIMEOUT_SECONDS,
+            timeout=timeout,
         ) as response:
             return json.loads(response.read().decode("utf-8"))
     except HTTPError as exc:
@@ -162,9 +168,7 @@ async def run_reset_nonvolatile_memory() -> None:
             payload = await asyncio.to_thread(
                 post_json,
                 f"{base_url}/settings/factory-reset",
-                {
-                    "force_format_sd_card": load_settings().force_format_sd_card_during_commissioning
-                },
+                {"force_format_sd_card": False},
             )
             if not payload.get("reset_requested", False):
                 raise RuntimeError("Device did not acknowledge the reset request.")
@@ -177,8 +181,33 @@ async def run_reset_nonvolatile_memory() -> None:
             await asyncio.sleep(RESET_REBOOT_GRACE_SECONDS)
             await wait_for_device(base_url, device_id)
 
+            if load_settings().force_format_sd_card_during_commissioning:
+                selected_device = get_find_device_task().device
+                if selected_device is not None:
+                    base_url = (
+                        f"http://{selected_device.ip_address}:{selected_device.port}"
+                    )
+
+                task.details = "Formatting SD card..."
+                format_payload = await asyncio.to_thread(
+                    post_json,
+                    f"{base_url}/sd-card/format",
+                    {},
+                    timeout=SD_FORMAT_HTTP_TIMEOUT_SECONDS,
+                )
+                if not format_payload.get("formatted", False):
+                    raise RuntimeError("Device did not report a successful SD format.")
+                if not format_payload.get("mounted", False):
+                    raise RuntimeError("Device formatted the SD card but did not remount it.")
+                if not format_payload.get("label_set", False):
+                    raise RuntimeError("Device remounted the SD card but did not set its label.")
+
             task.status = "success"
-            task.details = "Nonvolatile memory reset."
+            task.details = (
+                "Nonvolatile memory reset; SD card formatted and remounted."
+                if load_settings().force_format_sd_card_during_commissioning
+                else "Nonvolatile memory reset."
+            )
             task.reconnect_status = "success"
             task.reconnect_details = "Device reconnected."
         except asyncio.CancelledError:

--- a/factory_interface/src/factory_interface/pending_setup_runs.py
+++ b/factory_interface/src/factory_interface/pending_setup_runs.py
@@ -1,0 +1,88 @@
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class PendingSetupRun:
+    run_id: str
+    operator: str
+    notes: str
+    preflight: dict
+    serial_ports: list[str]
+    status: str = "running"
+    details: str = "Preparing to flash firmware."
+    created_at: datetime = field(default_factory=datetime.now)
+    updated_at: datetime = field(default_factory=datetime.now)
+    monitor_task: asyncio.Task | None = None
+
+    @property
+    def label(self) -> str:
+        if len(self.serial_ports) == 1:
+            return f"Unidentified Leaf — {self.serial_ports[0]}"
+        if self.serial_ports:
+            return "Unidentified Leaf — serial port search"
+        return "Unidentified Leaf"
+
+    def touch(self) -> None:
+        self.updated_at = datetime.now()
+
+    def snapshot(self) -> dict:
+        return {
+            "kind": "pending",
+            "run_id": self.run_id,
+            "label": self.label,
+            "url": f"/setup?run_id={self.run_id}",
+            "operator": self.operator,
+            "notes": self.notes,
+            "status": self.status,
+            "details": self.details,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "serial_ports": self.serial_ports,
+        }
+
+
+pending_setup_runs: dict[str, PendingSetupRun] = {}
+
+
+def create_pending_setup_run(
+    *,
+    operator: str,
+    notes: str,
+    preflight: dict,
+    serial_ports: list[str],
+) -> PendingSetupRun:
+    run = PendingSetupRun(
+        run_id=str(uuid.uuid4()),
+        operator=operator,
+        notes=notes,
+        preflight=preflight,
+        serial_ports=serial_ports,
+    )
+    pending_setup_runs[run.run_id] = run
+    return run
+
+
+def get_pending_setup_run(run_id: str) -> PendingSetupRun | None:
+    return pending_setup_runs.get(run_id)
+
+
+def list_pending_setup_runs() -> list[PendingSetupRun]:
+    return sorted(
+        pending_setup_runs.values(),
+        key=lambda run: run.created_at,
+        reverse=True,
+    )
+
+
+def latest_running_pending_setup_run() -> PendingSetupRun | None:
+    return next(
+        (run for run in list_pending_setup_runs() if run.status == "running"),
+        None,
+    )
+
+
+def remove_pending_setup_run(run_id: str) -> None:
+    pending_setup_runs.pop(run_id, None)

--- a/factory_interface/src/factory_interface/serial_ports.py
+++ b/factory_interface/src/factory_interface/serial_ports.py
@@ -1,0 +1,24 @@
+from serial.tools import list_ports
+
+from factory_interface.settings import load_settings
+
+
+def available_serial_ports() -> list[dict]:
+    ignored_ports = set(load_settings().ignored_serial_ports)
+    ports = []
+    for port in sorted(list_ports.comports(), key=lambda item: item.device.lower()):
+        ports.append(
+            {
+                "device": port.device,
+                "description": port.description or "Serial port",
+                "hwid": port.hwid or "",
+                "ignored": port.device in ignored_ports,
+            }
+        )
+    return ports
+
+
+def eligible_serial_ports() -> list[str]:
+    return [
+        port["device"] for port in available_serial_ports() if not port["ignored"]
+    ]

--- a/factory_interface/src/factory_interface/settings.py
+++ b/factory_interface/src/factory_interface/settings.py
@@ -29,6 +29,7 @@ class FactoryInterfaceSettings(ImplicitDict):
   github_releases: list[dict] = []
   setup_notes: str = ""
   force_format_sd_card_during_commissioning: bool = True
+  ignored_serial_ports: list[str] = []
 
 
 def find_build_paths(required_files: tuple[str, ...]) -> list[Path]:
@@ -421,6 +422,12 @@ def load_settings() -> FactoryInterfaceSettings:
 
   if not isinstance(settings.force_format_sd_card_during_commissioning, bool):
     settings.force_format_sd_card_during_commissioning = True
+    settings_changed = True
+
+  if not isinstance(settings.ignored_serial_ports, list) or not all(
+    isinstance(port, str) for port in settings.ignored_serial_ports
+  ):
+    settings.ignored_serial_ports = []
     settings_changed = True
 
   if not isinstance(settings.github_releases, list):

--- a/factory_interface/src/factory_interface/static/styles.css
+++ b/factory_interface/src/factory_interface/static/styles.css
@@ -684,6 +684,80 @@ button:disabled {
   cursor: pointer;
 }
 
+.serial-port-panel {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface-subtle);
+}
+
+.serial-port-panel h2,
+.serial-port-panel p {
+  margin: 0;
+}
+
+.serial-port-list {
+  display: grid;
+  gap: 8px;
+}
+
+.serial-port-option {
+  display: grid;
+  grid-template-columns: 22px 1fr;
+  align-items: center;
+  gap: 9px;
+  cursor: pointer;
+}
+
+.serial-port-option input {
+  position: relative;
+  box-sizing: border-box;
+  width: 16px !important;
+  min-width: 16px !important;
+  max-width: 16px;
+  height: 16px !important;
+  min-height: 16px !important;
+  max-height: 16px;
+  margin: 0;
+  padding: 0;
+  border: 1px solid #82918b;
+  border-radius: 3px;
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--field);
+  cursor: pointer;
+}
+
+.serial-port-option input:checked {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.serial-port-option input:checked::after {
+  position: absolute;
+  top: 1px;
+  left: 4px;
+  width: 4px;
+  height: 8px;
+  border: solid #0b0d0b;
+  border-width: 0 2px 2px 0;
+  content: "";
+  transform: rotate(45deg);
+}
+
+.serial-port-option input:focus-visible {
+  outline: 2px solid rgb(216 255 0 / 50%);
+  outline-offset: 2px;
+}
+
+.task-retry-button {
+  width: fit-content;
+  min-height: 36px;
+  padding: 7px 12px;
+}
+
 .bootloader-check input {
   width: 24px;
   min-height: 24px;

--- a/factory_interface/src/factory_interface/templates/base.html
+++ b/factory_interface/src/factory_interface/templates/base.html
@@ -4,7 +4,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }}</title>
-    <link rel="stylesheet" href="{{ url_for('static', path='/styles.css') }}">
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', path='/styles.css') }}?v={{ static_asset_version('styles.css') }}"
+    >
   </head>
   <body>
     <header class="topbar">

--- a/factory_interface/src/factory_interface/templates/settings.html
+++ b/factory_interface/src/factory_interface/templates/settings.html
@@ -80,7 +80,7 @@
           value="true"
           {% if settings.force_format_sd_card_during_commissioning %}checked{% endif %}
         >
-        <span>Force-format SD card during commissioning</span>
+        <span>Format SD card during commissioning</span>
       </label>
     </div>
     <button type="submit">Save settings</button>

--- a/factory_interface/src/factory_interface/templates/setup_checklist.html
+++ b/factory_interface/src/factory_interface/templates/setup_checklist.html
@@ -235,6 +235,12 @@
   let retrieveTestDetailsPollTimer = null;
   let setupCancellationRequested = false;
   let serialPorts = {{ serial_ports | tojson }};
+  let pendingRunId = {{ pending_run_id | tojson }};
+
+  function setupRunUrl(path) {
+    if (!pendingRunId) return path;
+    return `${path}?run_id=${encodeURIComponent(pendingRunId)}`;
+  }
 
   function renderSerialPorts() {
     serialPortList.replaceChildren();
@@ -672,10 +678,15 @@
     if (!canEnableBootloaderMode()) return;
     bootloaderCheckbox.checked = true;
     bootloaderCheckbox.disabled = true;
-    const response = await fetch("/api/setup/flash", {
+    const response = await fetch(setupRunUrl("/api/setup/flash"), {
       method: "POST",
     });
-    applyFlashTaskState(await response.json());
+    const payload = await response.json();
+    if (payload.pending_run_id && payload.pending_run_id !== pendingRunId) {
+      pendingRunId = payload.pending_run_id;
+      window.history.replaceState({}, "", `/setup?run_id=${encodeURIComponent(pendingRunId)}`);
+    }
+    applyFlashTaskState(payload);
   }
 
   async function startDiscoveryTask() {
@@ -754,7 +765,7 @@
   }
 
   async function handoffSetupSession() {
-    const response = await fetch("/api/setup/handoff", { method: "POST" });
+    const response = await fetch(setupRunUrl("/api/setup/handoff"), { method: "POST" });
     const payload = await response.json();
     if (!response.ok) {
       discoveryDetails.textContent = payload.detail || "Commissioning session could not be started.";

--- a/factory_interface/src/factory_interface/templates/setup_checklist.html
+++ b/factory_interface/src/factory_interface/templates/setup_checklist.html
@@ -15,8 +15,21 @@
       <ul>
         <li>Firmware: {{ application_firmware_label }}</li>
         <li>Non-application binaries: {{ non_application_binaries_label }}</li>
-        <li>SD card force-format: {{ "enabled" if force_format_sd_card_during_commissioning else "disabled" }}</li>
+        <li>SD card format: {{ "enabled" if force_format_sd_card_during_commissioning else "disabled" }}</li>
       </ul>
+    </div>
+
+    <div class="serial-port-panel">
+      <div class="field-label-row">
+        <h2>Serial ports</h2>
+        <button id="refresh-serial-ports" type="button">Refresh</button>
+      </div>
+      <p class="checklist-details">
+        Ignore ports that should not be used for flashing. Choices persist across commissioning
+        sessions.
+      </p>
+      <div id="serial-port-list" class="serial-port-list"></div>
+      <p id="serial-port-summary" class="checklist-details"></p>
     </div>
 
     <div class="checklist-item">
@@ -185,6 +198,9 @@
 
 <script>
   const setupNotes = document.querySelector("#setup-notes");
+  const serialPortList = document.querySelector("#serial-port-list");
+  const serialPortSummary = document.querySelector("#serial-port-summary");
+  const refreshSerialPortsButton = document.querySelector("#refresh-serial-ports");
   const binariesConfirmed = document.querySelector("#binaries-confirmed");
   const setupNotesConfirmed = document.querySelector("#setup-notes-confirmed");
   const setupNotesError = document.querySelector("#setup-notes-error");
@@ -218,6 +234,72 @@
   let selfTestPollTimer = null;
   let retrieveTestDetailsPollTimer = null;
   let setupCancellationRequested = false;
+  let serialPorts = {{ serial_ports | tojson }};
+
+  function renderSerialPorts() {
+    serialPortList.replaceChildren();
+    if (serialPorts.length === 0) {
+      serialPortList.textContent = "No serial ports detected.";
+      serialPortSummary.textContent = "Flashing requires at least one eligible serial port.";
+      return;
+    }
+
+    serialPorts.forEach((port) => {
+      const label = document.createElement("label");
+      label.className = "serial-port-option";
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.checked = Boolean(port.ignored);
+      checkbox.addEventListener("change", async () => {
+        checkbox.disabled = true;
+        try {
+          const response = await fetch("/api/setup/serial-ports/ignore", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ device: port.device, ignored: checkbox.checked }),
+          });
+          const payload = await response.json();
+          if (!response.ok) throw new Error(payload.detail || "Could not save serial port choice.");
+          serialPorts = payload.ports;
+          renderSerialPorts();
+        } catch (error) {
+          checkbox.checked = !checkbox.checked;
+          checkbox.disabled = false;
+          serialPortSummary.textContent = error.message || "Could not save serial port choice.";
+        }
+      });
+      const text = document.createElement("span");
+      text.textContent = `Ignore ${port.device} — ${port.description}`;
+      label.append(checkbox, text);
+      serialPortList.appendChild(label);
+    });
+
+    const eligible = serialPorts.filter((port) => !port.ignored);
+    if (eligible.length === 1) {
+      serialPortSummary.textContent = `Flash will use ${eligible[0].device}.`;
+    } else if (eligible.length > 1) {
+      serialPortSummary.textContent =
+        `${eligible.length} ports are eligible; esptool will use its standard port search.`;
+    } else {
+      serialPortSummary.textContent =
+        "All detected ports are ignored; allow a port before flashing.";
+    }
+  }
+
+  async function refreshSerialPorts() {
+    refreshSerialPortsButton.disabled = true;
+    try {
+      const response = await fetch("/api/setup/serial-ports");
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload.detail || "Could not read serial ports.");
+      serialPorts = payload.ports;
+      renderSerialPorts();
+    } catch (error) {
+      serialPortSummary.textContent = error.message || "Could not read serial ports.";
+    } finally {
+      refreshSerialPortsButton.disabled = false;
+    }
+  }
   const taskStatuses = {
     flash: "idle",
     discovery: "idle",
@@ -736,6 +818,8 @@
     updateBootloaderModeAvailability();
   });
 
+  refreshSerialPortsButton.addEventListener("click", refreshSerialPorts);
+
   bootloaderCheckbox.addEventListener("change", () => {
     if (bootloaderCheckbox.checked) {
       startFlashTask();
@@ -793,6 +877,7 @@
     notifyCommissioningCompleteDetails.hidden = !notifyCommissioningCompleteDetails.hidden;
   });
 
+  renderSerialPorts();
   refreshFlashTaskState();
   refreshDiscoveryTaskState();
   refreshFirmwareVersionTaskState();

--- a/factory_interface/src/factory_interface/templates/setup_session.html
+++ b/factory_interface/src/factory_interface/templates/setup_session.html
@@ -23,7 +23,7 @@
       <ul>
         <li>Firmware: {{ session.preflight.application_firmware_label }}</li>
         <li>Non-application binaries: {{ session.preflight.non_application_binaries_label }}</li>
-        <li>SD card force-format: {{ "enabled" if session.preflight.force_format_sd_card else "disabled" }}</li>
+        <li>SD card format: {{ "enabled" if session.preflight.force_format_sd_card else "disabled" }}</li>
       </ul>
     </div>
 
@@ -83,6 +83,17 @@
     </div>
 
     <div class="checklist-item checklist-item-with-details">
+      <button class="task-icon task-icon-empty" id="prepare-sd-card-task-icon" type="button" aria-label="Toggle SD card preparation details" disabled></button>
+      <span>Format SD card</span>
+      <div class="checklist-details-group" id="prepare-sd-card-details-group" hidden>
+        <p class="checklist-details" id="prepare-sd-card-details"></p>
+        <button class="task-retry-button" id="retry-format" type="button" hidden>Retry formatting</button>
+        <button class="task-retry-button" id="retry-mount" type="button" hidden>Retry SD mount</button>
+        <button class="task-retry-button" id="restart-device" type="button" hidden>Restart Leaf and continue</button>
+      </div>
+    </div>
+
+    <div class="checklist-item checklist-item-with-details">
       <button class="task-icon task-icon-empty" id="firmware-version-task-icon" type="button" aria-label="Toggle firmware version details" disabled></button>
       <span>Read firmware version</span>
       <p class="checklist-details" id="firmware-version-details" hidden></p>
@@ -91,7 +102,10 @@
     <div class="checklist-item checklist-item-with-details">
       <button class="task-icon task-icon-empty" id="self-test-task-icon" type="button" aria-label="Toggle verification test details" disabled></button>
       <span>Verification tests</span>
-      <div class="checklist-details verification-test-details" id="self-test-details" hidden></div>
+      <div class="checklist-details-group" id="self-test-details-group" hidden>
+        <div class="checklist-details verification-test-details" id="self-test-details"></div>
+        <button class="task-retry-button" id="retry-self-test" type="button" hidden>Restart self tests</button>
+      </div>
     </div>
 
     <div class="checklist-item checklist-item-with-details">
@@ -139,9 +153,24 @@
   const discardUrl = `/api/setup/sessions/${encodeURIComponent(macAddress)}`;
   const manualDiscoveryUrl =
     `/api/setup/sessions/${encodeURIComponent(macAddress)}/network-discovery/manual`;
+  const retryFormatUrl = `/api/setup/sessions/${encodeURIComponent(macAddress)}/retry-format`;
+  const retryMountUrl = `/api/setup/sessions/${encodeURIComponent(macAddress)}/retry-mount`;
+  const restartDeviceUrl =
+    `/api/setup/sessions/${encodeURIComponent(macAddress)}/restart-device`;
+  const retrySelfTestUrl =
+    `/api/setup/sessions/${encodeURIComponent(macAddress)}/retry-self-test`;
+  const retryFormatButton = document.querySelector("#retry-format");
+  const retryMountButton = document.querySelector("#retry-mount");
+  const restartDeviceButton = document.querySelector("#restart-device");
+  const retrySelfTestButton = document.querySelector("#retry-self-test");
   let pollTimer = null;
 
   const controls = {
+    prepare_sd_card: {
+      icon: document.querySelector("#prepare-sd-card-task-icon"),
+      details: document.querySelector("#prepare-sd-card-details"),
+      detailsContainer: document.querySelector("#prepare-sd-card-details-group"),
+    },
     network_discovery: {
       icon: document.querySelector("#discovery-task-icon"),
       details: document.querySelector("#discovery-details"),
@@ -158,6 +187,7 @@
     interactive_self_test: {
       icon: document.querySelector("#self-test-task-icon"),
       details: document.querySelector("#self-test-details"),
+      detailsContainer: document.querySelector("#self-test-details-group"),
     },
     retrieve_test_details: {
       icon: document.querySelector("#retrieve-test-details-task-icon"),
@@ -241,6 +271,7 @@
     setTaskIcon(control.icon, task.status);
     if (name === "interactive_self_test") {
       renderVerificationTests(control.details, task);
+      control.detailsContainer.hidden = task.status === "idle";
       return;
     }
     setDetails(control.details, task.details, task.status, control.detailsContainer || control.details);
@@ -249,6 +280,7 @@
   function applySession(session) {
     summary.textContent = `${session.mac_address} - ${session.details}`;
     applyTaskState("network_discovery", session.tasks.network_discovery);
+    applyTaskState("prepare_sd_card", session.tasks.prepare_sd_card);
     applyTaskState("firmware_version", session.tasks.firmware_version);
     applyTaskState("fanet_id", session.tasks.fanet_id);
     applyTaskState("interactive_self_test", session.tasks.interactive_self_test);
@@ -256,6 +288,15 @@
     applyTaskState("persist_results", session.tasks.persist_results);
     applyTaskState("clear_self_test_results", session.tasks.clear_self_test_results);
     applyTaskState("notify_commissioning_complete", session.tasks.notify_commissioning_complete);
+    const sdTask = session.tasks.prepare_sd_card;
+    const sdResult = sdTask.result || {};
+    const remountFailure =
+      sdTask.status === "failure" && sdResult.formatted === true && sdResult.mounted !== true;
+    retryFormatButton.hidden =
+      sdTask.status !== "failure" || sdResult.formatted === true;
+    retryMountButton.hidden = !remountFailure;
+    restartDeviceButton.hidden = !remountFailure;
+    retrySelfTestButton.hidden = session.tasks.interactive_self_test.status !== "failure";
 
     if (session.status !== "running" && pollTimer) {
       clearInterval(pollTimer);
@@ -281,6 +322,21 @@
       },
       body: JSON.stringify({ ip_address: ipAddress }),
     });
+  }
+
+  async function retrySessionTask(url, button) {
+    button.disabled = true;
+    try {
+      const response = await fetch(url, { method: "POST" });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload.detail || "Task could not be restarted.");
+      applySession(payload);
+      if (!pollTimer) pollTimer = setInterval(refreshSession, 1000);
+    } catch (error) {
+      summary.textContent = error.message || "Task could not be restarted.";
+    } finally {
+      button.disabled = false;
+    }
   }
 
   async function submitManualIp(form, input, details, fallbackText) {
@@ -313,6 +369,22 @@
     window.location.href = "/";
   });
 
+  retryFormatButton.addEventListener("click", () => {
+    retrySessionTask(retryFormatUrl, retryFormatButton);
+  });
+
+  retryMountButton.addEventListener("click", () => {
+    retrySessionTask(retryMountUrl, retryMountButton);
+  });
+
+  restartDeviceButton.addEventListener("click", () => {
+    retrySessionTask(restartDeviceUrl, restartDeviceButton);
+  });
+
+  retrySelfTestButton.addEventListener("click", () => {
+    retrySessionTask(retrySelfTestUrl, retrySelfTestButton);
+  });
+
   discoveryManualIpForm.addEventListener("submit", async (event) => {
     event.preventDefault();
     await submitManualIp(
@@ -330,12 +402,10 @@
   Object.values(controls).forEach((control) => {
     control.icon.addEventListener("click", () => {
       const detailsContainer = control.detailsContainer || control.details;
-      detailsContainer.hidden = false;
-      if (control.detailsContainer) {
-        const form = control.detailsContainer.querySelector(".manual-ip-entry");
+      detailsContainer.hidden = !detailsContainer.hidden;
+      const form = detailsContainer.querySelector?.(".manual-ip-entry");
+      if (form) {
         form.hidden = !form.hidden;
-      } else {
-        control.details.hidden = !control.details.hidden;
       }
     });
   });

--- a/factory_interface/src/factory_interface/templates/setup_sessions.html
+++ b/factory_interface/src/factory_interface/templates/setup_sessions.html
@@ -7,18 +7,67 @@
     <a class="button-link" href="/setup">New device</a>
   </div>
 
-  {% if sessions %}
-  <div class="session-list" aria-label="Commissioning sessions">
+  <div
+    class="session-list"
+    id="session-list"
+    aria-label="Commissioning sessions"
+    {% if not sessions %}hidden{% endif %}
+  >
     {% for session in sessions %}
-    <a class="session-row" href="/setup/{{ session.mac_address }}">
-      <span class="session-mac">{{ session.mac_address }}</span>
+    <a class="session-row" href="{{ session.url }}">
+      <span class="session-mac">{{ session.label }}</span>
       <span class="session-status session-status-{{ session.status }}">{{ session.status }}</span>
       <span class="session-details">{{ session.details }}</span>
     </a>
     {% endfor %}
   </div>
-  {% else %}
-  <p class="status-message">No commissioning sessions are active.</p>
-  {% endif %}
+  <p class="status-message" id="no-sessions" {% if sessions %}hidden{% endif %}>
+    No commissioning sessions are active.
+  </p>
 </section>
+
+<script>
+  const sessionList = document.querySelector("#session-list");
+  const noSessions = document.querySelector("#no-sessions");
+
+  function renderSessions(sessions) {
+    sessionList.replaceChildren();
+    sessionList.hidden = sessions.length === 0;
+    noSessions.hidden = sessions.length !== 0;
+
+    sessions.forEach((session) => {
+      const row = document.createElement("a");
+      row.className = "session-row";
+      row.href = session.url;
+
+      const label = document.createElement("span");
+      label.className = "session-mac";
+      label.textContent = session.label;
+
+      const status = document.createElement("span");
+      status.className = `session-status session-status-${session.status}`;
+      status.textContent = session.status;
+
+      const details = document.createElement("span");
+      details.className = "session-details";
+      details.textContent = session.details;
+
+      row.append(label, status, details);
+      sessionList.append(row);
+    });
+  }
+
+  async function refreshSessions() {
+    try {
+      const response = await fetch("/api/setup/session-summaries");
+      if (!response.ok) return;
+      const payload = await response.json();
+      renderSessions(payload.sessions);
+    } catch (error) {
+      // Keep the last rendered state during a temporary connection interruption.
+    }
+  }
+
+  setInterval(refreshSessions, 1000);
+</script>
 {% endblock %}

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -2140,6 +2140,13 @@ load();
   void startCommissioningSelfTest(WebServer& target) {
     if (!requireCommissioningHttp(target)) return;
 
+    // The diagnostic network defers the production test while commissioning is pending so the
+    // factory interface can format the SD card first. Mark the explicitly requested test as the
+    // production test without preventing a failed test from being restarted.
+    if (!settings.productionTest) {
+      settings.productionTest = true;
+      settings.save();
+    }
     requestInteractiveSelfTest();
     target.send(200, "application/json", selfTestSnapshotJson());
   }
@@ -2162,6 +2169,25 @@ load();
     clearSelfTestDetailsFiles(target);
   }
 
+  String sdCardFormatResultJson(const SDCard::FormatResult& result, bool labelSet) {
+    String json = "{\"formatted\":";
+    json += result.formatted ? "true" : "false";
+    json += ",\"mounted\":";
+    json += result.mounted ? "true" : "false";
+    json += ",\"label_set\":";
+    json += labelSet ? "true" : "false";
+    json += ",\"stage\":\"";
+    json += result.stage;
+    json += "\",\"mount_attempts\":";
+    json += result.mountAttempts;
+    json += ",\"esp_error_code\":";
+    json += static_cast<int>(result.error);
+    json += ",\"esp_error\":\"";
+    json += esp_err_to_name(result.error);
+    json += "\"}";
+    return json;
+  }
+
   void formatCommissioningSdCard(WebServer& target) {
     if (!requireCommissioningHttp(target)) return;
 
@@ -2175,17 +2201,30 @@ load();
       return;
     }
 
-    if (!sdcard.format()) {
-      target.send(500, "application/json", "{\"formatted\":false}");
+    const SDCard::FormatResult result = sdcard.formatDetailed();
+    const bool labelSet = result.mounted && sdcard.setLabel();
+    target.send(200, "application/json", sdCardFormatResultJson(result, labelSet));
+  }
+
+  void remountCommissioningSdCard(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    if (selfTest.updateNeeded() || interactive_self_test_pending) {
+      target.send(409, "application/json", "{\"detail\":\"Self test is running or pending.\"}");
       return;
     }
 
-    if (!sdcard.setLabel()) {
-      target.send(500, "application/json", "{\"formatted\":true,\"label_set\":false}");
-      return;
-    }
+    const SDCard::FormatResult result = sdcard.remountAfterFormat();
+    const bool labelSet = result.mounted && sdcard.setLabel();
+    target.send(200, "application/json", sdCardFormatResultJson(result, labelSet));
+  }
 
-    target.send(200, "application/json", "{\"formatted\":true,\"label_set\":true}");
+  void restartCommissioningDevice(WebServer& target) {
+    if (!requireCommissioningHttp(target)) return;
+
+    target.send(200, "application/json", "{\"restart_requested\":true}");
+    delay(250);
+    ESP.restart();
   }
 
   void markCommissioningComplete(WebServer& target) {
@@ -2215,6 +2254,9 @@ load();
     user_server.on("/self-test/results", HTTP_DELETE,
                    []() { clearCommissioningSelfTestResults(user_server); });
     user_server.on("/sd-card/format", HTTP_POST, []() { formatCommissioningSdCard(user_server); });
+    user_server.on("/sd-card/remount", HTTP_POST,
+                   []() { remountCommissioningSdCard(user_server); });
+    user_server.on("/restart", HTTP_POST, []() { restartCommissioningDevice(user_server); });
     user_server.on("/commissioning/complete", HTTP_POST,
                    []() { markCommissioningComplete(user_server); });
 
@@ -2230,6 +2272,10 @@ load();
                    []() { startCommissioningSelfTest(user_server); });
     user_server.on("/api/debug/sd-card/format", HTTP_POST,
                    []() { formatCommissioningSdCard(user_server); });
+    user_server.on("/api/debug/sd-card/remount", HTTP_POST,
+                   []() { remountCommissioningSdCard(user_server); });
+    user_server.on("/api/debug/restart", HTTP_POST,
+                   []() { restartCommissioningDevice(user_server); });
     user_server.on("/api/debug/self-test/details", HTTP_GET,
                    []() { sendCommissioningSelfTestDetails(user_server); });
     user_server.on("/api/debug/self-test/results", HTTP_DELETE,

--- a/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
+++ b/src/vario/diagnostics/diagnostic_network/diagnostic_network.cpp
@@ -90,6 +90,11 @@ void DiagnosticNetwork::update() {
       Serial.println("DiagnosticNetwork: Connected to network");
       printed_end_state_ = true;
     }
+    // During factory commissioning, wait for the factory interface to format the SD card and
+    // explicitly start the test. Preserve the automatic production-test behavior for older or
+    // non-commissioning diagnostic flows.
+    if (settings.commissioningPending) return;
+
     // begin self test (mark as official production test)
     if (!settings.productionTest && settings.consumeProductionTestForceFormatSdCard()) {
       Serial.println("DiagnosticNetwork: force-formatting SD card before production self test");

--- a/src/vario/storage/sd_card.cpp
+++ b/src/vario/storage/sd_card.cpp
@@ -37,6 +37,7 @@ constexpr DWORD SD_CARD_FORMAT_ALLOCATION_UNIT_SIZE = 16384;
 constexpr auto SD_CARD_VOLUME_LABEL = "LEAF VARIO";
 constexpr auto SD_CARD_MOUNT_POINT = "/sdcard";
 constexpr auto SD_CARD_FORMAT_MOUNT_POINT = "/sdcard_format";
+constexpr uint32_t SD_CARD_REMOUNT_DELAYS_MS[] = {500, 1000, 2000, 3000};
 
 SDCard sdcard;
 
@@ -209,9 +210,25 @@ void SDCard::unmount() {
 }
 
 bool SDCard::format() {
+  const FormatResult result = formatDetailed();
+  return result.formatted && result.mounted;
+}
+
+SDCard::FormatResult SDCard::formatDetailed() {
+  FormatResult result;
   if (!isCardPresent()) {
     if (DEBUG_SDCARD) Serial.println("SDcard Format Failed: no card present");
-    return false;
+    result.stage = "card_detection";
+    result.error = ESP_ERR_NOT_FOUND;
+    return result;
+  }
+
+  // Prevent the USB host from reading or writing the SD card while its filesystem and block
+  // device are being torn down. mount() configures and starts this LUN again after formatting.
+  if (msc_) {
+    msc_->mediaPresent(false);
+    msc_->end();
+    delay(100);
   }
 
   if (mounted_) {
@@ -220,16 +237,68 @@ bool SDCard::format() {
 
   if (DEBUG_SDCARD) Serial.println("Formatting SDcard");
 
-  if (!formatUnmounted()) {
-    return false;
+  if (!formatUnmounted(result.error, result.stage)) {
+    // The format may have failed before changing the card. Attempt to restore normal access.
+    mounted_ = mountWithRetries(result.mountAttempts);
+    result.mounted = mounted_;
+    return result;
   }
 
-  mounted_ = mount();
-  return mounted_;
+  result.formatted = true;
+  result.stage = "remount";
+  mounted_ = mountWithRetries(result.mountAttempts);
+  result.mounted = mounted_;
+  if (mounted_) {
+    result.stage = "complete";
+    result.error = ESP_OK;
+  }
+  return result;
 }
 
-bool SDCard::formatUnmounted() {
+SDCard::FormatResult SDCard::remountAfterFormat() {
+  FormatResult result;
+  result.formatted = true;
+  result.stage = "remount";
+
+  if (!isCardPresent()) {
+    result.stage = "card_detection";
+    result.error = ESP_ERR_NOT_FOUND;
+    return result;
+  }
+
+  if (mounted_) {
+    result.mounted = true;
+    result.stage = "complete";
+    return result;
+  }
+
+  mounted_ = mountWithRetries(result.mountAttempts);
+  result.mounted = mounted_;
+  if (mounted_) result.stage = "complete";
+  return result;
+}
+
+bool SDCard::mountWithRetries(uint8_t& attempts) {
+  attempts = 0;
+  for (uint32_t delayMs : SD_CARD_REMOUNT_DELAYS_MS) {
+    attempts++;
+    SD_MMC.end();
+    SD_MMC.setPins(SDIO_CLK, SDIO_CMD, SDIO_D0, SDIO_D1, SDIO_D2, SDIO_D3);
+    delay(delayMs);
+    if (mount()) return true;
+    if (DEBUG_SDCARD) {
+      Serial.printf("SDcard Remount Failed: attempt %u after %lu ms\n", attempts,
+                    static_cast<unsigned long>(delayMs));
+    }
+  }
+  return false;
+}
+
+bool SDCard::formatUnmounted(esp_err_t& error, const char*& stage) {
   if (DEBUG_SDCARD) Serial.println("Formatting unmounted SDcard");
+
+  error = ESP_OK;
+  stage = "temporary_mount";
 
   SD_MMC.end();
   SD_MMC.setPins(SDIO_CLK, SDIO_CMD, SDIO_D0, SDIO_D1, SDIO_D2, SDIO_D3);
@@ -265,13 +334,17 @@ bool SDCard::formatUnmounted() {
                                      &card);
     if (result != ESP_OK) {
       if (DEBUG_SDCARD) Serial.printf("SDcard Format Failed: mount/format returned 0x%x\n", result);
+      error = result;
+      stage = "mount_and_format";
       return false;
     }
   } else {
+    stage = "format";
     result = esp_vfs_fat_sdcard_format_cfg(SD_CARD_FORMAT_MOUNT_POINT, card, &mountConfig);
     if (result != ESP_OK) {
       if (DEBUG_SDCARD) Serial.printf("SDcard Format Failed: format returned 0x%x\n", result);
       esp_vfs_fat_sdcard_unmount(SD_CARD_FORMAT_MOUNT_POINT, card);
+      error = result;
       return false;
     }
   }
@@ -280,6 +353,8 @@ bool SDCard::formatUnmounted() {
   if (result != ESP_OK) {
     if (result != ESP_ERR_INVALID_STATE) {
       if (DEBUG_SDCARD) Serial.printf("SDcard Format Failed: unmount returned 0x%x\n", result);
+      error = result;
+      stage = "temporary_unmount";
       return false;
     }
 
@@ -288,6 +363,7 @@ bool SDCard::formatUnmounted() {
 
   SD_MMC.end();
   SD_MMC.setPins(SDIO_CLK, SDIO_CMD, SDIO_D0, SDIO_D1, SDIO_D2, SDIO_D3);
+  error = ESP_OK;
   return true;
 }
 

--- a/src/vario/storage/sd_card.h
+++ b/src/vario/storage/sd_card.h
@@ -2,15 +2,26 @@
 
 #include "FirmwareMSC.h"
 #include "USBMSC.h"
+#include "esp_err.h"
 
 class SDCard {
  public:
+  struct FormatResult {
+    bool formatted = false;
+    bool mounted = false;
+    uint8_t mountAttempts = 0;
+    const char* stage = "not_started";
+    esp_err_t error = ESP_OK;
+  };
+
   void init();
   void update();
 
   bool mount();
   void unmount();
   bool format();
+  FormatResult formatDetailed();
+  FormatResult remountAfterFormat();
   bool setLabel();
   bool isMounted() { return mounted_; }
 
@@ -25,7 +36,8 @@ class SDCard {
   FirmwareMSC* firmwareMSC_ = nullptr;
   USBMSC* msc_ = nullptr;
 
-  bool formatUnmounted();
+  bool formatUnmounted(esp_err_t& error, const char*& stage);
+  bool mountWithRetries(uint8_t& attempts);
 };
 
 extern SDCard sdcard;


### PR DESCRIPTION
## PR title

Improve factory commissioning reliability and session handling

## Summary

Improves commissioning speed and reliability across serial-port selection, SD-card preparation, self-test recovery, and session navigation.

## Changes

### Serial-port selection

- Displays detected serial ports before flashing.
- Allows operators to persistently ignore ports that should not be used.
- Automatically selects the port when exactly one eligible port remains.
- Falls back to normal ESP port discovery when multiple eligible ports remain.
- Uses compact, consistently sized ignore-port checkboxes.

### SD-card commissioning

- Formats the SD card only once during the automated flow.
- Separates formatting success from remount and volume-label failures.
- Stops USB mass-storage access before formatting.
- Adds delayed SD remount retries in Leaf firmware.
- Returns structured format and remount diagnostics.
- Adds Factory Interface controls to:
  - Retry SD mounting without formatting again.
  - Retry formatting after an actual format failure.
  - Restart Leaf, reconnect to the same device, and resume commissioning.

### Self-tests

- Prevents automatic self-test startup from racing commissioning operations.
- Allows failed self-tests to be restarted without restarting commissioning.
- Retrieves and persists the complete self-test report before clearing it.
- Notifies Leaf when commissioning has completed successfully.

### Session preservation

- Creates a pending session as soon as firmware flashing starts.
- Displays unidentified sessions using a label such as `Unidentified Leaf — COM9`.
- Gives pending sessions stable generated IDs before a MAC address is available.
- Promotes pending sessions to normal MAC-addressed sessions after discovery.
- Performs promotion server-side, independent of browser navigation.
- Returning to `/setup` resumes the active pending run instead of resetting it.
- Keeps failed pending runs visible so operators can revisit and retry them.
- Polls lightweight Home-page session summaries every second.
- Updates running, success, and failure states without requiring a manual refresh.
- Keeps the existing full session API unchanged.

## End-user impact

Normal end-user startup and SD-card behavior remain unchanged. The new recovery endpoints, restart behavior, self-test coordination, and pending-session lifecycle are used by factory commissioning.

Pending and established sessions remain in process memory, as before. They survive browser navigation but not a Factory Interface server restart.

## Verification

- Successfully commissioned units on the first attempt with SD formatting enabled.
- Confirmed completed commissioning records and passing self-test reports in `leaf_devices.db`.
- Built `leaf_3_2_7_release` successfully.
- Factory Interface Python compilation passed.
- Application import and Jinja template rendering passed.
- Pending-session summary and navigation checks passed.
- Browser-independent discovery promotion check passed.
- Diff formatting checks passed.
- Firmware was not automatically flashed during the build verification because no ESP32 serial port was connected at that time.