### PR TITLE
Add Thermal Core replay, simulator, and hosted training page

### DIFF
--- a/docs/dev-references/backlog/thermal-core-display.md
+++ b/docs/dev-references/backlog/thermal-core-display.md
@@ -1,0 +1,117 @@
+---
+title: Thermal Core Display Backlog
+description: Future display plan for a thermal core mode that helps pilots center their climbing turn.
+---
+
+# Thermal Core Display Backlog
+
+Leaf's thermal tracking work currently detects, saves, and maps previously found thermals. A possible
+next step is a live "thermal core" mode: while the pilot is actively circling in lift, estimate the
+target circle that should keep the glider better centered in the thermal and present that guidance on
+the 96 px wide LCD.
+
+This note captures the current display plan so the work can resume from the same design point.
+
+## Display Goals
+
+- Preserve spatial awareness. The page should show the pilot where they are relative to the target
+  circle, not only say "turn more" or "turn less".
+- Stay readable at a glance on the small monochrome LCD.
+- Prefer one primary spatial idea over multiple competing overlays.
+- Support left and right thermaling without wasting half the screen.
+- Make recent lift history visible without cluttering the page.
+
+## Proposed Layout
+
+- Draw the pilot as a fixed track-up arrow.
+- Bias the arrow horizontally based on turn direction:
+  - Left turn: place the arrow slightly right of center, leaving more room for the thermal circle on
+    the left.
+  - Right turn: place the arrow slightly left of center, leaving more room for the thermal circle on
+    the right.
+  - Unknown or low-confidence turn direction: fall back to a centered arrow.
+- Reuse the black/white glyph style from the existing thermal track page's aircraft pointer in
+  `src/vario/ui/display/pages/primary/page_thermal_track.cpp`.
+- Show only the current best target circle. Do not also draw the pilot's fitted/current flown circle;
+  the breadcrumbs already show recent flown path and a second circle is likely to be confusing.
+- Draw north-south and east-west cross lines through the target circle center. These lines should give
+  the pilot a stronger sense of the circle center and the display's rotation as the track-up view
+  changes.
+- Show recent breadcrumbs from the detector buffer, roughly the last 20-40 seconds.
+- Draw breadcrumbs as small circles with 5 px diameter.
+- Encode relative lift strength with ring thickness:
+  - 1 px ring: weaker/recent baseline lift.
+  - 2 px ring: moderate lift.
+  - 3 px ring: strongest recent lift.
+- Keep the aircraft marker visually dominant enough to orient the pilot, but not so large that it
+  hides the target circle or nearby breadcrumbs.
+
+## Coordinate Behavior
+
+- Use a track-up transform: the aircraft arrow points up and world coordinates rotate around the
+  aircraft according to current GPS course/track.
+- The aircraft remains in a fixed screen position for the current turn direction instead of being
+  centered on the display.
+- Scale should prioritize showing the useful portion of the target circle and recent breadcrumbs.
+  It is acceptable for the circle to be clipped by screen edges.
+- Prefer showing the next local arc of the target circle over fitting the entire circle at all costs.
+- Avoid abrupt zoom or center jumps; smooth scale and circle placement enough that the display feels
+  stable while circling.
+
+## Data Inputs
+
+The current thermal detector buffer lives in `ThermalTracker`:
+
+- `MAX_DETECTOR_SAMPLES = 40`.
+- Samples are approximately 1 Hz, though GPS updates may occasionally be missed.
+- Samples already include local meter coordinates, altitude, GPS course, time, and `climb30Cms`.
+
+For thermal core mode, add or expose a faster climb signal per sample:
+
+- Keep a running roughly 1 second average of baro climb rate.
+- Store that value with each detector sample, for example as `climb1sCms` or `climbFastCms`.
+- Continue using `climb30Cms` for broad thermal detection and saved thermal spine weighting.
+- Use the faster climb value for breadcrumb strength and live core/circle estimation.
+
+## Target Circle Estimation Context
+
+The target circle is conceptually distinct from the current flown circle:
+
+- The estimator may fit the pilot's current circle internally to understand turn geometry.
+- The display should only show the target circle that the pilot should migrate toward.
+- The target circle should be smoothed and confidence gated before display.
+- If confidence is low, consider showing breadcrumbs and the aircraft only, or a clearly degraded
+  target circle.
+
+Potential estimator inputs:
+
+- Recent local `xM/yM` positions from the detector buffer.
+- Recent course deltas to infer left/right turn direction and turn coverage.
+- Recent 1 second averaged climb values to identify stronger portions of the circle.
+- Optional lag compensation, where climb observed now is associated with aircraft position a few
+  seconds earlier.
+
+## Open Questions
+
+- Exact aircraft arrow size and pixel glyph.
+- Exact biased aircraft positions for left and right turns on the 96 px wide display.
+- Whether the NS/EW target-center lines should be full-screen clipped lines, short crosshairs, or
+  just line segments inside/near the target circle.
+- Whether breadcrumb ring thickness is enough to distinguish lift strength on the real LCD, or whether
+  strongest lift needs a filled center pixel/cross.
+- Whether a tiny text cue such as `HOLD`, `IN`, `OUT`, or `WEAK` should be included as a secondary
+  cue after the spatial display is working.
+- How much smoothing is needed so the target circle does not jump as detector samples enter and leave
+  the 40-sample buffer.
+
+## Suggested First Prototype
+
+1. Add the per-sample 1 second averaged climb signal to the thermal detector data path.
+2. Build a Leaf Labs-only thermal core display page using simulated or debug target-circle values.
+3. Render:
+   - biased track-up aircraft glyph,
+   - one target circle,
+   - NS/EW cross lines through the target center,
+   - 20-40 seconds of lift-weighted breadcrumbs.
+4. Tune layout with screenshots or a host-side LCD preview tool if available.
+5. Connect the display to the live estimator once the page is readable and stable.

--- a/src/vario/ui/display/menu_page.cpp
+++ b/src/vario/ui/display/menu_page.cpp
@@ -68,6 +68,26 @@ namespace menu_ui {
     u8g2.setCursor(ICON_BACK_X, y);
     printGlyph(ICON_BACK);
   }
+
+  void drawNoteBox(uint8_t rowY, const char* const* lines, uint8_t lineCount) {
+    constexpr uint8_t x = 3;
+    constexpr uint8_t w = 90;
+    constexpr uint8_t h = 44;
+    constexpr uint8_t r = 3;
+    const uint8_t y = rowY + 1;
+
+    u8g2.setDrawColor(0);
+    u8g2.drawRBox(x, y, w, h, r);
+    u8g2.setDrawColor(1);
+    u8g2.drawRFrame(x, y, w, h, r);
+
+    u8g2.setFont(leaf_5x8);
+    for (uint8_t i = 0; i < lineCount; i++) {
+      const uint8_t lineX = (96 - u8g2.getStrWidth(lines[i])) / 2;
+      u8g2.drawStr(lineX, y + 11 + i * 10, lines[i]);
+    }
+    u8g2.setFont(leaf_6x12);
+  }
 }  // namespace menu_ui
 
 void MenuPage::cursor_prev() {

--- a/src/vario/ui/display/menu_page.h
+++ b/src/vario/ui/display/menu_page.h
@@ -65,6 +65,7 @@ namespace menu_ui {
   void drawLabel(uint8_t x, uint8_t y, const char* label, uint8_t glyph = 0);
   void drawEnterIcon(uint8_t x, uint8_t y, bool selected);
   void drawBackIcon(uint8_t x, uint8_t y);
+  void drawNoteBox(uint8_t rowY, const char* const* lines, uint8_t lineCount);
 }  // namespace menu_ui
 
 // Base class for all Pages to be drawn with Menu Items with support for

--- a/src/vario/ui/display/pages/menu/page_menu_leaf_labs.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_leaf_labs.cpp
@@ -64,6 +64,16 @@ void LeafLabsMenuPage::draw() {
       }
       menu_ui::endRow();
     }
+
+    if (cursor_position == cursor_leaf_labs_thermal_track) {
+      const char* const noteLines[] = {
+          "Detects and saves",
+          "thermals as you",
+          "fly, then shows",
+          "them on a map",
+      };
+      menu_ui::drawNoteBox(menu_items_y[cursor_leaf_labs_thermal_track], noteLines, 4);
+    }
   } while (u8g2.nextPage());
 }
 

--- a/src/vario/ui/display/pages/menu/page_menu_vario.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.cpp
@@ -150,13 +150,14 @@ void VarioMenuPage::draw() {
       menu_ui::endRow();
     }
 
-    if (settings.volumeShortcut) {
-      u8g2.drawRFrame(3, 129, 90, 44, 3);
-      u8g2.setFont(leaf_5x8);
-      u8g2.drawStr(10, 140, "Hold UP or DOWN");
-      u8g2.drawStr(7, 150, "on a vario page to");
-      u8g2.drawStr(6, 160, "temporarily change");
-      u8g2.drawStr(20, 170, "vario volume");
+    if (cursor_position == cursor_vario_volumeShortcut) {
+      const char* const noteLines[] = {
+          "Hold UP or DOWN",
+          "on a vario page to",
+          "temporarily change",
+          "vario volume",
+      };
+      menu_ui::drawNoteBox(menu_items_y[cursor_vario_volumeShortcut], noteLines, 4);
     }
   } while (u8g2.nextPage());
 }

--- a/src/vario/ui/display/pages/primary/page_thermal_track.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_track.cpp
@@ -4,6 +4,7 @@
 #include <U8g2lib.h>
 
 #include "hardware/buttons.h"
+#include "instruments/baro.h"
 #include "logging/log.h"
 #include "navigation/thermal_tracker.h"
 #include "power.h"
@@ -18,13 +19,20 @@
 
 namespace {
   constexpr int16_t MAP_CX = 48;
-  constexpr int16_t MAP_CY = 109;
+  constexpr int16_t MAP_CY = 124;
   constexpr uint8_t MAP_D_500M = 50;
   constexpr uint8_t MAP_D_1500M = 74;
   constexpr uint8_t MAP_D_5000M = 96;
+  constexpr uint8_t MAP_R_5000M = MAP_D_5000M / 2;
+  constexpr uint8_t VARIO_BAR_TOP = 16;
+  constexpr uint8_t VARIO_BAR_WIDTH = 17;
+  constexpr uint8_t VARIO_BAR_HALF_HEIGHT = 50;
+  constexpr uint8_t ALT_X = 28;
+  constexpr uint8_t ALT_BASELINE_Y = 39;
 
   enum ThermalTrackPageItem : uint8_t {
     cursor_thermalTrackPage_none,
+    cursor_thermalTrackPage_alt,
     cursor_thermalTrackPage_timer,
   };
   constexpr uint8_t THERMAL_TRACK_CURSOR_MAX = cursor_thermalTrackPage_timer;
@@ -48,7 +56,7 @@ namespace {
 
   void printSelectedClimb(const ThermalDisplayItem* selected) {
     u8g2.setFont(leaf_6x12);
-    u8g2.setCursor(27, 42);
+    u8g2.setCursor(27, 57);
     if (selected == nullptr) {
       u8g2.print(settings.units_climb ? "----fpm" : "--.-m/s");
       return;
@@ -58,7 +66,7 @@ namespace {
 
   void printSelectedDistance(const ThermalDisplayItem* selected) {
     u8g2.setFont(leaf_6x12);
-    u8g2.setCursor(34, 57);
+    u8g2.setCursor(34, 72);
     if (selected == nullptr) {
       u8g2.print(settings.units_distance ? "--.-mi" : "--.-km");
       return;
@@ -158,6 +166,12 @@ namespace {
     drawCircleD(MAP_CX, MAP_CY, MAP_D_5000M);
   }
 
+  void maskMapCircle() {
+    u8g2.setDrawColor(0);
+    u8g2.drawDisc(MAP_CX, MAP_CY, MAP_R_5000M);
+    u8g2.setDrawColor(1);
+  }
+
   void drawDistanceScaleLabels() {
     u8g2.setFont(leaf_5x8);
     constexpr uint8_t labelHeight = 8;
@@ -174,9 +188,9 @@ namespace {
       u8g2.print(text);
     };
 
-    drawLabel(41, 136, settings.units_distance ? "0.3" : "0.5", padding);
-    drawLabel(41, 148, settings.units_distance ? "1.0" : "1.5", 0);
-    drawLabel(settings.units_distance ? 41 : 40, 160, settings.units_distance ? "3mi" : "5km",
+    drawLabel(41, 151, settings.units_distance ? "0.3" : "0.5", padding);
+    drawLabel(41, 163, settings.units_distance ? "1.0" : "1.5", 0);
+    drawLabel(settings.units_distance ? 41 : 40, 175, settings.units_distance ? "3mi" : "5km",
               padding);
     u8g2.setDrawColor(1);
   }
@@ -215,6 +229,43 @@ namespace {
     }
   }
 
+  void drawAltitudeField() {
+    const uint8_t altType = settings.disp_thmPageAltType == altType_MSL ? altType_MSL : altType_GPS;
+    display_alt_type(ALT_X, ALT_BASELINE_Y, leaf_21h, altType);
+    u8g2.setFont(leaf_labels);
+    u8g2.setCursor(78, ALT_BASELINE_Y + 10);
+    u8g2.print(settings.units_alt ? "ft" : "m");
+    u8g2.setCursor(78, ALT_BASELINE_Y + 18);
+    print_alt_label(altType);
+
+    if (thermalTrackPageCursor == cursor_thermalTrackPage_alt) {
+      display_selectionBox(ALT_X, ALT_BASELINE_Y - 23, 96 - ALT_X, 25, 6);
+    }
+  }
+
+  void drawSelectedThermalReadout(const ThermalDisplayItem* selected) {
+    printSelectedClimb(selected);
+    printSelectedDistance(selected);
+  }
+
+  void toggleAltitudeType() {
+    if (settings.disp_thmPageAltType == altType_MSL)
+      settings.disp_thmPageAltType = altType_GPS;
+    else
+      settings.disp_thmPageAltType = altType_MSL;
+    speaker.playSound(fx::neutral);
+  }
+
+  bool thermalTrackPageVolumeShortcut(Button button, ButtonEvent state) {
+    if (!settings.volumeShortcut || (button != Button::UP && button != Button::DOWN) ||
+        state != ButtonEvent::INCREMENTED) {
+      return false;
+    }
+
+    if (!settings.adjustShortcutVolume(button)) buttons.consumeButton();
+    return true;
+  }
+
   void thermalTrackPageCursorMove(Button button) {
     if (button == Button::UP) {
       thermalTrackPageCursor--;
@@ -241,12 +292,16 @@ void thermalTrackPage_draw() {
     display_headerAndFooter(thermalTrackPageCursor == cursor_thermalTrackPage_timer, false);
 
     const ThermalDisplayItem* selected = thermalTracker.selectedDisplayItem();
+    const int32_t climbRate = baro.climbRateFilteredValid() ? baro.climbRateFiltered() : 0;
 
+    display_varioBar(VARIO_BAR_TOP, VARIO_BAR_HALF_HEIGHT, VARIO_BAR_HALF_HEIGHT, VARIO_BAR_WIDTH,
+                     climbRate);
+    maskMapCircle();
     drawThermals();
     drawMapRingsAndLabels();
     drawUserTriangle();
-    printSelectedClimb(selected);
-    printSelectedDistance(selected);
+    drawAltitudeField();
+    drawSelectedThermalReadout(selected);
     drawDistanceScaleLabels();
   } while (u8g2.nextPage());
 }
@@ -259,7 +314,11 @@ void thermalTrackPage_button(Button button, ButtonEvent state, uint8_t count) {
       switch (button) {
         case Button::UP:
         case Button::DOWN:
-          if (state == ButtonEvent::CLICKED) thermalTrackPageCursorMove(button);
+          if (thermalTrackPageVolumeShortcut(button, state)) {
+            break;
+          } else if (state == ButtonEvent::CLICKED) {
+            thermalTrackPageCursorMove(button);
+          }
           break;
         case Button::RIGHT:
           if (state == ButtonEvent::CLICKED) {
@@ -278,6 +337,20 @@ void thermalTrackPage_button(Button button, ButtonEvent state, uint8_t count) {
             power.shutdown();
             return;
           }
+          break;
+      }
+      break;
+    case cursor_thermalTrackPage_alt:
+      switch (button) {
+        case Button::UP:
+        case Button::DOWN:
+          if (state == ButtonEvent::CLICKED) thermalTrackPageCursorMove(button);
+          break;
+        case Button::LEFT:
+        case Button::RIGHT:
+          break;
+        case Button::CENTER:
+          if (state == ButtonEvent::CLICKED) toggleAltitudeType();
           break;
       }
       break;

--- a/tools and analysis/display_editor/thermalTrack-layout.json
+++ b/tools and analysis/display_editor/thermalTrack-layout.json
@@ -239,6 +239,82 @@
       "y": 160,
       "text": "5km",
       "font": "leaf_5x8"
+    },
+    {
+      "id": 53,
+      "type": "text",
+      "name": "text 53",
+      "color": 1,
+      "visible": true,
+      "x": 69,
+      "y": 190,
+      "text": "3:24",
+      "font": "leaf_6x12"
+    },
+    {
+      "id": 54,
+      "type": "box",
+      "name": "box 54",
+      "color": 1,
+      "visible": true,
+      "x": 53,
+      "y": 176,
+      "w": 43,
+      "h": 16,
+      "fill": false,
+      "rounded": true,
+      "r": 2
+    },
+    {
+      "id": 55,
+      "type": "box",
+      "name": "box 55",
+      "color": 1,
+      "visible": true,
+      "x": 24,
+      "y": 161,
+      "w": 48,
+      "h": 15,
+      "fill": false,
+      "rounded": false,
+      "r": 1
+    },
+    {
+      "id": 56,
+      "type": "varioBar",
+      "name": "varioBar 56",
+      "color": 1,
+      "visible": true,
+      "x": 0,
+      "y": 0,
+      "w": 17,
+      "posTick": 10,
+      "negTick": 10
+    },
+    {
+      "id": 57,
+      "type": "text",
+      "name": "text 57",
+      "color": 1,
+      "visible": true,
+      "x": 20,
+      "y": 25,
+      "text": "14,250'",
+      "font": "leaf_21h"
+    },
+    {
+      "id": 58,
+      "type": "box",
+      "name": "box 58",
+      "color": 1,
+      "visible": true,
+      "x": 22,
+      "y": 27,
+      "w": 54,
+      "h": 33,
+      "fill": false,
+      "rounded": true,
+      "r": 7
     }
   ]
 }

--- a/tools and analysis/thermal_detection/igc_thermal_replay.html
+++ b/tools and analysis/thermal_detection/igc_thermal_replay.html
@@ -442,7 +442,7 @@
           <label class="speed-control">Speed
             <span class="speed-track">
               <span class="speed-ticks" id="speedTicks"></span>
-              <input id="speed" type="range" min="0" max="1" step="0.001" value="0.493">
+              <input id="speed" type="range" min="0" max="1" step="0.001" value="0">
             </span>
             <span id="speedLabel">30x</span>
           </label>
@@ -599,6 +599,20 @@ const followMaxAltitudeVerticalOffsetRatio = 0.25;
 const followCatchupStartRatio = 0.18;
 const followCatchupFullRatio = 0.38;
 const orbitYawRateRadPerS = 0.06;
+const leafScreenW = 96;
+const leafScreenH = 192;
+const leafPipHeaderH = 18;
+const leafPipGap = 8;
+const thermalCoreLookbackS = 40;
+const thermalCoreMinSamples = 8;
+const thermalCoreMinTurnDeg = 180;
+const thermalCoreMinRadiusM = 18;
+const thermalCoreMaxRadiusM = 180;
+const windBinCount = 8;
+const windSamplesPerBin = 6;
+const windStandardAirspeed = 10;
+const windAdjustmentStepMps = 0.1;
+const windIterationsPerFix = 8;
 const paramGroups = [
   ["Quality score", ["quality_climb_1_mps", "quality_climb_2_mps", "quality_gain_m", "quality_near_altitude_margin_m"]],
   ["Candidate detection", ["window_s", "min_gain_m", "min_turn_deg", "turn_reversal_hysteresis_deg", "stale_tolerance_s"]],
@@ -635,6 +649,12 @@ let perspectiveAmount = defaultPerspectiveAmount;
 let perspectiveControlRect = null;
 let currentFrameItems = {saved: [], failed: [], merged: []};
 let currentQualityAltitude = null;
+let corePipCollapsed = false;
+let trackPipCollapsed = false;
+let corePipHeaderRect = null;
+let trackPipHeaderRect = null;
+let corePipRect = null;
+let trackPipRect = null;
 let replayT = 0;
 let lastNow = performance.now();
 
@@ -872,6 +892,204 @@ function altitudeSourceLabel() {
   return altitudeSource === "pressure" ? "IGC pressure altitude" : "GPS altitude";
 }
 
+function windDxOf(angle, speed) {
+  return Math.cos(angle) * speed;
+}
+
+function windDyOf(angle, speed) {
+  return Math.sin(angle) * speed;
+}
+
+function windSpeedOf(wx, wy) {
+  return Math.hypot(wx, wy);
+}
+
+function windDirectionOf(wx, wy) {
+  return Math.atan2(wy, wx);
+}
+
+function createWindEstimatorState() {
+  return {
+    windSpeed: 0,
+    windDirectionTrue: 0,
+    windDirectionFrom: Math.PI,
+    airspeed: windStandardAirspeed,
+    airspeedLive: 0,
+    error: Number.MAX_VALUE,
+    recentBin: -1,
+    validEstimate: false,
+    bins: Array.from({length: windBinCount}, () => ({
+      angle: Array(windSamplesPerBin).fill(0),
+      speed: Array(windSamplesPerBin).fill(0),
+      dx: Array(windSamplesPerBin).fill(0),
+      dy: Array(windSamplesPerBin).fill(0),
+      averageAngle: 0,
+      averageSpeed: 0,
+      averageDx: 0,
+      averageDy: 0,
+      index: 0,
+      sampleCount: 0
+    }))
+  };
+}
+
+function submitVelocityForWindEstimate(state, groundVelocity) {
+  let relativeAngle = groundVelocity.trackAngle;
+  if (state.validEstimate) {
+    const dx = windDxOf(groundVelocity.trackAngle, groundVelocity.speed);
+    const dy = windDyOf(groundVelocity.trackAngle, groundVelocity.speed);
+    const wx = windDxOf(state.windDirectionTrue, state.windSpeed / 2);
+    const wy = windDyOf(state.windDirectionTrue, state.windSpeed / 2);
+    relativeAngle = windDirectionOf(dx - wx, dy - wy);
+  }
+  if (relativeAngle < 0) relativeAngle += 2 * Math.PI;
+  const binAngleSpan = 2 * Math.PI / windBinCount;
+  for (let b = 0; b < windBinCount; b += 1) {
+    if (relativeAngle < (b + 1) * binAngleSpan) {
+      const bin = state.bins[b];
+      bin.angle[bin.index] = groundVelocity.trackAngle;
+      bin.speed[bin.index] = groundVelocity.speed;
+      bin.index += 1;
+      bin.sampleCount += 1;
+      state.recentBin = b;
+      if (bin.sampleCount > windSamplesPerBin) bin.sampleCount = windSamplesPerBin;
+      if (bin.index >= windSamplesPerBin) bin.index = 0;
+      break;
+    }
+  }
+  if (state.validEstimate) {
+    state.airspeedLive = windSpeedOf(
+      windDxOf(groundVelocity.trackAngle, groundVelocity.speed) +
+        windDxOf(state.windDirectionFrom, state.windSpeed),
+      windDyOf(groundVelocity.trackAngle, groundVelocity.speed) +
+        windDyOf(state.windDirectionFrom, state.windSpeed)
+    );
+  }
+}
+
+function convertWindSamplesToDxDy(state) {
+  for (const bin of state.bins) {
+    for (let s = 0; s < bin.sampleCount; s += 1) {
+      bin.dx[s] = windDxOf(bin.angle[s], bin.speed[s]);
+      bin.dy[s] = windDyOf(bin.angle[s], bin.speed[s]);
+    }
+  }
+}
+
+function averageWindSamplePoints(state) {
+  for (const bin of state.bins) {
+    if (!bin.sampleCount) continue;
+    let sumAngle = 0;
+    let sumSpeed = 0;
+    for (let s = 0; s < bin.sampleCount; s += 1) {
+      sumAngle += bin.angle[s];
+      sumSpeed += bin.speed[s];
+    }
+    bin.averageAngle = sumAngle / bin.sampleCount;
+    bin.averageSpeed = sumSpeed / bin.sampleCount;
+    bin.averageDx = windDxOf(bin.averageAngle, bin.averageSpeed);
+    bin.averageDy = windDyOf(bin.averageAngle, bin.averageSpeed);
+  }
+}
+
+function windEstimatorHasEnoughPoints(state) {
+  let populatedBinCount = 0;
+  let continuousEmptyBinCount = 0;
+  let firstBinToHavePoints = 0;
+  let haveStartingBin = false;
+  let populatedSpan = 0;
+  const requiredPopulatedBins = 3;
+  const binsRequiredForSemiCircle = windBinCount / 2;
+  for (let i = 0; i < windBinCount; i += 1) {
+    if (state.bins[i].sampleCount > 0) {
+      populatedBinCount += 1;
+      continuousEmptyBinCount = 0;
+      if (!haveStartingBin) {
+        firstBinToHavePoints = i;
+        haveStartingBin = true;
+      } else {
+        populatedSpan = i - firstBinToHavePoints;
+      }
+    } else {
+      continuousEmptyBinCount += 1;
+      if (continuousEmptyBinCount >= binsRequiredForSemiCircle) return false;
+    }
+  }
+  return populatedBinCount >= requiredPopulatedBins && populatedSpan >= binsRequiredForSemiCircle;
+}
+
+function windEstimateErrorOf(state, wx, wy, airspeed) {
+  let sumSquareError = 0;
+  let n = 0;
+  for (const bin of state.bins) {
+    for (let sample = 0; sample < bin.sampleCount; sample += 1) {
+      const dx = bin.dx[sample] - wx;
+      const dy = bin.dy[sample] - wy;
+      const dr = Math.hypot(dx, dy) - airspeed;
+      sumSquareError += dr * dr;
+      n += 1;
+    }
+  }
+  return n ? Math.sqrt(sumSquareError / n) : Number.MAX_VALUE;
+}
+
+function updateWindEstimate(state) {
+  convertWindSamplesToDxDy(state);
+  if (!windEstimatorHasEnoughPoints(state)) return false;
+  averageWindSamplePoints(state);
+  let wx = windDxOf(state.windDirectionTrue, state.windSpeed);
+  let wy = windDyOf(state.windDirectionTrue, state.windSpeed);
+  let bestError = windEstimateErrorOf(state, wx, wy, state.airspeed);
+  const adjustments = [
+    [windAdjustmentStepMps, 0, 0],
+    [-windAdjustmentStepMps, 0, 0],
+    [0, windAdjustmentStepMps, 0],
+    [0, -windAdjustmentStepMps, 0],
+    [0, 0, windAdjustmentStepMps],
+    [0, 0, -windAdjustmentStepMps]
+  ];
+  let bestAdjustment = null;
+  for (const adjustment of adjustments) {
+    const newError = windEstimateErrorOf(
+      state,
+      wx + adjustment[0],
+      wy + adjustment[1],
+      state.airspeed + adjustment[2]
+    );
+    if (newError < bestError) {
+      bestError = newError;
+      bestAdjustment = adjustment;
+    }
+  }
+  if (bestAdjustment) {
+    state.airspeed += bestAdjustment[2];
+    wx += bestAdjustment[0];
+    wy += bestAdjustment[1];
+    state.windSpeed = windSpeedOf(wx, wy);
+    state.windDirectionTrue = windDirectionOf(wx, wy);
+    state.windDirectionFrom = state.windDirectionTrue + Math.PI;
+    state.error = bestError;
+  } else {
+    state.validEstimate = true;
+    state.error = bestError;
+  }
+  return state.validEstimate;
+}
+
+function windSnapshot(state) {
+  return {
+    validEstimate: state.validEstimate,
+    windSpeed: state.windSpeed,
+    windDirectionTrue: state.windDirectionTrue,
+    windDirectionFrom: state.windDirectionFrom,
+    windFromDeg: ((state.windDirectionFrom * 180 / Math.PI) % 360 + 360) % 360,
+    airspeed: state.airspeed,
+    airspeedLive: state.airspeedLive,
+    error: state.error,
+    recentBin: state.recentBin
+  };
+}
+
 function ensureAltitudeControls() {
   const pressureAvailable = hasPressureAltitude(rawFixes);
   if (!pressureAvailable && pendingAltitudeSource === "pressure") pendingAltitudeSource = "gps";
@@ -887,6 +1105,7 @@ function recomputeMetrics({resetCamera = true} = {}) {
   project(processed);
   applyActiveTerrain(processed);
   ensureAltitudeControls();
+  const windState = createWindEstimatorState();
   for (let i = 0; i < processed.length; i++) {
     const fix = processed[i];
     fix.detectorAlt = altitudeFor(fix, altitudeSource);
@@ -901,6 +1120,15 @@ function recomputeMetrics({resetCamera = true} = {}) {
         fix.bearing = bearing(processed[bearingStart], fix);
       }
     }
+    const displayBearingStart = priorIndex(processed, i, 1);
+    fix.displayBearing = fix.bearing;
+    if (Number.isFinite(fix.trackDeg)) {
+      fix.displayBearing = fix.trackDeg;
+    } else if (displayBearingStart < i) {
+      const dx = fix.x - processed[displayBearingStart].x;
+      const dy = fix.y - processed[displayBearingStart].y;
+      if (Math.hypot(dx, dy) >= 1.5) fix.displayBearing = bearing(processed[displayBearingStart], fix);
+    }
     const varioStart = priorIndex(processed, i, params.vario_avg_s);
     const climbStart = priorIndex(processed, i, 30);
     const varioDt = Math.max(1, fix.t - processed[varioStart].t);
@@ -908,6 +1136,22 @@ function recomputeMetrics({resetCamera = true} = {}) {
       ? fix.climbMps
       : (fix.detectorAlt - processed[varioStart].detectorAlt) / varioDt;
     fix.climb30 = (fix.detectorAlt - processed[climbStart].detectorAlt) / Math.max(1, fix.t - processed[climbStart].t);
+    fix.groundSpeedMps = 0;
+    if (i > 0) {
+      const previous = processed[i - 1];
+      const dt = Math.max(1, fix.t - previous.t);
+      const dx = fix.x - previous.x;
+      const dy = fix.y - previous.y;
+      fix.groundSpeedMps = Math.hypot(dx, dy) / dt;
+    }
+    if (Number.isFinite(fix.bearing) && fix.groundSpeedMps >= 1.5) {
+      submitVelocityForWindEstimate(windState, {
+        trackAngle: fix.bearing * Math.PI / 180,
+        speed: fix.groundSpeedMps
+      });
+      for (let step = 0; step < windIterationsPerFix; step += 1) updateWindEstimate(windState);
+    }
+    fix.wind = windSnapshot(windState);
     const start = Math.max(priorIndex(processed, i, params.window_s), i - leafDetectorSampleBuffer + 1);
     const window = processed.slice(start, i + 1);
     fix.windowDuration = window[window.length - 1].t - window[0].t;
@@ -1642,20 +1886,36 @@ function pivotMapOnPosition(position, map) {
 
 function smoothedFollowPosition(index, visualFix = null) {
   if (!processed.length) return null;
-  const windowCount = Math.min(100, processed.length);
-  const end = Math.max(windowCount - 1, index);
-  const start = Math.max(0, end - windowCount + 1);
+  const current = visualFix || processed[index];
+  const endT = current?.t ?? processed[index].t;
+  const startT = Math.max(0, endT - 12);
   let total = 0;
-  const acc = {x: 0, y: 0, z: 0};
-  for (let i = start; i <= end && i < processed.length; i += 1) {
-    const point = visualFix && i === index ? visualFix : processed[i];
-    acc.x += point.x;
-    acc.y += point.y;
-    acc.z += point.detectorAlt;
+  const acc = {x: 0, y: 0, z: 0, weight: 0};
+  for (let i = 0; i <= index && i < processed.length; i += 1) {
+    const point = processed[i];
+    if (point.t < startT || point.t > endT) continue;
+    const age = Math.max(0, endT - point.t);
+    const weight = Math.exp(-age / 5);
+    acc.x += point.x * weight;
+    acc.y += point.y * weight;
+    acc.z += point.detectorAlt * weight;
+    acc.weight += weight;
     total += 1;
   }
-  if (!total) return itemPosition(processed[index]);
-  return {x: acc.x / total, y: acc.y / total, z: acc.z / total};
+  if (visualFix && visualFix.t >= startT) {
+    const weight = 1.25;
+    acc.x += visualFix.x * weight;
+    acc.y += visualFix.y * weight;
+    acc.z += visualFix.detectorAlt * weight;
+    acc.weight += weight;
+    total += 1;
+  }
+  if (!total || acc.weight <= 0) return itemPosition(current);
+  return {
+    x: current.x,
+    y: current.y,
+    z: acc.z / acc.weight
+  };
 }
 
 function applyFollowScreenCatchup(target, map, verticalOffsetRatio = followMaxAltitudeVerticalOffsetRatio) {
@@ -2338,6 +2598,11 @@ function lerpNumeric(a, b, ratio) {
   return Number.isFinite(a) ? a : b;
 }
 
+function lerpAngleDeg(a, b, ratio) {
+  if (Number.isFinite(a) && Number.isFinite(b)) return (a + angleDelta(b, a) * ratio + 360) % 360;
+  return Number.isFinite(a) ? a : b;
+}
+
 function visualFixAt(t) {
   if (!processed.length) return null;
   const i = currentIndex(t);
@@ -2356,7 +2621,10 @@ function visualFixAt(t) {
     groundAlt: lerpNumeric(a.groundAlt, b.groundAlt, ratio),
     vario: lerpNumeric(a.vario, b.vario, ratio),
     climb30: lerpNumeric(a.climb30, b.climb30, ratio),
-    bearing: lerpNumeric(a.bearing, b.bearing, ratio)
+    bearing: lerpAngleDeg(a.bearing, b.bearing, ratio),
+    displayBearing: lerpAngleDeg(a.displayBearing, b.displayBearing, ratio),
+    groundSpeedMps: lerpNumeric(a.groundSpeedMps, b.groundSpeedMps, ratio),
+    wind: ratio < 0.5 ? a.wind : b.wind
   };
 }
 
@@ -2383,6 +2651,669 @@ function fmtDuration(t) {
   const m = Math.floor(t / 60);
   const s = Math.floor(t % 60);
   return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function fitCircle(points) {
+  if (points.length < 3) return null;
+  const meanX = avg(points.map(p => p.x));
+  const meanY = avg(points.map(p => p.y));
+  let suu = 0, suv = 0, svv = 0, suuu = 0, svvv = 0, suvv = 0, svuu = 0;
+  for (const point of points) {
+    const u = point.x - meanX;
+    const v = point.y - meanY;
+    const uu = u * u;
+    const vv = v * v;
+    suu += uu;
+    suv += u * v;
+    svv += vv;
+    suuu += uu * u;
+    svvv += vv * v;
+    suvv += u * vv;
+    svuu += v * uu;
+  }
+  const det = suu * svv - suv * suv;
+  if (Math.abs(det) < 1e-9) return null;
+  const rhsU = -(suuu + suvv);
+  const rhsV = -(svuu + svvv);
+  const a = (rhsU * svv - rhsV * suv) / det;
+  const b = (suu * rhsV - suv * rhsU) / det;
+  const cx = meanX - a / 2;
+  const cy = meanY - b / 2;
+  const distances = points.map(p => Math.hypot(p.x - cx, p.y - cy));
+  const radius = avg(distances);
+  const residual = Math.sqrt(avg(distances.map(d => (d - radius) ** 2)));
+  if (!Number.isFinite(radius) || radius <= 0) return null;
+  return {x: cx, y: cy, radius, residual};
+}
+
+function recentReplaySamples(index, visualFix, secondsBack = thermalCoreLookbackS) {
+  if (!processed.length) return [];
+  const endT = visualFix?.t ?? processed[index]?.t ?? replayT;
+  const startT = endT - secondsBack;
+  const samples = processed.filter((point, i) => i <= index && point.t >= startT && point.t <= endT);
+  if (visualFix && visualFix.t > (samples[samples.length - 1]?.t ?? -Infinity)) samples.push(visualFix);
+  return samples.filter(point =>
+    Number.isFinite(point.x) &&
+    Number.isFinite(point.y) &&
+    Number.isFinite(point.bearing) &&
+    Number.isFinite(point.vario)
+  );
+}
+
+function windCorrectCoreSamples(samples, visualFix) {
+  const wind = visualFix?.wind;
+  if (!wind?.validEstimate || !Number.isFinite(wind.windSpeed)) return samples.map(point => ({...point}));
+  const wx = Math.sin(wind.windDirectionTrue) * wind.windSpeed;
+  const wy = Math.cos(wind.windDirectionTrue) * wind.windSpeed;
+  const originT = visualFix.t;
+  return samples.map(point => {
+    const dt = point.t - originT;
+    return {
+      ...point,
+      groundX: point.x,
+      groundY: point.y,
+      x: point.x - wx * dt,
+      y: point.y - wy * dt
+    };
+  });
+}
+
+function turnStats(points) {
+  let signed = 0;
+  let absolute = 0;
+  let lastBearing = null;
+  let firstBearing = null;
+  let firstT = null;
+  let lastT = null;
+  for (const point of points) {
+    if (!Number.isFinite(point.bearing)) continue;
+    if (firstBearing === null) {
+      firstBearing = point.bearing;
+      firstT = point.t;
+    }
+    if (lastBearing !== null) {
+      const delta = angleDelta(point.bearing, lastBearing);
+      signed += delta;
+      absolute += Math.abs(delta);
+    }
+    lastBearing = point.bearing;
+    lastT = point.t;
+  }
+  const direction = Math.abs(signed) < 45 ? 0 : signed > 0 ? 1 : -1;
+  const duration = firstT !== null && lastT !== null ? Math.max(1, lastT - firstT) : 1;
+  return {signed, absolute, direction, turnRateDps: absolute / duration};
+}
+
+function recentTurnRateDps(points, secondsBack = 6) {
+  if (points.length < 2) return 0;
+  const endT = points[points.length - 1].t;
+  const recent = points.filter(point => endT - point.t <= secondsBack && Number.isFinite(point.bearing));
+  if (recent.length < 2) return 0;
+  let total = 0;
+  let last = recent[0].bearing;
+  for (const point of recent.slice(1)) {
+    total += Math.abs(angleDelta(point.bearing, last));
+    last = point.bearing;
+  }
+  return total / Math.max(1, recent[recent.length - 1].t - recent[0].t);
+}
+
+function estimateThermalCore(index, visualFix) {
+  const groundSamples = recentReplaySamples(index, visualFix);
+  const samples = windCorrectCoreSamples(groundSamples, visualFix);
+  const stats = turnStats(samples);
+  const fit = fitCircle(samples);
+  const turnOk = stats.absolute >= thermalCoreMinTurnDeg && stats.direction !== 0;
+  if (samples.length < thermalCoreMinSamples || !turnOk || !Number.isFinite(visualFix.bearing)) {
+    return {valid: false, samples, stats, fit, reason: "WAIT"};
+  }
+
+  const currentBearing = visualFix.bearing;
+  const bins = Array.from({length: 12}, () => ({weight: 0, lift: 0, age: 0}));
+  let currentWeight = 0;
+  let currentLift = 0;
+  let oppositeWeight = 0;
+  let oppositeLift = 0;
+  let recentWeight = 0;
+  let recentLift = 0;
+  let priorWeight = 0;
+  let priorLift = 0;
+  const nowT = visualFix.t;
+  for (const sample of samples) {
+    const age = Math.max(0, nowT - sample.t);
+    const ageWeight = Math.exp(-age / 12);
+    const signedPhase = stats.direction * angleDelta(sample.bearing, currentBearing);
+    const phase = (signedPhase + 360) % 360;
+    const oppositeDistance = Math.abs(angleDelta(phase, 180));
+    const currentDistance = Math.min(phase, 360 - phase);
+    const bin = bins[Math.min(bins.length - 1, Math.floor(phase / 360 * bins.length))];
+    bin.weight += ageWeight;
+    bin.lift += sample.vario * ageWeight;
+    bin.age += age * ageWeight;
+    if (currentDistance <= 35) {
+      currentWeight += ageWeight;
+      currentLift += sample.vario * ageWeight;
+    }
+    if (oppositeDistance <= 35) {
+      oppositeWeight += ageWeight;
+      oppositeLift += sample.vario * ageWeight;
+    }
+    if (age <= 5) {
+      recentWeight += ageWeight;
+      recentLift += sample.vario * ageWeight;
+    } else if (age <= 16) {
+      priorWeight += ageWeight;
+      priorLift += sample.vario * ageWeight;
+    }
+  }
+
+  for (const bin of bins) {
+    bin.avgLift = bin.weight > 0 ? bin.lift / bin.weight : null;
+    bin.avgAge = bin.weight > 0 ? bin.age / bin.weight : null;
+  }
+
+  const currentAvg = currentWeight > 0 ? currentLift / currentWeight : visualFix.vario;
+  const oppositeAvg = oppositeWeight > 0 ? oppositeLift / oppositeWeight : null;
+  const recentAvg = recentWeight > 0 ? recentLift / recentWeight : visualFix.vario;
+  const priorAvg = priorWeight > 0 ? priorLift / priorWeight : recentAvg;
+  const symmetry = oppositeAvg === null ? 0 : currentAvg - oppositeAvg;
+  const trend = recentAvg - priorAvg;
+  const confidence = clamp(
+    (samples.length / leafDetectorSampleBuffer) * 0.25 +
+    (stats.absolute / 360) * 0.45 +
+    (oppositeWeight > 0 ? 0.3 : 0),
+    0,
+    1
+  );
+  const advice = confidence < 0.34
+    ? 0
+    : clamp(symmetry / 0.9 * 0.65 + trend / 1.1 * 0.35, -1, 1);
+  const actualTurnRateDps = recentTurnRateDps(samples);
+  const suggestedTurnRateDps = clamp(actualTurnRateDps * (1 - advice * 0.5), 0, 40);
+  let cue = "HOLD";
+  if (confidence < 0.34) cue = "WEAK";
+  else if (advice <= -0.55) cue = "TIGHT++";
+  else if (advice <= -0.2) cue = "TIGHT";
+  else if (advice >= 0.55) cue = "WIDE++";
+  else if (advice >= 0.2) cue = "WIDE";
+
+  return {
+    valid: confidence >= 0.34,
+    samples,
+    stats,
+    fit,
+    confidence,
+    bins,
+    cue,
+    currentAvg,
+    oppositeAvg,
+    symmetry,
+    trend,
+    advice,
+    actualTurnRateDps,
+    suggestedTurnRateDps,
+    displayRadius: fit && fit.radius >= thermalCoreMinRadiusM && fit.radius <= thermalCoreMaxRadiusM
+      ? fit.radius
+      : Math.max(35, Math.min(95, visualFix.groundSpeedMps * 8 || 65))
+  };
+}
+
+function leafPipScale(map) {
+  const expandedCount = (corePipCollapsed ? 0 : 1) + (trackPipCollapsed ? 0 : 1);
+  const collapsedCount = (corePipCollapsed ? 1 : 0) + (trackPipCollapsed ? 1 : 0);
+  const available = map.h - 22 - leafPipGap - collapsedCount * leafPipHeaderH - expandedCount * leafPipGap;
+  if (expandedCount <= 0) return 1.4;
+  return clamp(Math.floor((available / expandedCount) / leafScreenH * 100) / 100, 0.78, 1.28);
+}
+
+function leafPipLayouts(map) {
+  const scale = leafPipScale(map);
+  const w = leafScreenW * scale;
+  const screenH = leafScreenH * scale;
+  const x = map.x + map.w - w - 12;
+  let y = map.y + map.h - 12;
+  const place = collapsed => {
+    const h = leafPipHeaderH + (collapsed ? 0 : screenH);
+    y -= h;
+    const rect = {x, y, w, h, scale, screenH, collapsed};
+    y -= leafPipGap;
+    return rect;
+  };
+  const track = place(trackPipCollapsed);
+  const core = place(corePipCollapsed);
+  return {core, track};
+}
+
+function drawLeafPipFrame(rect, title, collapsed) {
+  ctx.save();
+  ctx.fillStyle = "rgba(8, 8, 8, 0.88)";
+  ctx.strokeStyle = "#777";
+  ctx.lineWidth = 1;
+  ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.fillStyle = "#eee";
+  ctx.font = "12px system-ui, sans-serif";
+  ctx.textBaseline = "middle";
+  ctx.fillText(`[${title} ${collapsed ? "^" : "v"}]`, rect.x + 6, rect.y + leafPipHeaderH / 2);
+  ctx.restore();
+  return {x: rect.x, y: rect.y, w: rect.w, h: leafPipHeaderH};
+}
+
+function beginLeafScreen(rect) {
+  ctx.save();
+  ctx.translate(rect.x, rect.y + leafPipHeaderH);
+  ctx.scale(rect.scale, rect.scale);
+  ctx.fillStyle = "#f4f4f4";
+  ctx.fillRect(0, 0, leafScreenW, leafScreenH);
+  ctx.strokeStyle = "#111";
+  ctx.lineWidth = 1;
+  ctx.strokeRect(0.5, 0.5, leafScreenW - 1, leafScreenH - 1);
+  ctx.beginPath();
+  ctx.rect(0, 0, leafScreenW, leafScreenH);
+  ctx.clip();
+}
+
+function endLeafScreen() {
+  ctx.restore();
+}
+
+function drawLeafAircraft(x, y, size = 11) {
+  ctx.save();
+  ctx.fillStyle = "#111";
+  ctx.strokeStyle = "#f4f4f4";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(x, y - size);
+  ctx.lineTo(x + size * 0.72, y + size * 0.75);
+  ctx.lineTo(x, y + size * 0.34);
+  ctx.lineTo(x - size * 0.72, y + size * 0.75);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+}
+
+function coreScreenPoint(point, fix, headingDeg, aircraftX, aircraftY, metersPerPx) {
+  const dx = point.x - fix.x;
+  const dy = point.y - fix.y;
+  const h = headingDeg * Math.PI / 180;
+  const right = Math.cos(h) * dx - Math.sin(h) * dy;
+  const ahead = Math.sin(h) * dx + Math.cos(h) * dy;
+  return {x: aircraftX + right / metersPerPx, y: aircraftY - ahead / metersPerPx};
+}
+
+function drawCoreTurnRateBar(estimate) {
+  const x = 13;
+  const y = 49;
+  const w = 70;
+  const h = 7;
+  const maxRate = 40;
+  const direction = estimate.stats?.direction || 1;
+  const xForRate = rate => {
+    const ratio = clamp(rate / maxRate, 0, 1);
+    return direction > 0 ? x + ratio * w : x + (1 - ratio) * w;
+  };
+  const actualX = xForRate(estimate.actualTurnRateDps || 0);
+  const suggestedX = xForRate(estimate.suggestedTurnRateDps ?? estimate.actualTurnRateDps ?? 0);
+  ctx.save();
+  ctx.strokeStyle = "#111";
+  ctx.fillStyle = "#111";
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x, y, w, h);
+  ctx.beginPath();
+  ctx.moveTo(direction > 0 ? x : x + w, y + h + 1);
+  ctx.lineTo(direction > 0 ? x : x + w, y + h + 4);
+  ctx.moveTo(direction > 0 ? x + w : x, y + h + 1);
+  ctx.lineTo(direction > 0 ? x + w : x, y + h + 4);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.arc(actualX, y + h / 2, 3, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.moveTo(suggestedX, y - 4);
+  ctx.lineTo(suggestedX - 3, y - 9);
+  ctx.lineTo(suggestedX + 3, y - 9);
+  ctx.closePath();
+  ctx.fill();
+  ctx.font = "6px system-ui, sans-serif";
+  ctx.textBaseline = "top";
+  ctx.textAlign = "center";
+  ctx.fillText("0", direction > 0 ? x : x + w, y + h + 5);
+  ctx.fillText("40", direction > 0 ? x + w : x, y + h + 5);
+  ctx.restore();
+}
+
+function drawCoreTargetBullseye(cx, cy) {
+  ctx.save();
+  ctx.fillStyle = "#f4f4f4";
+  ctx.strokeStyle = "#111";
+  ctx.lineWidth = 1;
+
+  const left = cx - 28;
+  const right = cx + 28;
+  const top = cy - 11;
+  const bottom = cy + 11;
+  const innerTop = cy - 4;
+  const innerBottom = cy + 4;
+
+  ctx.beginPath();
+  ctx.moveTo(left, innerTop);
+  ctx.lineTo(cx - 6, innerTop);
+  ctx.lineTo(cx - 6, top);
+  ctx.lineTo(cx + 6, top);
+  ctx.lineTo(cx + 6, innerTop);
+  ctx.lineTo(right, innerTop);
+  ctx.lineTo(right, innerBottom);
+  ctx.lineTo(cx + 6, innerBottom);
+  ctx.lineTo(cx + 6, bottom);
+  ctx.lineTo(cx - 6, bottom);
+  ctx.lineTo(cx - 6, innerBottom);
+  ctx.lineTo(left, innerBottom);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawMaskedPlusGlyph(cx, cy) {
+  ctx.save();
+  const drawPlus = (fill, armHalfW, armHalfL) => {
+    ctx.fillStyle = fill;
+    ctx.fillRect(cx - armHalfW, cy - armHalfL, armHalfW * 2, armHalfL * 2);
+    ctx.fillRect(cx - armHalfL, cy - armHalfW, armHalfL * 2, armHalfW * 2);
+  };
+  drawPlus("#f4f4f4", 4, 10);
+  drawPlus("#111", 2, 8);
+  ctx.restore();
+}
+
+function drawCoreLeafScreen(rect, estimate, visualFix) {
+  if (rect.collapsed) return;
+  beginLeafScreen(rect);
+  const direction = estimate.stats?.direction || 0;
+  const aircraftX = direction < 0 ? 76 : direction > 0 ? 20 : 48;
+  const aircraftY = 118;
+  const heading = Number.isFinite(visualFix.displayBearing)
+    ? visualFix.displayBearing
+    : Number.isFinite(visualFix.bearing) ? visualFix.bearing : 0;
+  const displayRadiusM = estimate.displayRadius || estimate.fit?.radius || 70;
+  const ringRadius = 38;
+  const metersPerPx = Math.max(1.1, displayRadiusM / ringRadius);
+  const turnSide = direction < 0 ? -1 : direction > 0 ? 1 : 0;
+  const ringCx = turnSide ? aircraftX + turnSide * ringRadius : aircraftX;
+  const ringCy = aircraftY;
+  const advice = estimate.valid ? estimate.advice || 0 : 0;
+  const dynamicRadius = ringRadius * (1 + advice * 0.36);
+  const dynamicCx = turnSide ? aircraftX + turnSide * dynamicRadius : aircraftX;
+
+  ctx.strokeStyle = "#d0d0d0";
+  ctx.lineWidth = 1;
+  for (let x = 0; x <= leafScreenW; x += 12) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, leafScreenH);
+    ctx.stroke();
+  }
+  for (let y = 0; y <= leafScreenH; y += 12) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(leafScreenW, y);
+    ctx.stroke();
+  }
+
+  if (estimate.valid && Math.abs(advice) >= 0.08) {
+    ctx.strokeStyle = "#111";
+    ctx.lineWidth = Math.abs(advice) >= 0.55 ? 3 : 2;
+    ctx.beginPath();
+    const startAngle = turnSide > 0 ? Math.PI : 0;
+    const endAngle = startAngle + turnSide * Math.PI * 0.75;
+    ctx.arc(dynamicCx, ringCy, dynamicRadius, startAngle, endAngle, turnSide < 0);
+    ctx.stroke();
+  }
+
+  const samples = estimate.samples || [];
+  const climbs = samples.map(p => p.vario).filter(Number.isFinite);
+  const minClimb = climbs.length ? Math.min(...climbs) : 0;
+  const maxClimb = climbs.length ? Math.max(...climbs) : 1;
+  for (const sample of samples) {
+    const p = coreScreenPoint(sample, visualFix, heading, aircraftX, aircraftY, metersPerPx);
+    if (p.x < -6 || p.x > leafScreenW + 6 || p.y < -6 || p.y > leafScreenH + 6) continue;
+    const strength = clamp((sample.vario - minClimb) / Math.max(0.1, maxClimb - minClimb), 0, 1);
+    ctx.strokeStyle = "#111";
+    ctx.fillStyle = "#111";
+    if (strength <= 0.25) {
+      ctx.fillRect(Math.round(p.x), Math.round(p.y), 1, 1);
+    } else {
+      ctx.lineWidth = 1;
+      const diameter = strength > 0.78 ? 7 : strength > 0.52 ? 5 : 3;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, diameter / 2, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+
+  drawCoreTargetBullseye(ringCx, ringCy);
+  drawMaskedPlusGlyph(dynamicCx, ringCy);
+
+  drawLeafAircraft(aircraftX, aircraftY, 11);
+  ctx.fillStyle = "#111";
+  ctx.font = "16px system-ui, sans-serif";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  ctx.fillText(estimate.cue || (estimate.valid ? "HOLD" : "WAIT"), 48, 5);
+  ctx.font = "7px system-ui, sans-serif";
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+  const opposite = Number.isFinite(estimate.oppositeAvg) ? estimate.oppositeAvg.toFixed(1) : "--";
+  ctx.fillText(`now ${Number.isFinite(estimate.currentAvg) ? estimate.currentAvg.toFixed(1) : "--"}`, 4, 27);
+  ctx.fillText(`opp ${opposite}`, 4, 36);
+  ctx.fillText(`${Math.round((estimate.confidence || 0) * 100)}%`, 76, 36);
+  drawCoreTurnRateBar(estimate);
+  ctx.textAlign = "start";
+  endLeafScreen();
+}
+
+function mapThermalTrackRadius(distanceM) {
+  if (distanceM <= 500) return distanceM / 500 * 25;
+  if (distanceM <= 1500) return 25 + (distanceM - 500) / 1000 * 12;
+  if (distanceM <= 5000) return 37 + (distanceM - 1500) / 3500 * 11;
+  return 48;
+}
+
+function thermalTrackItems(savedThermals, visualFix) {
+  const items = [];
+  for (const thermal of savedThermals) {
+    const point = spinePointAtAltitude(thermal.spine || [thermal], visualFix.detectorAlt, 250) || thermal;
+    const dx = point.x - visualFix.x;
+    const dy = point.y - visualFix.y;
+    const distanceM = Math.hypot(dx, dy);
+    const bearingDeg = angleDeg(dx, dy);
+    const turnDeg = angleDelta(bearingDeg, Number.isFinite(visualFix.bearing) ? visualFix.bearing : 0);
+    const radius = mapThermalTrackRadius(distanceM);
+    items.push({
+      thermal,
+      distanceM,
+      turnDeg,
+      quality: thermalQuality(thermal),
+      x: 48 + Math.sin(turnDeg * Math.PI / 180) * radius,
+      y: 124 - Math.cos(turnDeg * Math.PI / 180) * radius
+    });
+  }
+  items.sort((a, b) => b.quality - a.quality || Math.abs(a.turnDeg) - Math.abs(b.turnDeg));
+  if (items.length) {
+    let selected = items[0];
+    for (const item of items) {
+      if (Math.abs(item.turnDeg) < Math.abs(selected.turnDeg)) selected = item;
+    }
+    selected.selected = true;
+  }
+  return items;
+}
+
+function drawTrackLeafScreen(rect, savedThermals, visualFix) {
+  if (rect.collapsed) return;
+  beginLeafScreen(rect);
+  ctx.fillStyle = "#f4f4f4";
+  ctx.fillRect(0, 0, leafScreenW, leafScreenH);
+  ctx.fillStyle = "#111";
+  ctx.font = "18px system-ui, sans-serif";
+  ctx.textBaseline = "top";
+  ctx.fillText(`${Math.round(visualFix.detectorAlt)}`, 28, 15);
+  ctx.font = "8px system-ui, sans-serif";
+  ctx.fillText("m", 79, 30);
+
+  const barTop = 16;
+  const barX = 5;
+  const barH = 100;
+  const mid = barTop + barH / 2;
+  ctx.strokeStyle = "#111";
+  ctx.lineWidth = 1;
+  ctx.strokeRect(barX, barTop, 16, barH);
+  ctx.beginPath();
+  ctx.moveTo(barX, mid);
+  ctx.lineTo(barX + 16, mid);
+  ctx.stroke();
+  const climb = clamp(visualFix.vario, -5, 5);
+  const fillH = Math.abs(climb) / 5 * (barH / 2);
+  ctx.fillStyle = "#111";
+  if (climb >= 0) ctx.fillRect(barX + 3, mid - fillH, 10, fillH);
+  else ctx.fillRect(barX + 3, mid, 10, fillH);
+
+  const items = thermalTrackItems(savedThermals, visualFix);
+  const selected = items.find(item => item.selected);
+  ctx.font = "9px system-ui, sans-serif";
+  ctx.fillText(selected ? `${selected.thermal.avg_climb_mps >= 0 ? "+" : ""}${selected.thermal.avg_climb_mps.toFixed(1)}m/s` : "--.-m/s", 28, 49);
+  const distText = selected ? selected.distanceM < 1000 ? `${Math.round(selected.distanceM)}m` : `${(selected.distanceM / 1000).toFixed(1)}km` : "--.-km";
+  ctx.fillText(distText, 34, 64);
+
+  const cx = 48;
+  const cy = 124;
+  ctx.strokeStyle = "#111";
+  ctx.lineWidth = 1;
+  for (const r of [25, 37, 48]) {
+    ctx.beginPath();
+    ctx.arc(cx, cy, r, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(cx, cy, 48, 0, Math.PI * 2);
+  ctx.clip();
+  for (const item of items) {
+    ctx.lineWidth = item.quality >= 4 ? 3 : item.quality >= 2 ? 2 : 1;
+    ctx.beginPath();
+    ctx.arc(item.x, item.y, 4, 0, Math.PI * 2);
+    if (item.quality >= 5) ctx.fill();
+    else ctx.stroke();
+  }
+  for (const item of items) {
+    if (!item.selected) continue;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.arc(item.x, item.y, 6, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.restore();
+  drawLeafAircraft(cx, cy, 6);
+  ctx.font = "7px system-ui, sans-serif";
+  ctx.fillText("0.5", 41, 147);
+  ctx.fillText("1.5", 41, 160);
+  ctx.fillText("5km", 40, 173);
+  endLeafScreen();
+}
+
+function drawLeafPips(map, savedThermals, visualFix, coreEstimate) {
+  const layouts = leafPipLayouts(map);
+  corePipRect = layouts.core;
+  trackPipRect = layouts.track;
+  corePipHeaderRect = drawLeafPipFrame(layouts.core, "Core", corePipCollapsed);
+  drawCoreLeafScreen(layouts.core, coreEstimate, visualFix);
+  trackPipHeaderRect = drawLeafPipFrame(layouts.track, "Track", trackPipCollapsed);
+  drawTrackLeafScreen(layouts.track, savedThermals, visualFix);
+}
+
+function drawWindWidget(map, visualFix) {
+  const wind = visualFix?.wind;
+  const x = map.x + 10;
+  const y = map.y + map.h - 104;
+  const w = 148;
+  const h = 88;
+  ctx.save();
+  ctx.fillStyle = "rgba(8, 8, 8, 0.78)";
+  ctx.strokeStyle = "#777";
+  ctx.lineWidth = 1;
+  ctx.fillRect(x, y, w, h);
+  ctx.strokeRect(x, y, w, h);
+  ctx.fillStyle = "#ddd";
+  ctx.font = "12px system-ui, sans-serif";
+  ctx.textBaseline = "top";
+  ctx.fillText("Wind estimate", x + 8, y + 7);
+  const cx = x + 39;
+  const cy = y + 51;
+  ctx.strokeStyle = "#777";
+  ctx.beginPath();
+  ctx.arc(cx, cy, 22, 0, Math.PI * 2);
+  ctx.moveTo(cx, cy - 25);
+  ctx.lineTo(cx, cy - 18);
+  ctx.moveTo(cx + 25, cy);
+  ctx.lineTo(cx + 18, cy);
+  ctx.moveTo(cx, cy + 25);
+  ctx.lineTo(cx, cy + 18);
+  ctx.moveTo(cx - 25, cy);
+  ctx.lineTo(cx - 18, cy);
+  ctx.stroke();
+  ctx.fillStyle = "#999";
+  ctx.font = "9px system-ui, sans-serif";
+  ctx.fillText("N", cx - 3, cy - 35);
+  if (wind?.validEstimate) {
+    const fromRad = wind.windDirectionFrom;
+    const arrowLen = clamp(wind.windSpeed / 8, 0.25, 1) * 20;
+    const dx = Math.sin(fromRad) * arrowLen;
+    const dy = -Math.cos(fromRad) * arrowLen;
+    ctx.strokeStyle = "#84c8ff";
+    ctx.fillStyle = "#84c8ff";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(cx - dx, cy - dy);
+    ctx.lineTo(cx + dx, cy + dy);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(cx + dx, cy + dy, 3, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = "#ddd";
+    ctx.font = "11px system-ui, sans-serif";
+    ctx.fillText(`${Math.round(wind.windFromDeg)} deg`, x + 77, y + 31);
+    ctx.fillText(`${wind.windSpeed.toFixed(1)} m/s`, x + 77, y + 47);
+    ctx.fillStyle = "#aaa";
+    ctx.font = "10px system-ui, sans-serif";
+    ctx.fillText(`air ${wind.airspeed.toFixed(1)}`, x + 77, y + 64);
+    ctx.fillText(`err ${wind.error.toFixed(2)}`, x + 8, y + 73);
+  } else {
+    ctx.fillStyle = "#aaa";
+    ctx.font = "11px system-ui, sans-serif";
+    ctx.fillText("warming up", x + 77, y + 39);
+    ctx.font = "10px system-ui, sans-serif";
+    ctx.fillText("needs turn span", x + 77, y + 56);
+  }
+  ctx.restore();
+}
+
+function toggleLeafPipAt(point) {
+  if (corePipHeaderRect && pointInRect(point, corePipHeaderRect)) {
+    corePipCollapsed = !corePipCollapsed;
+    draw();
+    return true;
+  }
+  if (trackPipHeaderRect && pointInRect(point, trackPipHeaderRect)) {
+    trackPipCollapsed = !trackPipCollapsed;
+    draw();
+    return true;
+  }
+  if ((corePipRect && pointInRect(point, corePipRect)) ||
+      (trackPipRect && pointInRect(point, trackPipRect))) {
+    return true;
+  }
+  return false;
 }
 
 function drawTerrainMesh(map) {
@@ -2578,6 +3509,7 @@ function draw() {
   const merged = buildMergedThermals(saved);
   const activeMerged = merged.filter(merge => !merge.consumed);
   const savedTotals = savedAccounting(saved, activeMerged);
+  const coreEstimate = estimateThermalCore(i, visualFix);
   const activeSaved = saved.filter(th => !savedTotals.consumedIds.has(th.id));
   const consumedSaved = saved.filter(th => savedTotals.consumedIds.has(th.id));
   const consumedMerged = merged.filter(merge => merge.consumed);
@@ -2590,10 +3522,9 @@ function draw() {
   const H = canvas.height;
   const {tape, map, vario, profile, profileLabel} = mapLayout();
   if (followCurrentFix && playing) {
-    const followPosition = smoothedFollowPosition(i, visualFix);
+    const followPosition = itemPosition(visualFix);
     const verticalOffsetRatio = followVerticalOffsetRatioForPosition(followPosition);
     centerMapOnPosition(followPosition, verticalOffsetRatio);
-    applyFollowScreenCatchup(visualFix, map, verticalOffsetRatio);
   }
   updateScrubLayout(profile);
   const altRange = visibleAltitudeRange(processed);
@@ -2695,7 +3626,9 @@ function draw() {
   drawMapOrbitControl(map);
   drawMapTerrainControl(map);
   drawMapPerspectiveControl(map);
+  drawWindWidget(map, visualFix);
   ctx.restore();
+  drawLeafPips(map, savedTotals.savedThermals, visualFix, coreEstimate);
 
   ctx.fillStyle = "#bbb";
   ctx.font = "15px system-ui, sans-serif";
@@ -3123,6 +4056,10 @@ canvas.addEventListener("pointerdown", event => {
   resizeCanvasToDisplay();
   const {map, profile} = mapLayout();
   const point = canvasPoint(event);
+  if (event.button === 0 && toggleLeafPipAt(point)) {
+    event.preventDefault();
+    return;
+  }
   if (event.button === 0 && pointInRect(point, profile)) {
     replayT = Math.max(0, Math.min(bounds.duration, (point.x - profile.x) / Math.max(1, profile.w) * bounds.duration));
     playing = false;
@@ -3144,7 +4081,7 @@ canvas.addEventListener("pointerdown", event => {
     if (followCurrentFix && playing) {
       const i = currentIndex();
       const visualFix = visualFixAt(replayT) || processed[i];
-      const followPosition = smoothedFollowPosition(i, visualFix);
+      const followPosition = itemPosition(visualFix);
       centerMapOnPosition(followPosition, followVerticalOffsetRatioForPosition(followPosition));
     }
     event.preventDefault();
@@ -3262,7 +4199,7 @@ fileInput.addEventListener("change", async () => {
 seedEmbeddedTerrainCache();
 buildParamControls();
 recomputeMetrics();
-speed.value = sliderValueForSpeed(30).toFixed(3);
+speed.value = sliderValueForSpeed(1).toFixed(3);
 buildSpeedTicks();
 updateSpeedLabel();
 updateParamDisabled();

--- a/tools and analysis/thermal_detection/thermal_core_game.html
+++ b/tools and analysis/thermal_detection/thermal_core_game.html
@@ -6,120 +6,204 @@
 <title>Leaf Thermal Core Simulator</title>
 <style>
   :root {
-    color-scheme: light dark;
-    --bg: #f6f7f8;
-    --fg: #14171a;
-    --muted: #5f6872;
-    --panel: #ffffff;
-    --border: #cbd1d8;
-    --accent: #1f6feb;
-    --accent-soft: #dceaff;
-    --good: #128a45;
-    --warn: #b15b00;
-    --bad: #b42318;
-    --canvas: #e9edf1;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --bg: #111417;
-      --fg: #edf0f3;
-      --muted: #a2abb5;
-      --panel: #191d22;
-      --border: #39414b;
-      --accent: #78a8ff;
-      --accent-soft: #1d2c46;
-      --good: #54c878;
-      --warn: #e6a14a;
-      --bad: #f17468;
-      --canvas: #20262d;
-    }
+    color-scheme: dark;
+    --bg: #303030;
+    --bg-deep: #202423;
+    --panel: #505050;
+    --panel-subtle: #444746;
+    --field: #f7faf6;
+    --field-ink: #17201b;
+    --fg: #f6f8f3;
+    --muted: #dce5d6;
+    --muted-dim: #aeb8aa;
+    --border: #727872;
+    --accent: #d8ff00;
+    --accent-strong: #c5e900;
+    --accent-soft: rgb(216 255 0 / 16%);
+    --hero-green: #84b53f;
+    --good: #69d178;
+    --climb: #2784d8;
+    --sink: #cf3f3f;
+    --warn: #ffb459;
+    --bad: #ef766f;
+    --canvas: #171d1b;
+    --focus: rgb(216 255 0 / 36%);
   }
   * { box-sizing: border-box; }
   body {
     margin: 0;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    background: var(--bg);
+    min-height: 100vh;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+    background:
+      radial-gradient(circle at 18% 0%, rgb(132 181 63 / 18%), transparent 34rem),
+      linear-gradient(135deg, #3b3b3b 0%, var(--bg) 42%, #242827 100%);
     color: var(--fg);
+  }
+  .topbar {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 18px;
+    min-height: 58px;
+    padding: 10px 18px;
+    border-bottom: 1px solid rgb(255 255 255 / 10%);
+    background: var(--accent);
+    color: #0b0d0b;
+  }
+  .brand-mark {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    min-width: 0;
+  }
+  .brand-leaf {
+    font-size: 22px;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+  }
+  .brand-title {
+    color: #202423;
+    font-size: 15px;
+    font-weight: 750;
+  }
+  .brand-subtitle {
+    color: rgb(11 13 11 / 70%);
+    font-size: 12px;
+    font-weight: 700;
+    text-align: right;
   }
   .app {
     display: grid;
-    grid-template-columns: minmax(640px, 1fr) 330px;
-    gap: 14px;
-    padding: 14px;
-    min-height: 100vh;
+    grid-template-columns: 300px minmax(560px, 1fr) 340px;
+    gap: 16px;
+    min-height: calc(100vh - 58px);
+    padding: 16px;
   }
   .stage {
     min-width: 0;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 10px;
+    border: 1px solid rgb(255 255 255 / 10%);
+    border-radius: 10px;
+    background: linear-gradient(180deg, #252b29, #1b211f);
+    box-shadow: 0 18px 34px rgb(0 0 0 / 28%);
   }
   canvas {
     display: block;
-    width: 100%;
+    width: min(100%, calc((100vh - 110px) * 1.441));
+    max-height: calc(100vh - 110px);
     height: auto;
     background: var(--canvas);
-    border: 1px solid var(--border);
+    border: 1px solid rgb(216 255 0 / 24%);
+    border-radius: 8px;
+    box-shadow: inset 0 0 0 1px rgb(255 255 255 / 5%);
   }
   .side {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 12px;
+    min-width: 0;
   }
   .card {
     background: var(--panel);
     border: 1px solid var(--border);
     border-radius: 8px;
-    padding: 10px;
+    padding: 12px;
+    box-shadow: 0 8px 18px rgb(0 0 0 / 16%);
   }
   h1, h2 {
-    margin: 0 0 8px;
-    font-size: 16px;
-    font-weight: 600;
+    margin: 0 0 10px;
+    color: #ffffff;
+    font-size: 15px;
+    font-weight: 800;
+    letter-spacing: 0.015em;
   }
-  h2 { font-size: 14px; }
+  h1 {
+    font-size: 18px;
+  }
+  h2 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    text-transform: uppercase;
+  }
+  h2::before {
+    width: 5px;
+    height: 18px;
+    border-radius: 999px;
+    background: var(--accent);
+    content: "";
+  }
   .row {
     display: grid;
     grid-template-columns: 1fr auto;
     align-items: center;
     gap: 8px;
-    margin: 8px 0;
+    margin: 10px 0;
   }
   .row label, .row .label {
     font-size: 12px;
+    font-weight: 750;
     color: var(--muted);
   }
   .row output {
+    color: #ffffff;
     font-variant-numeric: tabular-nums;
     font-size: 12px;
+    font-weight: 800;
   }
   input[type="range"] {
     grid-column: 1 / -1;
     width: 100%;
+    accent-color: var(--accent);
   }
   input[type="number"], input[type="text"] {
     width: 96px;
-    padding: 6px 7px;
-    color: var(--fg);
-    background: var(--bg);
-    border: 1px solid var(--border);
+    min-height: 36px;
+    padding: 7px 9px;
+    color: var(--field-ink);
+    background: var(--field);
+    border: 1px solid #b9c7c1;
     border-radius: 6px;
+    font: inherit;
+    font-weight: 700;
   }
   button {
     appearance: none;
     border: 1px solid var(--border);
-    background: var(--panel);
+    background: var(--panel-subtle);
     color: var(--fg);
     border-radius: 6px;
-    padding: 7px 10px;
+    min-height: 36px;
+    padding: 7px 11px;
     font: inherit;
+    font-size: 13px;
+    font-weight: 800;
     cursor: pointer;
   }
+  button:hover,
+  button:focus-visible,
+  input:focus-visible {
+    border-color: var(--accent);
+    outline: 3px solid var(--focus);
+  }
   button.primary {
-    color: white;
-    background: #1f6feb;
-    border-color: #1f6feb;
+    color: #0b0d0b;
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+  button[aria-pressed="true"] {
+    color: #0b0d0b;
+    background: var(--accent);
+    border-color: var(--accent);
   }
   .buttons {
     display: flex;
-    gap: 8px;
+    gap: 7px;
     flex-wrap: wrap;
   }
   .stats {
@@ -130,19 +214,22 @@
   .stat {
     border: 1px solid var(--border);
     border-radius: 6px;
-    padding: 7px;
-    background: color-mix(in srgb, var(--panel), var(--bg) 35%);
+    padding: 9px;
+    background: var(--panel-subtle);
   }
   .stat span {
     display: block;
-    color: var(--muted);
+    color: var(--muted-dim);
     font-size: 11px;
+    font-weight: 750;
+    text-transform: uppercase;
   }
   .stat strong {
     display: block;
     margin-top: 3px;
-    font-size: 18px;
-    font-weight: 600;
+    color: #ffffff;
+    font-size: 20px;
+    font-weight: 800;
     font-variant-numeric: tabular-nums;
   }
   .hint {
@@ -158,6 +245,12 @@
     margin: 8px 0;
     color: var(--muted);
     font-size: 12px;
+    font-weight: 750;
+  }
+  .check input {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--accent);
   }
   .trial-list {
     width: 100%;
@@ -165,30 +258,84 @@
     font-size: 12px;
   }
   .trial-list th, .trial-list td {
-    padding: 4px 3px;
+    padding: 6px 3px;
     text-align: right;
     border-bottom: 1px solid var(--border);
     font-variant-numeric: tabular-nums;
   }
+  .trial-list th {
+    color: var(--muted-dim);
+    font-size: 11px;
+    text-transform: uppercase;
+  }
   .trial-list th:first-child, .trial-list td:first-child { text-align: left; }
+  @media (max-width: 1220px) {
+    .app {
+      grid-template-columns: minmax(560px, 1fr) 340px;
+    }
+    .info-side {
+      display: contents;
+    }
+    .info-side .intro-card,
+    .info-side .scenario-card,
+    .info-side .trial-card,
+    .info-side .score-card,
+    .info-side .trials-card {
+      grid-column: 1 / -1;
+    }
+  }
   @media (max-width: 980px) {
-    .app { grid-template-columns: 1fr; }
+    .app {
+      grid-template-columns: 1fr;
+    }
+    .info-side {
+      display: flex;
+    }
+    canvas {
+      width: 100%;
+      max-height: none;
+    }
+  }
+  @media (max-width: 640px) {
+    .topbar {
+      grid-template-columns: 1fr;
+      gap: 2px;
+    }
+    .brand-subtitle {
+      text-align: left;
+    }
+    .app {
+      padding: 10px;
+    }
   }
 </style>
 </head>
 <body>
+<header class="topbar">
+  <div class="brand-mark">
+    <div class="brand-leaf">Leaf</div>
+    <div class="brand-title">Thermal Core Trainer</div>
+  </div>
+  <div class="brand-subtitle">Vario skills and turn-rate guidance lab</div>
+</header>
 <main class="app">
-  <section class="stage">
-    <canvas id="sim" width="980" height="680" aria-label="Thermal core simulator"></canvas>
-  </section>
-
-  <aside class="side">
-    <section class="card">
+  <aside class="side info-side">
+    <section class="card intro-card">
       <h1>Thermal core simulator</h1>
       <p class="hint">Left/right arrows ramp turn rate. Hold Shift for faster trim. Space pauses. The seed makes the same thermal repeatable.</p>
     </section>
 
-    <section class="card">
+    <section class="card scenario-card">
+      <h2>Scenario</h2>
+      <div class="buttons">
+        <button class="preset" type="button" data-preset="easy">Easy</button>
+        <button class="preset" type="button" data-preset="medium">Med</button>
+        <button class="preset" type="button" data-preset="hard">Hard</button>
+        <button class="preset" type="button" data-preset="expert">Expert</button>
+      </div>
+    </section>
+
+    <section class="card trial-card">
       <h2>Trial</h2>
       <div class="row">
         <label for="seed">Seed</label>
@@ -198,7 +345,6 @@
         <label for="duration">Duration</label><output id="durationOut"></output>
         <input id="duration" type="range" min="60" max="480" step="30" value="180">
       </div>
-      <label class="check"><input id="showThermal" type="checkbox" checked> Show thermal visual</label>
       <div class="buttons">
         <button id="start" class="primary" type="button">Start</button>
         <button id="reset" type="button">Reset</button>
@@ -207,38 +353,30 @@
       </div>
     </section>
 
-    <section class="card">
-      <h2>Thermal</h2>
-      <div class="row">
-        <label for="wind">Wind</label><output id="windOut"></output>
-        <input id="wind" type="range" min="0" max="20" step="1" value="8">
-      </div>
-      <div class="row">
-        <label for="diameter">Nominal diameter</label><output id="diameterOut"></output>
-        <input id="diameter" type="range" min="50" max="400" step="5" value="110">
-      </div>
-      <div class="row">
-        <label for="diameterVariance">Diameter variance</label><output id="diameterVarianceOut"></output>
-        <input id="diameterVariance" type="range" min="0" max="60" step="5" value="25">
-      </div>
-      <div class="row">
-        <label for="strength">Net core strength</label><output id="strengthOut"></output>
-        <input id="strength" type="range" min="1" max="5" step="0.1" value="3.0">
-      </div>
-      <div class="row">
-        <label for="strengthVariance">Strength variance</label><output id="strengthVarianceOut"></output>
-        <input id="strengthVariance" type="range" min="0" max="70" step="5" value="30">
-      </div>
-      <div class="row">
-        <label for="texture">Lumpiness</label><output id="textureOut"></output>
-        <input id="texture" type="range" min="0" max="80" step="5" value="30">
-      </div>
-      <div class="row">
-        <label for="sink">Glider sink</label><output id="sinkOut"></output>
-        <input id="sink" type="range" min="0.6" max="1.6" step="0.1" value="1.0">
+    <section class="card score-card">
+      <h2>Score</h2>
+      <div class="stats">
+        <div class="stat"><span>Altitude gain</span><strong id="gain">0 m</strong></div>
+        <div class="stat"><span>Avg climb</span><strong id="avgClimb">0.0</strong></div>
+        <div class="stat"><span>Centering</span><strong id="centering">0%</strong></div>
+        <div class="stat"><span>Score</span><strong id="score">0</strong></div>
       </div>
     </section>
 
+    <section class="card trials-card">
+      <h2>Trials</h2>
+      <table class="trial-list">
+        <thead><tr><th>#</th><th>seed</th><th>gain</th><th>avg</th><th>center</th><th>score</th></tr></thead>
+        <tbody id="trials"></tbody>
+      </table>
+    </section>
+  </aside>
+
+  <section class="stage">
+    <canvas id="sim" width="980" height="680" aria-label="Thermal core simulator"></canvas>
+  </section>
+
+  <aside class="side config-side">
     <section class="card">
       <h2>Audio</h2>
       <div class="row">
@@ -251,21 +389,36 @@
     </section>
 
     <section class="card">
-      <h2>Score</h2>
-      <div class="stats">
-        <div class="stat"><span>Altitude gain</span><strong id="gain">0 m</strong></div>
-        <div class="stat"><span>Avg climb</span><strong id="avgClimb">0.0</strong></div>
-        <div class="stat"><span>Centering</span><strong id="centering">0%</strong></div>
-        <div class="stat"><span>Score</span><strong id="score">0</strong></div>
+      <h2>Thermal</h2>
+      <label class="check"><input id="showThermal" type="checkbox"> Show thermal visual</label>
+      <div class="row">
+        <label for="wind">Wind</label><output id="windOut"></output>
+        <input id="wind" type="range" min="0" max="20" step="1" value="8">
       </div>
-    </section>
-
-    <section class="card">
-      <h2>Trials</h2>
-      <table class="trial-list">
-        <thead><tr><th>#</th><th>seed</th><th>gain</th><th>avg</th><th>center</th><th>score</th></tr></thead>
-        <tbody id="trials"></tbody>
-      </table>
+      <div class="row">
+        <label for="diameter">Nominal diameter</label><output id="diameterOut"></output>
+        <input id="diameter" type="range" min="50" max="400" step="5" value="200">
+      </div>
+      <div class="row">
+        <label for="diameterVariance">Diameter variance</label><output id="diameterVarianceOut"></output>
+        <input id="diameterVariance" type="range" min="0" max="70" step="1" value="25">
+      </div>
+      <div class="row">
+        <label for="strength">Net core strength</label><output id="strengthOut"></output>
+        <input id="strength" type="range" min="1" max="6" step="0.1" value="4.0">
+      </div>
+      <div class="row">
+        <label for="strengthVariance">Strength variance</label><output id="strengthVarianceOut"></output>
+        <input id="strengthVariance" type="range" min="0" max="70" step="1" value="30">
+      </div>
+      <div class="row">
+        <label for="texture">Lumpiness</label><output id="textureOut"></output>
+        <input id="texture" type="range" min="0" max="80" step="1" value="30">
+      </div>
+      <div class="row">
+        <label for="sink">Glider sink</label><output id="sinkOut"></output>
+        <input id="sink" type="range" min="0.6" max="1.6" step="0.1" value="1.0">
+      </div>
     </section>
   </aside>
 </main>
@@ -275,6 +428,11 @@
 
 const canvas = document.getElementById("sim");
 const ctx = canvas.getContext("2d");
+const simW = 980;
+const simH = 680;
+let canvasCssW = simW;
+let canvasCssH = simH;
+let canvasPixelRatio = 1;
 
 const ui = {
   seed: document.getElementById("seed"),
@@ -329,11 +487,76 @@ let lastFrame = performance.now();
 let accumulator = 0;
 let trials = [];
 let keys = new Set();
+let activeTargetTurnRateDps = 19;
 
 let state = freshState(Number(ui.seed.value));
 
+const thermalPresets = {
+  easy: {
+    showThermal: true,
+    wind: 0,
+    diameter: 200,
+    diameterVariance: 0,
+    strength: 6,
+    strengthVariance: 0,
+    texture: 0,
+    sink: 1,
+    targetTurnRate: 15
+  },
+  medium: {
+    showThermal: true,
+    wind: 4,
+    diameter: 225,
+    diameterVariance: 12.5,
+    strength: 5,
+    strengthVariance: 15,
+    texture: 15,
+    sink: 1,
+    targetTurnRate: 17
+  },
+  hard: {
+    showThermal: false,
+    wind: 8,
+    diameter: 200,
+    diameterVariance: 25,
+    strength: 4,
+    strengthVariance: 30,
+    texture: 30,
+    sink: 1,
+    targetTurnRate: 19
+  },
+  expert: {
+    showThermal: false,
+    wind: 12,
+    diameter: 175,
+    diameterVariance: 50,
+    strength: 4,
+    strengthVariance: 50,
+    texture: 50,
+    sink: 1,
+    targetTurnRate: 21
+  }
+};
+
 function clamp(v, min, max) {
   return Math.max(min, Math.min(max, v));
+}
+
+function resizeCanvasForDisplay() {
+  const rect = canvas.getBoundingClientRect();
+  const cssW = Math.max(1, rect.width);
+  const cssH = Math.max(1, rect.height);
+  const dpr = Math.max(1, window.devicePixelRatio || 1);
+  const backingW = Math.round(cssW * dpr);
+  const backingH = Math.round(cssH * dpr);
+  if (canvas.width !== backingW || canvas.height !== backingH || canvasPixelRatio !== dpr) {
+    canvas.width = backingW;
+    canvas.height = backingH;
+    canvasCssW = cssW;
+    canvasCssH = cssH;
+    canvasPixelRatio = dpr;
+  }
+  ctx.setTransform(cssW / simW * dpr, 0, 0, cssH / simH * dpr, 0, 0);
 }
 
 function lerp(a, b, t) {
@@ -391,23 +614,36 @@ function makeThermal(seed) {
     bendX: (rand() - 0.5) * 0.10,
     bendY: (rand() - 0.5) * 0.10,
     driftJitterX: (rand() - 0.5) * 0.55,
-    driftJitterY: (rand() - 0.5) * 0.55
+    driftJitterY: (rand() - 0.5) * 0.55,
+    entryOffsetFraction: (rand() - 0.5) * 1.0
   };
 }
 
 function freshState(seed) {
   const thermal = makeThermal(seed);
+  const params = readParams();
+  const startAlt = 1000;
+  const startHeading = 8;
+  const h = startHeading * Math.PI / 180;
+  const forward = {x: Math.sin(h), y: Math.cos(h)};
+  const right = {x: Math.cos(h), y: -Math.sin(h)};
+  const profile = thermalProfileAt(0, startAlt, params, thermal);
+  const center = thermalCenterAt(0, startAlt, params, thermal);
+  const lateralOffset = thermal.entryOffsetFraction * profile.radius * 0.5;
+  const leadInDistance = profile.radius * 1.12 + 45;
+  const startX = center.x - forward.x * leadInDistance + right.x * lateralOffset;
+  const startY = center.y - forward.y * leadInDistance + right.y * lateralOffset;
   return {
     running: false,
     finished: false,
     t: 0,
     seed,
     thermal,
-    x: -25,
-    y: 0,
-    z: 1000,
-    heading: 8,
-    turnRate: 18,
+    x: startX,
+    y: startY,
+    z: startAlt,
+    heading: startHeading,
+    turnRate: 0,
     vario: 0,
     lift: 0,
     centerDistanceSum: 0,
@@ -418,7 +654,7 @@ function freshState(seed) {
     altitudeTrace: [],
     varioTrace: [],
     lastSampleT: -1,
-    startAlt: 1000,
+    startAlt,
     finishStats: null
   };
 }
@@ -433,6 +669,27 @@ function resetTrial(seed = Number(ui.seed.value)) {
 function newSeed() {
   const seed = Math.floor(1000 + Math.random() * 900000);
   resetTrial(seed);
+}
+
+function applyThermalPreset(name) {
+  const preset = thermalPresets[name];
+  if (!preset) return;
+  ui.showThermal.checked = preset.showThermal;
+  ui.wind.value = preset.wind;
+  ui.diameter.value = preset.diameter;
+  ui.diameterVariance.value = preset.diameterVariance;
+  ui.strength.value = preset.strength;
+  ui.strengthVariance.value = preset.strengthVariance;
+  ui.texture.value = preset.texture;
+  ui.sink.value = preset.sink;
+  activeTargetTurnRateDps = preset.targetTurnRate;
+  document.querySelectorAll(".preset").forEach(button => {
+    button.setAttribute("aria-pressed", button.dataset.preset === name ? "true" : "false");
+  });
+  if (!state.running) {
+    state = freshState(Number(ui.seed.value));
+  }
+  updateOutputs();
 }
 
 function windVector(params, thermal = state.thermal) {
@@ -454,10 +711,10 @@ function thermalCenterAt(t, alt, params, thermal = state.thermal) {
   };
 }
 
-function thermalProfileAt(t, alt, params) {
+function thermalProfileAt(t, alt, params, thermal = state.thermal) {
   const z = (alt - 1000) / 110;
-  const diameterWave = smoothWave(z, state.thermal.phaseA, state.thermal.phaseB, 1.25, 2.7);
-  const strengthWave = smoothWave(z, state.thermal.phaseC, state.thermal.phaseD, 1.0, 2.35);
+  const diameterWave = smoothWave(z, thermal.phaseA, thermal.phaseB, 1.25, 2.7);
+  const strengthWave = smoothWave(z, thermal.phaseC, thermal.phaseD, 1.0, 2.35);
   const diameter = params.diameterM * (1 + params.diameterVariance * diameterWave);
   const strength = (params.strength + params.sink) * (1 + params.strengthVariance * strengthWave);
   return {
@@ -498,6 +755,19 @@ function ensureAudio() {
   beepOsc.connect(beepGain);
   beepGain.connect(audioCtx.destination);
   beepOsc.start();
+}
+
+async function unlockAudio(warmup = false) {
+  ensureAudio();
+  if (audioCtx.state === "suspended") await audioCtx.resume();
+  if (warmup) testToneUntil = audioCtx.currentTime + 0.08;
+}
+
+async function toggleRun() {
+  await unlockAudio(true);
+  if (state.finished) resetTrial(state.seed);
+  state.running = !state.running;
+  ui.start.textContent = state.running ? "Pause" : "Start";
 }
 
 function stopAudioTone() {
@@ -768,10 +1038,10 @@ function drawMainMap(rect, estimate) {
   ctx.beginPath();
   ctx.rect(rect.x, rect.y, rect.w, rect.h);
   ctx.clip();
-  ctx.fillStyle = "#eef2f6";
+  ctx.fillStyle = "#eef4ee";
   ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
 
-  ctx.strokeStyle = "#d3d8de";
+  ctx.strokeStyle = "#d3ddd0";
   ctx.lineWidth = 1;
   const grid = 50 * scale;
   for (let gx = rect.x - 200; gx < rect.x + rect.w + 200; gx += grid) {
@@ -790,14 +1060,14 @@ function drawMainMap(rect, estimate) {
   if (params.showThermal) {
     const c = mapPoint(center.x, center.y, focusX, focusY, scale, rect);
     const grd = ctx.createRadialGradient(c.x, c.y, 0, c.x, c.y, profile.radius * scale * 1.45);
-    grd.addColorStop(0, "rgba(56, 150, 80, 0.34)");
-    grd.addColorStop(0.55, "rgba(56, 150, 80, 0.15)");
+    grd.addColorStop(0, "rgba(132, 181, 63, 0.42)");
+    grd.addColorStop(0.55, "rgba(132, 181, 63, 0.18)");
     grd.addColorStop(1, "rgba(56, 150, 80, 0)");
     ctx.fillStyle = grd;
     ctx.beginPath();
     ctx.arc(c.x, c.y, profile.radius * scale * 1.45, 0, Math.PI * 2);
     ctx.fill();
-    ctx.strokeStyle = "rgba(20, 90, 40, 0.55)";
+    ctx.strokeStyle = "rgba(75, 124, 38, 0.62)";
     ctx.setLineDash([5, 5]);
     ctx.beginPath();
     ctx.arc(c.x, c.y, profile.radius * scale, 0, Math.PI * 2);
@@ -805,8 +1075,8 @@ function drawMainMap(rect, estimate) {
     ctx.setLineDash([]);
   }
 
-  ctx.strokeStyle = "#333";
-  ctx.lineWidth = 1.5;
+  ctx.strokeStyle = "#202423";
+  ctx.lineWidth = 1.8;
   ctx.beginPath();
   let started = false;
   for (const sample of state.samples) {
@@ -821,24 +1091,24 @@ function drawMainMap(rect, estimate) {
   ctx.stroke();
 
   const p = mapPoint(state.x, state.y, focusX, focusY, scale, rect);
-  drawArrow(p.x, p.y, state.heading, 13, "#111");
+  drawArrow(p.x, p.y, state.heading, 13, "#202423");
 
   const wind = windVector(params);
   const wx = rect.x + 42;
   const wy = rect.y + 50;
-  ctx.strokeStyle = "#111";
+  ctx.strokeStyle = "#202423";
   ctx.lineWidth = 2;
   ctx.beginPath();
   ctx.moveTo(wx, wy);
   ctx.lineTo(wx + wind.x * 6, wy - wind.y * 6);
   ctx.stroke();
-  ctx.fillStyle = "#111";
+  ctx.fillStyle = "#202423";
   ctx.beginPath();
   ctx.arc(wx + wind.x * 6, wy - wind.y * 6, 3, 0, Math.PI * 2);
   ctx.fill();
-  drawText(`${params.windMph.toFixed(0)} mph wind`, rect.x + 10, rect.y + 18, 12, "left", "#111");
+  drawText(`${params.windMph.toFixed(0)} mph wind`, rect.x + 10, rect.y + 18, 12, "left", "#202423");
 
-  drawText(estimate.cue, rect.x + rect.w - 16, rect.y + 18, 16, "right", "#111");
+  drawText(estimate.cue, rect.x + rect.w - 16, rect.y + 18, 16, "right", "#202423");
   ctx.restore();
 }
 
@@ -865,9 +1135,65 @@ function drawTape(rect, value, minValue, maxValue, label, units, active = true) 
   ctx.restore();
 }
 
+function drawVarioBar(rect, value) {
+  ctx.save();
+  ctx.fillStyle = "#f7faf6";
+  ctx.strokeStyle = "#202423";
+  ctx.lineWidth = 1;
+  ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+  const mid = rect.y + rect.h / 2;
+  ctx.strokeStyle = "#707a72";
+  ctx.beginPath();
+  ctx.moveTo(rect.x, mid);
+  ctx.lineTo(rect.x + rect.w, mid);
+  ctx.stroke();
+
+  const clamped = clamp(value, -7, 7);
+  const barH = Math.abs(clamped) / 7 * (rect.h / 2);
+  ctx.fillStyle = clamped >= 0 ? "#2374d8" : "#cf3f3f";
+  const inset = 12;
+  if (clamped >= 0) {
+    ctx.fillRect(rect.x + inset, mid - barH, rect.w - inset * 2, barH);
+  } else {
+    ctx.fillRect(rect.x + inset, mid, rect.w - inset * 2, barH);
+  }
+
+  for (let i = -6; i <= 6; i += 2) {
+    const y = mid - i / 7 * (rect.h / 2);
+    ctx.strokeStyle = i === 0 ? "#202423" : "#9aa59a";
+    ctx.beginPath();
+    ctx.moveTo(rect.x - 8, y);
+    ctx.lineTo(rect.x - 2, y);
+    ctx.moveTo(rect.x + rect.w + 2, y);
+    ctx.lineTo(rect.x + rect.w + 8, y);
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = "#202423";
+  ctx.fillRect(rect.x + 5, mid - 12, rect.w - 10, 24);
+  drawText(`${value >= 0 ? "+" : ""}${value.toFixed(1)}`, rect.x + rect.w / 2, mid, 12, "center", "#fff");
+  drawText("+7", rect.x - 12, rect.y + 4, 11, "right", "#dce5d6");
+  drawText("-7", rect.x - 12, rect.y + rect.h - 4, 11, "right", "#dce5d6");
+  drawText("m/s", rect.x + rect.w / 2, rect.y - 14, 11, "center", "#dce5d6");
+  ctx.restore();
+}
+
+function drawAltitudeBox(rect, altitude) {
+  ctx.save();
+  ctx.fillStyle = "#eef4ee";
+  ctx.strokeStyle = "rgba(216, 255, 0, 0.60)";
+  ctx.lineWidth = 1;
+  ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+  drawText("Altitude (m)", rect.x + rect.w / 2, rect.y + 14, 10, "center", "#202423");
+  drawText(altitude.toFixed(0), rect.x + rect.w / 2, rect.y + 39, 24, "center", "#202423");
+  ctx.restore();
+}
+
 function drawTurnRate(rect, estimate) {
   ctx.save();
-  ctx.strokeStyle = "#111";
+  ctx.strokeStyle = "#dce5d6";
   ctx.lineWidth = 1;
   ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
   const center = rect.x + rect.w / 2;
@@ -875,25 +1201,129 @@ function drawTurnRate(rect, estimate) {
   ctx.moveTo(center, rect.y);
   ctx.lineTo(center, rect.y + rect.h);
   ctx.stroke();
+  const target = clamp(activeTargetTurnRateDps, 0, maxTurnRateDps);
+  for (const side of [-1, 1]) {
+    const targetX = center + side * target / maxTurnRateDps * rect.w / 2;
+    const gradient = ctx.createLinearGradient(targetX - 14, rect.y, targetX + 14, rect.y);
+    gradient.addColorStop(0, "rgba(0, 0, 0, 0)");
+    gradient.addColorStop(0.42, "rgba(216, 255, 0, 0.18)");
+    gradient.addColorStop(0.5, "rgba(216, 255, 0, 0.72)");
+    gradient.addColorStop(0.58, "rgba(216, 255, 0, 0.18)");
+    gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(targetX - 14, rect.y + 1, 28, rect.h - 2);
+    ctx.strokeStyle = "rgba(216, 255, 0, 0.78)";
+    ctx.beginPath();
+    ctx.moveTo(targetX, rect.y + 1);
+    ctx.lineTo(targetX, rect.y + rect.h - 1);
+    ctx.stroke();
+  }
   const actualX = center + state.turnRate / maxTurnRateDps * rect.w / 2;
-  ctx.fillStyle = "#111";
+  ctx.strokeStyle = "#d8ff00";
+  ctx.lineWidth = 3;
   ctx.beginPath();
   ctx.arc(actualX, rect.y + rect.h / 2, 7, 0, Math.PI * 2);
-  ctx.fill();
-  if (estimate.valid) {
-    const sign = state.turnRate < 0 ? -1 : 1;
-    const suggestedSigned = sign * estimate.suggestedTurnRateDps;
-    const suggestedX = center + suggestedSigned / maxTurnRateDps * rect.w / 2;
+  ctx.stroke();
+  drawText("-30", rect.x, rect.y + rect.h + 13, 11, "left", "#dce5d6");
+  drawText("+30", rect.x + rect.w, rect.y + rect.h + 13, 11, "right", "#dce5d6");
+  ctx.restore();
+}
+
+function drawTurnRateModule(rect, estimate) {
+  ctx.save();
+  ctx.fillStyle = "#202423";
+  ctx.strokeStyle = "rgba(216, 255, 0, 0.35)";
+  ctx.lineWidth = 1;
+  ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+  drawText("Turn rate", rect.x + rect.w / 2, rect.y + 15, 12, "center", "#dce5d6");
+  drawTurnRate({x: rect.x + 12, y: rect.y + 36, w: rect.w - 24, h: 18}, estimate);
+  drawBankSilhouette(rect.x + rect.w / 2, rect.y + 112, state.turnRate);
+  ctx.restore();
+}
+
+function drawBankSilhouette(cx, cy, turnRateDps) {
+  const bank = clamp(turnRateDps / maxTurnRateDps, -1, 1) * 42 * Math.PI / 180;
+  ctx.save();
+  ctx.strokeStyle = "rgba(216, 255, 0, 0.18)";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(cx - 56, cy + 8);
+  ctx.lineTo(cx + 56, cy + 8);
+  ctx.stroke();
+  ctx.restore();
+
+  ctx.save();
+  ctx.translate(cx, cy);
+  ctx.rotate(bank);
+
+  const canopyY = -28;
+  const pilotY = 34;
+  const canopyPoint = t => {
+    const x = -48 + t * 96;
+    const arch = Math.sin(t * Math.PI);
+    return {
+      x,
+      y: canopyY + 18 - arch * 21
+    };
+  };
+
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.strokeStyle = "#202423";
+  ctx.lineWidth = 7;
+  ctx.beginPath();
+  ctx.moveTo(-50, canopyY + 18);
+  ctx.bezierCurveTo(-36, canopyY - 15, 36, canopyY - 15, 50, canopyY + 18);
+  ctx.stroke();
+
+  ctx.strokeStyle = "#d8ff00";
+  ctx.lineWidth = 4;
+  ctx.beginPath();
+  ctx.moveTo(-48, canopyY + 16);
+  ctx.bezierCurveTo(-35, canopyY - 11, 35, canopyY - 11, 48, canopyY + 16);
+  ctx.stroke();
+
+  ctx.strokeStyle = "rgba(32, 36, 35, 0.72)";
+  ctx.lineWidth = 1.3;
+  for (let i = 1; i < 8; i += 1) {
+    const p = canopyPoint(i / 8);
     ctx.beginPath();
-    ctx.moveTo(suggestedX, rect.y - 2);
-    ctx.lineTo(suggestedX - 5, rect.y - 10);
-    ctx.lineTo(suggestedX + 5, rect.y - 10);
-    ctx.closePath();
-    ctx.fill();
+    ctx.moveTo(p.x, p.y + 2);
+    ctx.lineTo(p.x * 0.18, pilotY - 11);
+    ctx.stroke();
   }
-  drawText("-30", rect.x, rect.y + rect.h + 13, 11, "left", "#111");
-  drawText("turn rate", center, rect.y - 15, 11, "center", "#111");
-  drawText("+30", rect.x + rect.w, rect.y + rect.h + 13, 11, "right", "#111");
+
+  ctx.strokeStyle = "#202423";
+  ctx.lineWidth = 1.7;
+  ctx.beginPath();
+  for (const t of [0.06, 0.18, 0.32, 0.50, 0.68, 0.82, 0.94]) {
+    const p = canopyPoint(t);
+    ctx.moveTo(p.x, p.y + 4);
+    ctx.lineTo((t - 0.5) * 18, pilotY - 8);
+  }
+  ctx.stroke();
+
+  ctx.strokeStyle = "#d8ff00";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(-8, pilotY - 10);
+  ctx.lineTo(-4, pilotY + 1);
+  ctx.moveTo(8, pilotY - 10);
+  ctx.lineTo(4, pilotY + 1);
+  ctx.stroke();
+
+  ctx.fillStyle = "#202423";
+  ctx.strokeStyle = "#d8ff00";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(0, pilotY - 13, 4, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.ellipse(0, pilotY, 6, 11, 0, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
   ctx.restore();
 }
 
@@ -1057,12 +1487,16 @@ function drawCoreTurnBarInLeaf(estimate) {
 
 function drawTrace(rect, trace, minV, maxV, label) {
   ctx.save();
-  ctx.strokeStyle = "#111";
+  ctx.fillStyle = "#eef4ee";
+  ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.strokeStyle = "#202423";
   ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
-  drawText(label, rect.x + 8, rect.y + 12, 11, "left", "#111");
+  drawText(label, rect.x + 8, rect.y + 12, 11, "left", "#202423");
   if (trace.length > 1) {
     const startT = trace[0].t;
     const endT = trace[trace.length - 1].t;
+    ctx.strokeStyle = "#202423";
+    ctx.lineWidth = 1.5;
     ctx.beginPath();
     trace.forEach((p, i) => {
       const x = rect.x + (p.t - startT) / Math.max(1, endT - startT) * rect.w;
@@ -1076,33 +1510,27 @@ function drawTrace(rect, trace, minV, maxV, label) {
 }
 
 function draw() {
+  resizeCanvasForDisplay();
   const estimate = estimateCoreGuidance();
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  ctx.fillStyle = "#e9edf1";
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-  const map = {x: 16, y: 18, w: 690, h: 520};
-  const altTape = {x: 724, y: 18, w: 58, h: 520};
-  const varioTape = {x: 796, y: 18, w: 58, h: 520};
+  ctx.clearRect(0, 0, simW, simH);
+  ctx.fillStyle = "#171d1b";
+  ctx.fillRect(0, 0, simW, simH);
+  const map = {x: 16, y: 18, w: 720, h: 520};
+  const altitudeBox = {x: 750, y: 18, w: 96, h: 58};
+  const varioTape = {x: 760, y: 108, w: 74, h: 430};
   const core = {x: 872, y: 18, w: 96, h: 192};
-  const turn = {x: 872, y: 236, w: 96, h: 18};
+  const turnModule = {x: 860, y: 232, w: 112, h: 166};
   drawMainMap(map, estimate);
-  drawTape(altTape, state.z, state.startAlt - 20, state.startAlt + 360, "alt", "m");
-  drawTape(varioTape, state.vario, -5, 7, "vario", "");
+  drawAltitudeBox(altitudeBox, state.z);
+  drawVarioBar(varioTape, state.vario);
   drawCoreScreen(core, estimate);
-  drawTurnRate(turn, estimate);
+  drawTurnRateModule(turnModule, estimate);
   drawTrace({x: 16, y: 562, w: 460, h: 90}, state.altitudeTrace, state.startAlt - 20, state.startAlt + 360, "altitude");
-  drawTrace({x: 494, y: 562, w: 360, h: 90}, state.varioTrace, -5, 7, "vario");
+  drawTrace({x: 494, y: 562, w: 340, h: 90}, state.varioTrace, -5, 7, "vario");
 
-  const stats = currentStats();
-  drawText(`${state.running ? "RUN" : state.finished ? "DONE" : "READY"}  ${state.t.toFixed(0)}s`, 872, 306, 14, "left", "#111");
-  drawText(`alt ${state.z.toFixed(0)}m`, 872, 332, 12, "left", "#111");
-  drawText(`vario ${state.vario >= 0 ? "+" : ""}${state.vario.toFixed(1)}m/s`, 872, 354, 12, "left", "#111");
-  drawText(`turn ${state.turnRate >= 0 ? "+" : ""}${state.turnRate.toFixed(1)} deg/s`, 872, 376, 12, "left", "#111");
-  drawText(`gain ${stats.gain.toFixed(0)}m`, 872, 398, 12, "left", "#111");
-  drawText(`center ${Math.round(stats.centering * 100)}%`, 872, 420, 12, "left", "#111");
-  drawText(`score ${stats.score}`, 872, 442, 12, "left", "#111");
+  drawText(`${state.running ? "RUN" : state.finished ? "DONE" : "READY"}  ${state.t.toFixed(0)}s`, 916, 424, 14, "center", "#d8ff00");
   if (!state.running && !state.finished) {
-    drawText("Press Start, then fly by vario or Core.", map.x + map.w / 2, map.y + map.h / 2, 18, "center", "#111");
+    drawText("Press Start, then fly by vario or Core.", map.x + map.w / 2, map.y + map.h / 2, 18, "center", "#202423");
   }
 }
 
@@ -1138,11 +1566,7 @@ function loop(now) {
 }
 
 ui.start.addEventListener("click", async () => {
-  ensureAudio();
-  if (audioCtx.state === "suspended") await audioCtx.resume();
-  if (state.finished) resetTrial(state.seed);
-  state.running = !state.running;
-  ui.start.textContent = state.running ? "Pause" : "Start";
+  await toggleRun();
 });
 ui.reset.addEventListener("click", () => {
   resetTrial(Number(ui.seed.value));
@@ -1157,9 +1581,11 @@ ui.newSeed.addEventListener("click", () => {
   ui.start.textContent = "Start";
 });
 ui.testTone.addEventListener("click", async () => {
-  ensureAudio();
-  if (audioCtx.state === "suspended") await audioCtx.resume();
+  await unlockAudio(false);
   testToneUntil = audioCtx.currentTime + 0.75;
+});
+document.querySelectorAll(".preset").forEach(button => {
+  button.addEventListener("click", () => applyThermalPreset(button.dataset.preset));
 });
 
 for (const el of [ui.seed, ui.duration, ui.wind, ui.diameter, ui.diameterVariance, ui.strength, ui.strengthVariance, ui.texture, ui.showThermal, ui.sink, ui.volume]) {
@@ -1171,15 +1597,14 @@ window.addEventListener("keydown", event => {
   if (["ArrowLeft", "ArrowRight", "Space", "ShiftLeft", "ShiftRight"].includes(event.code)) event.preventDefault();
   keys.add(event.code);
   if (event.code === "Space") {
-    state.running = !state.running;
-    ui.start.textContent = state.running ? "Pause" : "Start";
+    toggleRun();
   }
 });
 window.addEventListener("keyup", event => {
   keys.delete(event.code);
 });
 
-updateOutputs();
+applyThermalPreset("hard");
 requestAnimationFrame(loop);
 </script>
 </body>

--- a/tools and analysis/thermal_detection/thermal_core_game.html
+++ b/tools and analysis/thermal_detection/thermal_core_game.html
@@ -83,8 +83,10 @@
   .stage {
     min-width: 0;
     display: flex;
+    flex-direction: column;
+    gap: 10px;
     justify-content: center;
-    align-items: flex-start;
+    align-items: center;
     padding: 10px;
     border: 1px solid rgb(255 255 255 / 10%);
     border-radius: 10px;
@@ -100,6 +102,10 @@
     border: 1px solid rgb(216 255 0 / 24%);
     border-radius: 8px;
     box-shadow: inset 0 0 0 1px rgb(255 255 255 / 5%);
+  }
+  .stage:has(.tutorial-card:not([hidden])) canvas {
+    width: min(100%, calc((100vh - 260px) * 1.441));
+    max-height: calc(100vh - 260px);
   }
   .side {
     display: flex;
@@ -238,6 +244,35 @@
     font-size: 12px;
     line-height: 1.35;
   }
+  .tutorial-card {
+    width: min(100%, calc((100vh - 260px) * 1.441));
+    border-color: var(--accent);
+    background: linear-gradient(90deg, #202423, #465038 55%, #202423);
+    padding: 14px 16px;
+  }
+  .tutorial-card[hidden] {
+    display: none;
+  }
+  .tutorial-title {
+    margin: 0 0 6px;
+    color: #ffffff;
+    font-size: 15px;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+  .tutorial-message {
+    margin: 0 0 10px;
+    color: #ffffff;
+    font-size: 15px;
+    font-weight: 650;
+    line-height: 1.35;
+  }
+  .tutorial-goal {
+    margin: 0 0 10px;
+    color: var(--muted);
+    font-size: 13px;
+    line-height: 1.35;
+  }
   .check {
     display: flex;
     align-items: center;
@@ -333,6 +368,9 @@
         <button class="preset" type="button" data-preset="hard">Hard</button>
         <button class="preset" type="button" data-preset="expert">Expert</button>
       </div>
+      <div class="buttons">
+        <button id="tutorialStart" type="button">Start Tutorial</button>
+      </div>
     </section>
 
     <section class="card trial-card">
@@ -373,6 +411,15 @@
   </aside>
 
   <section class="stage">
+    <section id="tutorialCard" class="card tutorial-card" hidden>
+      <h2>Tutorial</h2>
+      <p id="tutorialTitle" class="tutorial-title"></p>
+      <p id="tutorialMessage" class="tutorial-message"></p>
+      <p id="tutorialGoal" class="tutorial-goal"></p>
+      <div class="buttons">
+        <button id="tutorialContinue" class="primary" type="button">Continue</button>
+      </div>
+    </section>
     <canvas id="sim" width="980" height="680" aria-label="Thermal core simulator"></canvas>
   </section>
 
@@ -451,6 +498,12 @@ const ui = {
   same: document.getElementById("same"),
   newSeed: document.getElementById("newSeed"),
   testTone: document.getElementById("testTone"),
+  tutorialStart: document.getElementById("tutorialStart"),
+  tutorialCard: document.getElementById("tutorialCard"),
+  tutorialTitle: document.getElementById("tutorialTitle"),
+  tutorialMessage: document.getElementById("tutorialMessage"),
+  tutorialGoal: document.getElementById("tutorialGoal"),
+  tutorialContinue: document.getElementById("tutorialContinue"),
   durationOut: document.getElementById("durationOut"),
   windOut: document.getElementById("windOut"),
   diameterOut: document.getElementById("diameterOut"),
@@ -488,6 +541,100 @@ let accumulator = 0;
 let trials = [];
 let keys = new Set();
 let activeTargetTurnRateDps = 19;
+let tutorial = {
+  active: false,
+  step: 0,
+  phase: "idle",
+  showTargetMarkers: true,
+  showThermalRings: true,
+  pauseForCallout: false,
+  turnPromptHeading: null,
+  peakVario: -Infinity,
+  goalSeconds: 0,
+  orbitAngle: 0,
+  orbitCount: 0,
+  orbitMinRadius: Infinity,
+  orbitMaxRadius: 0,
+  orbitMaxError: 0,
+  orbitLastBearing: null,
+  lastOrbitFailed: false,
+  lastInstruction: ""
+};
+
+const tutorialSteps = [
+  {
+    title: "1. Center with visual help",
+    briefTitle: "Now center the thermal",
+    practiceTitle: "1b. Center by sound",
+    completeTitle: "Visual centering complete",
+    showThermal: true,
+    showRings: true,
+    showTargetMarkers: false,
+    targetRadius: false,
+    intro:
+      "Fly straight into the lift. When the vario peaks and just begins to fade, you are about halfway through the core. That is the moment to start turning.",
+    brief:
+      "Now the goal is to keep the vario constant. If it starts to drop, you are moving away from the center and need to tighten your turn. If it starts to increase, you are moving toward the center and need to widen your turn. Try to fly a few orbits centered on the thermal.",
+    practice:
+      "Hold this turn and listen. If the beeps fade, tighten slightly. If they build, widen slightly.",
+    complete:
+      "Good. You used the vario trend and visual rings to move your circle toward the thermal center."
+  },
+  {
+    title: "2. Core at a target rate",
+    briefTitle: "Now core the thermal",
+    practiceTitle: "2b. Core at target rate",
+    completeTitle: "Target-rate coring complete",
+    showThermal: true,
+    showRings: true,
+    showTargetMarkers: true,
+    targetRadius: true,
+    intro:
+      "This time the green target bands are back. They represent the nominal turn rate that gives an efficient target radius around the core.",
+    brief:
+      "Now add the target turn-rate habit. Use vario changes to slide your circle onto the center, then return toward the green target band so the bank stays efficient.",
+    practice:
+      "Use the green target bands as your home base. Tighten or widen just enough to move the circle, then settle back near the target.",
+    complete:
+      "Good. You held a radius close to the target turn-rate circle."
+  },
+  {
+    title: "3. Center without rings",
+    briefTitle: "Now center without rings",
+    practiceTitle: "3b. Fuzzy-blob centering",
+    completeTitle: "Blob-only centering complete",
+    showThermal: true,
+    showRings: false,
+    showTargetMarkers: true,
+    targetRadius: false,
+    intro:
+      "Try the same entry and centering exercise again, but without the concentric rings. You still get the fuzzy green thermal shape, but the constant-vario path is no longer drawn for you.",
+    brief:
+      "Same idea: keep the vario as constant as possible. Fading beeps mean tighten; building beeps mean widen.",
+    practice:
+      "Use the sound first. Let the fuzzy thermal visual confirm what your ears are telling you.",
+    complete:
+      "Good. You centered the thermal without the constant-radius guide rings."
+  },
+  {
+    title: "4. Center by vario only",
+    briefTitle: "Now fly by sound only",
+    practiceTitle: "4b. Sound-only centering",
+    completeTitle: "Sound-only centering complete",
+    showThermal: false,
+    showRings: false,
+    showTargetMarkers: true,
+    targetRadius: false,
+    intro:
+      "Final basic drill: the thermal visual is hidden. Fly the same technique using only the vario tone and the flight instruments.",
+    brief:
+      "Trust the vario. If it fades, tighten. If it builds, widen. The goal is still a steady-radius circle centered on the lift.",
+    practice:
+      "Listen for symmetry. Try to make each orbit sound boring and steady.",
+    complete:
+      "Congratulations, you can center a thermal with only the vario."
+  }
+];
 
 let state = freshState(Number(ui.seed.value));
 
@@ -692,6 +839,116 @@ function applyThermalPreset(name) {
   updateOutputs();
 }
 
+function setTutorialText(title, message, goal = "", canContinue = false) {
+  ui.tutorialCard.hidden = !tutorial.active;
+  ui.tutorialTitle.textContent = title;
+  ui.tutorialMessage.textContent = message;
+  ui.tutorialGoal.textContent = goal;
+  ui.tutorialContinue.hidden = !canContinue;
+}
+
+function resetTutorialOrbitProgress() {
+  tutorial.goalSeconds = 0;
+  tutorial.orbitAngle = 0;
+  tutorial.orbitCount = 0;
+  tutorial.orbitMinRadius = Infinity;
+  tutorial.orbitMaxRadius = 0;
+  tutorial.orbitMaxError = 0;
+  tutorial.orbitLastBearing = null;
+  tutorial.lastOrbitFailed = false;
+}
+
+function tutorialGoalText(metrics = null) {
+  const lesson = tutorialSteps[tutorial.step] || tutorialSteps[0];
+  if (!metrics) {
+    return lesson.targetRadius
+      ? "Goal: complete 2 consecutive orbits within +/-10% of the thermal diameter from the target turn-rate radius."
+      : "Goal: complete 2 consecutive smooth orbits at any radius, with radial spread under 25% of the thermal diameter.";
+  }
+  if (lesson.targetRadius) {
+    return `Goal progress: ${tutorial.orbitCount}/2 target-radius orbits. Max radius error: ${Math.round(metrics.error)}m / ${Math.round(metrics.allowedError)}m.`;
+  }
+  return `Goal progress: ${tutorial.orbitCount}/2 smooth orbits. Current radius spread: ${Math.round(metrics.spread)}m / ${Math.round(metrics.allowedSpread)}m.`;
+}
+
+function configureTutorialStep(step) {
+  const lesson = tutorialSteps[step] || tutorialSteps[0];
+  tutorial.step = step;
+  tutorial.phase = "entry";
+  tutorial.pauseForCallout = false;
+  tutorial.turnPromptHeading = null;
+  tutorial.peakVario = -Infinity;
+  resetTutorialOrbitProgress();
+  tutorial.lastInstruction = "";
+  applyThermalPreset("easy");
+  ui.showThermal.checked = lesson.showThermal;
+  tutorial.showThermalRings = lesson.showRings;
+  tutorial.showTargetMarkers = lesson.showTargetMarkers;
+  ui.duration.value = 480;
+  state = freshState(Number(ui.seed.value));
+  state.running = false;
+  state.finished = false;
+  ui.start.textContent = "Start";
+  updateOutputs();
+  setTutorialText(
+    lesson.title,
+    lesson.intro,
+    "First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start."
+  );
+}
+
+function startTutorial() {
+  tutorial.active = true;
+  ui.tutorialCard.hidden = false;
+  ui.tutorialStart.textContent = "Exit Tutorial";
+  configureTutorialStep(0);
+}
+
+function exitTutorial() {
+  tutorial.active = false;
+  tutorial.showTargetMarkers = true;
+  tutorial.showThermalRings = true;
+  ui.tutorialCard.hidden = true;
+  ui.tutorialStart.textContent = "Start Tutorial";
+  state.running = false;
+  ui.start.textContent = "Start";
+  stopAudioTone();
+}
+
+function continueTutorial() {
+  if (!tutorial.active) return;
+  const lesson = tutorialSteps[tutorial.step] || tutorialSteps[0];
+  tutorial.pauseForCallout = false;
+  if (tutorial.phase === "centering-brief") {
+    tutorial.phase = lesson.targetRadius ? "coring" : "centering";
+    resetTutorialOrbitProgress();
+    tutorial.lastInstruction = "";
+    state.running = true;
+    ui.start.textContent = "Pause";
+    setTutorialText(
+      lesson.practiceTitle,
+      lesson.practice,
+      tutorialGoalText()
+    );
+    return;
+  }
+  if (tutorial.phase === "step-complete") {
+    if (tutorial.step < tutorialSteps.length - 1) configureTutorialStep(tutorial.step + 1);
+    else {
+      setTutorialText(
+        "Tutorial complete",
+        "Congratulations, you can center a thermal with only the vario.",
+        "Next: try more random invisible thermals, then practice different entries such as aimed at the center, offset toward the edge, or crossing through the middle.",
+        false
+      );
+      tutorial.active = false;
+      ui.tutorialStart.textContent = "Start Tutorial";
+      state.running = false;
+      ui.start.textContent = "Start";
+    }
+  }
+}
+
 function windVector(params, thermal = state.thermal) {
   return {
     x: Math.sin(thermal.windDir) * params.windMps,
@@ -730,7 +987,10 @@ function liftAt(x, y, alt, t, params) {
   const dy = y - center.y;
   const r = Math.hypot(dx, dy);
   const nr = r / Math.max(1, profile.radius);
-  const core = profile.strength * Math.exp(-nr * nr * 1.65);
+  const coreShape = tutorial.active
+    ? Math.max(0, 1 - nr)
+    : Math.exp(-nr * nr * 1.65);
+  const core = profile.strength * coreShape;
   const edgeSink = -0.45 * Math.max(0, nr - 1.0);
   const az = Math.atan2(dy, dx);
   const lump = Math.sin(az * 3 + t * 0.045 + state.thermal.lumpPhase) * 0.6 +
@@ -874,8 +1134,137 @@ function updatePhysics(stepDt) {
     state.lastSampleT = state.t;
     sampleNow(params);
   }
+  updateTutorial(stepDt);
   updateAudio(stepDt);
-  if (state.t >= params.duration) finishTrial();
+  if (!tutorial.active && state.t >= params.duration) finishTrial();
+}
+
+function updateTutorial(stepDt) {
+  if (!tutorial.active || tutorial.pauseForCallout) return;
+  const lesson = tutorialSteps[tutorial.step] || tutorialSteps[0];
+  tutorial.peakVario = Math.max(tutorial.peakVario, state.vario);
+  if (tutorial.phase === "entry") {
+    if (tutorial.peakVario > 1.0 && state.t > 6 && state.vario < tutorial.peakVario - 0.25) {
+      tutorial.phase = "turn-callout";
+      tutorial.turnPromptHeading = state.heading;
+      setTutorialText(
+        tutorial.step === 0 ? "Start turning now" : "Turn now",
+        "The vario just peaked and began to fade. You have crossed into the useful part of the thermal. Start a smooth turn now.",
+        "First goal: turn about 90 degrees soon after the peak."
+      );
+    }
+    return;
+  }
+
+  if (tutorial.phase === "turn-callout") {
+    if (tutorial.turnPromptHeading != null && Math.abs(angleDeltaDeg(tutorial.turnPromptHeading, state.heading)) >= 90) {
+      tutorial.phase = "centering-brief";
+      tutorial.turnPromptHeading = null;
+      tutorial.pauseForCallout = true;
+      state.running = false;
+      ui.start.textContent = "Start";
+      setTutorialText(
+        lesson.briefTitle,
+        lesson.brief,
+        "Press Space bar or Continue to begin the orbit practice.",
+        true
+      );
+    }
+    return;
+  }
+
+  const recent = state.varioTrace.slice(-50);
+  const varioTrend = recent.length >= 2 ? recent[recent.length - 1].v - recent[0].v : 0;
+  if (tutorial.phase === "centering" || tutorial.phase === "coring") {
+    let instruction = "Hold this turn and listen for a steady beep.";
+    if (Math.abs(state.turnRate) < 6) {
+      instruction = "Build a smooth turn with the arrow keys.";
+    } else if (varioTrend > 0.18) {
+      instruction = "Lift is improving: widen slightly so your circle moves toward the core.";
+    } else if (varioTrend < -0.18) {
+      instruction = "Lift is fading: tighten slightly to avoid sliding away from the core.";
+    }
+    const orbit = updateTutorialOrbitProgress(readParams());
+    if (orbit.failed) {
+      instruction = lesson.targetRadius
+        ? "That orbit missed the target radius. Re-center, return to the green band, and try again."
+        : "That orbit wandered too much. Re-center and try for two smoother laps.";
+    }
+
+    if (instruction !== tutorial.lastInstruction || orbit.changed) {
+      tutorial.lastInstruction = instruction;
+      setTutorialText(
+        lesson.practiceTitle,
+        instruction,
+        tutorialGoalText(orbit)
+      );
+    }
+
+    if (tutorial.orbitCount >= 2) {
+      tutorial.phase = "step-complete";
+      tutorial.pauseForCallout = true;
+      state.running = false;
+      ui.start.textContent = "Start";
+      setTutorialText(
+        lesson.completeTitle,
+        lesson.complete,
+        tutorial.step < tutorialSteps.length - 1 ? "Press Continue for the next drill." : "Press Continue to finish.",
+        true
+      );
+    }
+  }
+}
+
+function updateTutorialOrbitProgress(params) {
+  const lesson = tutorialSteps[tutorial.step] || tutorialSteps[0];
+  const center = thermalCenterAt(state.t, state.z, params);
+  const profile = thermalProfileAt(state.t, state.z, params);
+  const dx = state.x - center.x;
+  const dy = state.y - center.y;
+  const radius = Math.hypot(dx, dy);
+  const bearing = (Math.atan2(dx, dy) * 180 / Math.PI + 360) % 360;
+  const allowedSpread = profile.radius * 2 * 0.25;
+  const targetRadius = baseAirspeed / Math.max(0.01, activeTargetTurnRateDps * Math.PI / 180);
+  const allowedError = profile.radius * 2 * 0.10;
+  const radiusError = Math.abs(radius - targetRadius);
+  let changed = false;
+  let failed = false;
+
+  tutorial.orbitMinRadius = Math.min(tutorial.orbitMinRadius, radius);
+  tutorial.orbitMaxRadius = Math.max(tutorial.orbitMaxRadius, radius);
+  tutorial.orbitMaxError = Math.max(tutorial.orbitMaxError, radiusError);
+
+  if (tutorial.orbitLastBearing == null) {
+    tutorial.orbitLastBearing = bearing;
+    return {spread: 0, allowedSpread, error: radiusError, allowedError, targetRadius, changed, failed};
+  }
+
+  const delta = Math.abs(angleDeltaDeg(tutorial.orbitLastBearing, bearing));
+  tutorial.orbitLastBearing = bearing;
+  if (delta < 45) tutorial.orbitAngle += delta;
+
+  let spread = tutorial.orbitMaxRadius - tutorial.orbitMinRadius;
+  let error = tutorial.orbitMaxError;
+  while (tutorial.orbitAngle >= 360) {
+    const orbitPassed = lesson.targetRadius ? error <= allowedError : spread <= allowedSpread;
+    if (orbitPassed) {
+      tutorial.orbitCount += 1;
+      tutorial.lastOrbitFailed = false;
+    } else {
+      tutorial.orbitCount = 0;
+      tutorial.lastOrbitFailed = true;
+      failed = true;
+    }
+    tutorial.orbitAngle -= 360;
+    tutorial.orbitMinRadius = radius;
+    tutorial.orbitMaxRadius = radius;
+    tutorial.orbitMaxError = radiusError;
+    spread = 0;
+    error = radiusError;
+    changed = true;
+  }
+
+  return {spread, allowedSpread, error, allowedError, targetRadius, changed, failed};
 }
 
 function turnStats(samples) {
@@ -1020,6 +1409,54 @@ function drawArrow(x, y, heading, size, fill = "#111") {
   ctx.restore();
 }
 
+function drawTurnPreview(x, y, headingDeg, turnRateDps, scale) {
+  const previewSeconds = 2.2;
+  const steps = 28;
+  const startOffsetM = 5;
+  const rateRad = turnRateDps * Math.PI / 180;
+  let heading = headingDeg * Math.PI / 180;
+  let px = x + Math.sin(heading) * startOffsetM * scale;
+  let py = y - Math.cos(heading) * startOffsetM * scale;
+
+  ctx.save();
+  ctx.strokeStyle = "rgba(216, 255, 0, 0.92)";
+  ctx.lineWidth = 3;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.beginPath();
+  ctx.moveTo(px, py);
+  for (let i = 1; i <= steps; i++) {
+    const dtStep = previewSeconds / steps;
+    heading += rateRad * dtStep;
+    px += Math.sin(heading) * baseAirspeed * dtStep * scale;
+    py -= Math.cos(heading) * baseAirspeed * dtStep * scale;
+    ctx.lineTo(px, py);
+  }
+  ctx.stroke();
+
+  ctx.strokeStyle = "rgba(32, 36, 35, 0.92)";
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  ctx.fillStyle = "#d8ff00";
+  for (const seconds of [1, 2]) {
+    let tickHeading = headingDeg * Math.PI / 180;
+    let tx = x + Math.sin(tickHeading) * startOffsetM * scale;
+    let ty = y - Math.cos(tickHeading) * startOffsetM * scale;
+    const tickSteps = Math.round(steps * seconds / previewSeconds);
+    for (let i = 1; i <= tickSteps; i++) {
+      const dtStep = previewSeconds / steps;
+      tickHeading += rateRad * dtStep;
+      tx += Math.sin(tickHeading) * baseAirspeed * dtStep * scale;
+      ty -= Math.cos(tickHeading) * baseAirspeed * dtStep * scale;
+    }
+    ctx.beginPath();
+    ctx.arc(tx, ty, 2.2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}
+
 function mapPoint(worldX, worldY, centerX, centerY, scale, rect) {
   return {
     x: rect.x + rect.w / 2 + (worldX - centerX) * scale,
@@ -1041,24 +1478,9 @@ function drawMainMap(rect, estimate) {
   ctx.fillStyle = "#eef4ee";
   ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
 
-  ctx.strokeStyle = "#d3ddd0";
-  ctx.lineWidth = 1;
-  const grid = 50 * scale;
-  for (let gx = rect.x - 200; gx < rect.x + rect.w + 200; gx += grid) {
-    ctx.beginPath();
-    ctx.moveTo(gx, rect.y);
-    ctx.lineTo(gx, rect.y + rect.h);
-    ctx.stroke();
-  }
-  for (let gy = rect.y - 200; gy < rect.y + rect.h + 200; gy += grid) {
-    ctx.beginPath();
-    ctx.moveTo(rect.x, gy);
-    ctx.lineTo(rect.x + rect.w, gy);
-    ctx.stroke();
-  }
+  const c = mapPoint(center.x, center.y, focusX, focusY, scale, rect);
 
   if (params.showThermal) {
-    const c = mapPoint(center.x, center.y, focusX, focusY, scale, rect);
     const grd = ctx.createRadialGradient(c.x, c.y, 0, c.x, c.y, profile.radius * scale * 1.45);
     grd.addColorStop(0, "rgba(132, 181, 63, 0.42)");
     grd.addColorStop(0.55, "rgba(132, 181, 63, 0.18)");
@@ -1067,11 +1489,25 @@ function drawMainMap(rect, estimate) {
     ctx.beginPath();
     ctx.arc(c.x, c.y, profile.radius * scale * 1.45, 0, Math.PI * 2);
     ctx.fill();
-    ctx.strokeStyle = "rgba(75, 124, 38, 0.62)";
-    ctx.setLineDash([5, 5]);
-    ctx.beginPath();
-    ctx.arc(c.x, c.y, profile.radius * scale, 0, Math.PI * 2);
-    ctx.stroke();
+    if (!tutorial.active || tutorial.showThermalRings) {
+      ctx.strokeStyle = "rgba(75, 124, 38, 0.62)";
+      ctx.setLineDash([5, 5]);
+      ctx.beginPath();
+      ctx.arc(c.x, c.y, profile.radius * scale, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.setLineDash([]);
+    }
+  }
+
+  if (tutorial.active && tutorial.showThermalRings) {
+    ctx.strokeStyle = "rgba(32, 36, 35, 0.18)";
+    ctx.lineWidth = 1;
+    ctx.setLineDash([3, 7]);
+    for (const ring of [0.25, 0.5, 0.75, 1]) {
+      ctx.beginPath();
+      ctx.arc(c.x, c.y, profile.radius * scale * ring, 0, Math.PI * 2);
+      ctx.stroke();
+    }
     ctx.setLineDash([]);
   }
 
@@ -1091,6 +1527,7 @@ function drawMainMap(rect, estimate) {
   ctx.stroke();
 
   const p = mapPoint(state.x, state.y, focusX, focusY, scale, rect);
+  drawTurnPreview(p.x, p.y, state.heading, state.turnRate, scale);
   drawArrow(p.x, p.y, state.heading, 13, "#202423");
 
   const wind = windVector(params);
@@ -1201,22 +1638,24 @@ function drawTurnRate(rect, estimate) {
   ctx.moveTo(center, rect.y);
   ctx.lineTo(center, rect.y + rect.h);
   ctx.stroke();
-  const target = clamp(activeTargetTurnRateDps, 0, maxTurnRateDps);
-  for (const side of [-1, 1]) {
-    const targetX = center + side * target / maxTurnRateDps * rect.w / 2;
-    const gradient = ctx.createLinearGradient(targetX - 14, rect.y, targetX + 14, rect.y);
-    gradient.addColorStop(0, "rgba(0, 0, 0, 0)");
-    gradient.addColorStop(0.42, "rgba(216, 255, 0, 0.18)");
-    gradient.addColorStop(0.5, "rgba(216, 255, 0, 0.72)");
-    gradient.addColorStop(0.58, "rgba(216, 255, 0, 0.18)");
-    gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
-    ctx.fillStyle = gradient;
-    ctx.fillRect(targetX - 14, rect.y + 1, 28, rect.h - 2);
-    ctx.strokeStyle = "rgba(216, 255, 0, 0.78)";
-    ctx.beginPath();
-    ctx.moveTo(targetX, rect.y + 1);
-    ctx.lineTo(targetX, rect.y + rect.h - 1);
-    ctx.stroke();
+  if (!tutorial.active || tutorial.showTargetMarkers) {
+    const target = clamp(activeTargetTurnRateDps, 0, maxTurnRateDps);
+    for (const side of [-1, 1]) {
+      const targetX = center + side * target / maxTurnRateDps * rect.w / 2;
+      const gradient = ctx.createLinearGradient(targetX - 14, rect.y, targetX + 14, rect.y);
+      gradient.addColorStop(0, "rgba(0, 0, 0, 0)");
+      gradient.addColorStop(0.42, "rgba(216, 255, 0, 0.18)");
+      gradient.addColorStop(0.5, "rgba(216, 255, 0, 0.72)");
+      gradient.addColorStop(0.58, "rgba(216, 255, 0, 0.18)");
+      gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
+      ctx.fillStyle = gradient;
+      ctx.fillRect(targetX - 14, rect.y + 1, 28, rect.h - 2);
+      ctx.strokeStyle = "rgba(216, 255, 0, 0.78)";
+      ctx.beginPath();
+      ctx.moveTo(targetX, rect.y + 1);
+      ctx.lineTo(targetX, rect.y + rect.h - 1);
+      ctx.stroke();
+    }
   }
   const actualX = center + state.turnRate / maxTurnRateDps * rect.w / 2;
   ctx.strokeStyle = "#d8ff00";
@@ -1515,11 +1954,11 @@ function draw() {
   ctx.clearRect(0, 0, simW, simH);
   ctx.fillStyle = "#171d1b";
   ctx.fillRect(0, 0, simW, simH);
-  const map = {x: 16, y: 18, w: 720, h: 520};
-  const altitudeBox = {x: 750, y: 18, w: 96, h: 58};
-  const varioTape = {x: 760, y: 108, w: 74, h: 430};
+  const map = {x: 16, y: 18, w: 520, h: 520};
+  const altitudeBox = {x: 560, y: 18, w: 96, h: 58};
+  const varioTape = {x: 570, y: 108, w: 74, h: 430};
   const core = {x: 872, y: 18, w: 96, h: 192};
-  const turnModule = {x: 860, y: 232, w: 112, h: 166};
+  const turnModule = {x: map.x + map.w - 128, y: map.y + map.h - 184, w: 112, h: 166};
   drawMainMap(map, estimate);
   drawAltitudeBox(altitudeBox, state.z);
   drawVarioBar(varioTape, state.vario);
@@ -1529,8 +1968,24 @@ function draw() {
   drawTrace({x: 494, y: 562, w: 340, h: 90}, state.varioTrace, -5, 7, "vario");
 
   drawText(`${state.running ? "RUN" : state.finished ? "DONE" : "READY"}  ${state.t.toFixed(0)}s`, 916, 424, 14, "center", "#d8ff00");
-  if (!state.running && !state.finished) {
-    drawText("Press Start, then fly by vario or Core.", map.x + map.w / 2, map.y + map.h / 2, 18, "center", "#202423");
+  if (tutorial.active && tutorial.phase === "turn-callout") {
+    ctx.save();
+    ctx.font = "22px system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.lineWidth = 5;
+    ctx.strokeStyle = "rgba(238, 244, 238, 0.92)";
+    ctx.strokeText("START TURNING NOW", map.x + map.w / 2, map.y + map.h * 0.34);
+    ctx.fillStyle = "#202423";
+    ctx.fillText("START TURNING NOW", map.x + map.w / 2, map.y + map.h * 0.34);
+    ctx.font = "13px system-ui, sans-serif";
+    ctx.lineWidth = 4;
+    ctx.strokeText("Turn about 90 degrees", map.x + map.w / 2, map.y + map.h * 0.34 + 28);
+    ctx.fillText("Turn about 90 degrees", map.x + map.w / 2, map.y + map.h * 0.34 + 28);
+    ctx.restore();
+  }
+  if (!state.running && !state.finished && !(tutorial.active && tutorial.phase === "turn-callout")) {
+    drawText("Press Space to start", map.x + map.w / 2, map.y + map.h / 2, 18, "center", "#202423");
   }
 }
 
@@ -1584,8 +2039,16 @@ ui.testTone.addEventListener("click", async () => {
   await unlockAudio(false);
   testToneUntil = audioCtx.currentTime + 0.75;
 });
+ui.tutorialStart.addEventListener("click", () => {
+  if (tutorial.active) exitTutorial();
+  else startTutorial();
+});
+ui.tutorialContinue.addEventListener("click", continueTutorial);
 document.querySelectorAll(".preset").forEach(button => {
-  button.addEventListener("click", () => applyThermalPreset(button.dataset.preset));
+  button.addEventListener("click", () => {
+    if (tutorial.active) exitTutorial();
+    applyThermalPreset(button.dataset.preset);
+  });
 });
 
 for (const el of [ui.seed, ui.duration, ui.wind, ui.diameter, ui.diameterVariance, ui.strength, ui.strengthVariance, ui.texture, ui.showThermal, ui.sink, ui.volume]) {
@@ -1595,8 +2058,13 @@ for (const el of [ui.seed, ui.duration, ui.wind, ui.diameter, ui.diameterVarianc
 
 window.addEventListener("keydown", event => {
   if (["ArrowLeft", "ArrowRight", "Space", "ShiftLeft", "ShiftRight"].includes(event.code)) event.preventDefault();
+  if (event.code === "Space" && event.repeat) return;
   keys.add(event.code);
   if (event.code === "Space") {
+    if (tutorial.active && tutorial.pauseForCallout) {
+      continueTutorial();
+      return;
+    }
     toggleRun();
   }
 });

--- a/tools and analysis/thermal_detection/thermal_core_game.html
+++ b/tools and analysis/thermal_detection/thermal_core_game.html
@@ -1,0 +1,1186 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Leaf Thermal Core Simulator</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f6f7f8;
+    --fg: #14171a;
+    --muted: #5f6872;
+    --panel: #ffffff;
+    --border: #cbd1d8;
+    --accent: #1f6feb;
+    --accent-soft: #dceaff;
+    --good: #128a45;
+    --warn: #b15b00;
+    --bad: #b42318;
+    --canvas: #e9edf1;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #111417;
+      --fg: #edf0f3;
+      --muted: #a2abb5;
+      --panel: #191d22;
+      --border: #39414b;
+      --accent: #78a8ff;
+      --accent-soft: #1d2c46;
+      --good: #54c878;
+      --warn: #e6a14a;
+      --bad: #f17468;
+      --canvas: #20262d;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+  }
+  .app {
+    display: grid;
+    grid-template-columns: minmax(640px, 1fr) 330px;
+    gap: 14px;
+    padding: 14px;
+    min-height: 100vh;
+  }
+  .stage {
+    min-width: 0;
+  }
+  canvas {
+    display: block;
+    width: 100%;
+    height: auto;
+    background: var(--canvas);
+    border: 1px solid var(--border);
+  }
+  .side {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px;
+  }
+  h1, h2 {
+    margin: 0 0 8px;
+    font-size: 16px;
+    font-weight: 600;
+  }
+  h2 { font-size: 14px; }
+  .row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 8px;
+    margin: 8px 0;
+  }
+  .row label, .row .label {
+    font-size: 12px;
+    color: var(--muted);
+  }
+  .row output {
+    font-variant-numeric: tabular-nums;
+    font-size: 12px;
+  }
+  input[type="range"] {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+  input[type="number"], input[type="text"] {
+    width: 96px;
+    padding: 6px 7px;
+    color: var(--fg);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+  }
+  button {
+    appearance: none;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    color: var(--fg);
+    border-radius: 6px;
+    padding: 7px 10px;
+    font: inherit;
+    cursor: pointer;
+  }
+  button.primary {
+    color: white;
+    background: #1f6feb;
+    border-color: #1f6feb;
+  }
+  .buttons {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+  .stat {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 7px;
+    background: color-mix(in srgb, var(--panel), var(--bg) 35%);
+  }
+  .stat span {
+    display: block;
+    color: var(--muted);
+    font-size: 11px;
+  }
+  .stat strong {
+    display: block;
+    margin-top: 3px;
+    font-size: 18px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+  }
+  .hint {
+    margin: 0;
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1.35;
+  }
+  .check {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    margin: 8px 0;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  .trial-list {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+  .trial-list th, .trial-list td {
+    padding: 4px 3px;
+    text-align: right;
+    border-bottom: 1px solid var(--border);
+    font-variant-numeric: tabular-nums;
+  }
+  .trial-list th:first-child, .trial-list td:first-child { text-align: left; }
+  @media (max-width: 980px) {
+    .app { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<main class="app">
+  <section class="stage">
+    <canvas id="sim" width="980" height="680" aria-label="Thermal core simulator"></canvas>
+  </section>
+
+  <aside class="side">
+    <section class="card">
+      <h1>Thermal core simulator</h1>
+      <p class="hint">Left/right arrows ramp turn rate. Hold Shift for faster trim. Space pauses. The seed makes the same thermal repeatable.</p>
+    </section>
+
+    <section class="card">
+      <h2>Trial</h2>
+      <div class="row">
+        <label for="seed">Seed</label>
+        <input id="seed" type="number" value="2641" step="1">
+      </div>
+      <div class="row">
+        <label for="duration">Duration</label><output id="durationOut"></output>
+        <input id="duration" type="range" min="60" max="480" step="30" value="180">
+      </div>
+      <label class="check"><input id="showThermal" type="checkbox" checked> Show thermal visual</label>
+      <div class="buttons">
+        <button id="start" class="primary" type="button">Start</button>
+        <button id="reset" type="button">Reset</button>
+        <button id="same" type="button">Repeat</button>
+        <button id="newSeed" type="button">New seed</button>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Thermal</h2>
+      <div class="row">
+        <label for="wind">Wind</label><output id="windOut"></output>
+        <input id="wind" type="range" min="0" max="20" step="1" value="8">
+      </div>
+      <div class="row">
+        <label for="diameter">Nominal diameter</label><output id="diameterOut"></output>
+        <input id="diameter" type="range" min="50" max="400" step="5" value="110">
+      </div>
+      <div class="row">
+        <label for="diameterVariance">Diameter variance</label><output id="diameterVarianceOut"></output>
+        <input id="diameterVariance" type="range" min="0" max="60" step="5" value="25">
+      </div>
+      <div class="row">
+        <label for="strength">Net core strength</label><output id="strengthOut"></output>
+        <input id="strength" type="range" min="1" max="5" step="0.1" value="3.0">
+      </div>
+      <div class="row">
+        <label for="strengthVariance">Strength variance</label><output id="strengthVarianceOut"></output>
+        <input id="strengthVariance" type="range" min="0" max="70" step="5" value="30">
+      </div>
+      <div class="row">
+        <label for="texture">Lumpiness</label><output id="textureOut"></output>
+        <input id="texture" type="range" min="0" max="80" step="5" value="30">
+      </div>
+      <div class="row">
+        <label for="sink">Glider sink</label><output id="sinkOut"></output>
+        <input id="sink" type="range" min="0.6" max="1.6" step="0.1" value="1.0">
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Audio</h2>
+      <div class="row">
+        <label for="volume">Vario volume</label><output id="volumeOut"></output>
+        <input id="volume" type="range" min="0" max="100" step="1" value="35">
+      </div>
+      <div class="buttons">
+        <button id="testTone" type="button">Test tone</button>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Score</h2>
+      <div class="stats">
+        <div class="stat"><span>Altitude gain</span><strong id="gain">0 m</strong></div>
+        <div class="stat"><span>Avg climb</span><strong id="avgClimb">0.0</strong></div>
+        <div class="stat"><span>Centering</span><strong id="centering">0%</strong></div>
+        <div class="stat"><span>Score</span><strong id="score">0</strong></div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h2>Trials</h2>
+      <table class="trial-list">
+        <thead><tr><th>#</th><th>seed</th><th>gain</th><th>avg</th><th>center</th><th>score</th></tr></thead>
+        <tbody id="trials"></tbody>
+      </table>
+    </section>
+  </aside>
+</main>
+
+<script>
+"use strict";
+
+const canvas = document.getElementById("sim");
+const ctx = canvas.getContext("2d");
+
+const ui = {
+  seed: document.getElementById("seed"),
+  duration: document.getElementById("duration"),
+  wind: document.getElementById("wind"),
+  diameter: document.getElementById("diameter"),
+  diameterVariance: document.getElementById("diameterVariance"),
+  strength: document.getElementById("strength"),
+  strengthVariance: document.getElementById("strengthVariance"),
+  texture: document.getElementById("texture"),
+  showThermal: document.getElementById("showThermal"),
+  sink: document.getElementById("sink"),
+  volume: document.getElementById("volume"),
+  start: document.getElementById("start"),
+  reset: document.getElementById("reset"),
+  same: document.getElementById("same"),
+  newSeed: document.getElementById("newSeed"),
+  testTone: document.getElementById("testTone"),
+  durationOut: document.getElementById("durationOut"),
+  windOut: document.getElementById("windOut"),
+  diameterOut: document.getElementById("diameterOut"),
+  diameterVarianceOut: document.getElementById("diameterVarianceOut"),
+  strengthOut: document.getElementById("strengthOut"),
+  strengthVarianceOut: document.getElementById("strengthVarianceOut"),
+  textureOut: document.getElementById("textureOut"),
+  sinkOut: document.getElementById("sinkOut"),
+  volumeOut: document.getElementById("volumeOut"),
+  gain: document.getElementById("gain"),
+  avgClimb: document.getElementById("avgClimb"),
+  centering: document.getElementById("centering"),
+  score: document.getElementById("score"),
+  trials: document.getElementById("trials")
+};
+
+const leafScreenW = 96;
+const leafScreenH = 192;
+const maxTurnRateDps = 30;
+const baseAirspeed = 10.0;
+const dt = 1 / 60;
+const coreLookbackS = 40;
+const coreMinSamples = 16;
+const coreBinCount = 12;
+const mphToMps = 0.44704;
+
+let audioCtx = null;
+let beepOsc = null;
+let beepGain = null;
+let beepTimer = 0;
+let beepOn = false;
+let testToneUntil = 0;
+let lastFrame = performance.now();
+let accumulator = 0;
+let trials = [];
+let keys = new Set();
+
+let state = freshState(Number(ui.seed.value));
+
+function clamp(v, min, max) {
+  return Math.max(min, Math.min(max, v));
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function angleDeltaDeg(a, b) {
+  let d = ((b - a + 540) % 360) - 180;
+  return d;
+}
+
+function seededRandom(seed) {
+  let x = seed >>> 0;
+  return function rand() {
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    return ((x >>> 0) / 4294967296);
+  };
+}
+
+function smoothWave(z, phaseA, phaseB, scaleA, scaleB) {
+  return Math.sin(z * scaleA + phaseA) * 0.62 + Math.sin(z * scaleB + phaseB) * 0.38;
+}
+
+function readParams() {
+  return {
+    seed: Number(ui.seed.value) || 1,
+    duration: Number(ui.duration.value),
+    windMph: Number(ui.wind.value),
+    windMps: Number(ui.wind.value) * mphToMps,
+    diameterM: Number(ui.diameter.value),
+    diameterVariance: Number(ui.diameterVariance.value) / 100,
+    strength: Number(ui.strength.value),
+    strengthVariance: Number(ui.strengthVariance.value) / 100,
+    texture: Number(ui.texture.value) / 100,
+    showThermal: ui.showThermal.checked,
+    sink: Number(ui.sink.value),
+    volume: Number(ui.volume.value) / 100
+  };
+}
+
+function makeThermal(seed) {
+  const rand = seededRandom(seed);
+  const windDir = rand() * Math.PI * 2;
+  const slantDir = windDir + (rand() - 0.5) * 0.55;
+  return {
+    phaseA: rand() * Math.PI * 2,
+    phaseB: rand() * Math.PI * 2,
+    phaseC: rand() * Math.PI * 2,
+    phaseD: rand() * Math.PI * 2,
+    lumpPhase: rand() * Math.PI * 2,
+    windDir,
+    slantDir,
+    bendX: (rand() - 0.5) * 0.10,
+    bendY: (rand() - 0.5) * 0.10,
+    driftJitterX: (rand() - 0.5) * 0.55,
+    driftJitterY: (rand() - 0.5) * 0.55
+  };
+}
+
+function freshState(seed) {
+  const thermal = makeThermal(seed);
+  return {
+    running: false,
+    finished: false,
+    t: 0,
+    seed,
+    thermal,
+    x: -25,
+    y: 0,
+    z: 1000,
+    heading: 8,
+    turnRate: 18,
+    vario: 0,
+    lift: 0,
+    centerDistanceSum: 0,
+    centerDistanceSqSum: 0,
+    centerRadiusSum: 0,
+    centerSamples: 0,
+    samples: [],
+    altitudeTrace: [],
+    varioTrace: [],
+    lastSampleT: -1,
+    startAlt: 1000,
+    finishStats: null
+  };
+}
+
+function resetTrial(seed = Number(ui.seed.value)) {
+  stopAudioTone();
+  state = freshState(seed);
+  ui.seed.value = String(seed);
+  updateOutputs();
+}
+
+function newSeed() {
+  const seed = Math.floor(1000 + Math.random() * 900000);
+  resetTrial(seed);
+}
+
+function windVector(params, thermal = state.thermal) {
+  return {
+    x: Math.sin(thermal.windDir) * params.windMps,
+    y: Math.cos(thermal.windDir) * params.windMps
+  };
+}
+
+function thermalCenterAt(t, alt, params, thermal = state.thermal) {
+  const wind = windVector(params, thermal);
+  const windSlantDeg = lerp(0, 18, clamp(params.windMph / 20, 0, 1));
+  const slant = Math.tan(windSlantDeg * Math.PI / 180);
+  const relAlt = alt - 1000;
+  const slow = Math.sin(t * 0.010 + thermal.phaseD) * 8;
+  return {
+    x: wind.x * t + Math.sin(thermal.slantDir) * relAlt * slant + thermal.bendX * relAlt + thermal.driftJitterX * slow,
+    y: wind.y * t + Math.cos(thermal.slantDir) * relAlt * slant + thermal.bendY * relAlt + thermal.driftJitterY * slow
+  };
+}
+
+function thermalProfileAt(t, alt, params) {
+  const z = (alt - 1000) / 110;
+  const diameterWave = smoothWave(z, state.thermal.phaseA, state.thermal.phaseB, 1.25, 2.7);
+  const strengthWave = smoothWave(z, state.thermal.phaseC, state.thermal.phaseD, 1.0, 2.35);
+  const diameter = params.diameterM * (1 + params.diameterVariance * diameterWave);
+  const strength = (params.strength + params.sink) * (1 + params.strengthVariance * strengthWave);
+  return {
+    radius: clamp(diameter * 0.5, 18, 320),
+    strength: clamp(strength, 0.2, 9)
+  };
+}
+
+function liftAt(x, y, alt, t, params) {
+  const center = thermalCenterAt(t, alt, params);
+  const profile = thermalProfileAt(t, alt, params);
+  const dx = x - center.x;
+  const dy = y - center.y;
+  const r = Math.hypot(dx, dy);
+  const nr = r / Math.max(1, profile.radius);
+  const core = profile.strength * Math.exp(-nr * nr * 1.65);
+  const edgeSink = -0.45 * Math.max(0, nr - 1.0);
+  const az = Math.atan2(dy, dx);
+  const lump = Math.sin(az * 3 + t * 0.045 + state.thermal.lumpPhase) * 0.6 +
+    Math.sin(az * 5 - t * 0.032 + state.thermal.phaseB) * 0.4;
+  const shaped = core * (1 + params.texture * 0.28 * lump) + edgeSink;
+  return {
+    lift: shaped,
+    radius: profile.radius,
+    strength: profile.strength,
+    distance: r,
+    center
+  };
+}
+
+function ensureAudio() {
+  if (audioCtx) return;
+  audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  beepOsc = audioCtx.createOscillator();
+  beepGain = audioCtx.createGain();
+  beepOsc.type = "sine";
+  beepGain.gain.value = 0;
+  beepOsc.connect(beepGain);
+  beepGain.connect(audioCtx.destination);
+  beepOsc.start();
+}
+
+function stopAudioTone() {
+  beepOn = false;
+  if (beepGain && audioCtx) {
+    beepGain.gain.setTargetAtTime(0, audioCtx.currentTime, 0.01);
+  }
+}
+
+function updateAudio(stepDt) {
+  if (audioCtx && beepOsc && beepGain && audioCtx.currentTime < testToneUntil) {
+    beepOsc.frequency.setTargetAtTime(820, audioCtx.currentTime, 0.02);
+    beepGain.gain.setTargetAtTime(readParams().volume * 0.12, audioCtx.currentTime, 0.01);
+    return;
+  }
+  if (!state.running || state.finished || !audioCtx || !beepOsc || !beepGain) {
+    stopAudioTone();
+    return;
+  }
+  const volume = readParams().volume;
+  const climb = Math.max(0, state.vario);
+  if (volume <= 0 || climb <= 0.05) {
+    stopAudioTone();
+    return;
+  }
+  const pitch = 420 + Math.min(5, climb) * 145;
+  const period = clamp(0.74 - climb * 0.09, 0.17, 0.72);
+  const duty = clamp(0.20 + climb * 0.11, 0.18, 0.82);
+  beepTimer = (beepTimer + stepDt) % period;
+  const nextOn = beepTimer < period * duty;
+  beepOsc.frequency.setTargetAtTime(pitch, audioCtx.currentTime, 0.025);
+  if (nextOn !== beepOn) beepOn = nextOn;
+  const target = beepOn ? volume * 0.12 : 0;
+  beepGain.gain.setTargetAtTime(target, audioCtx.currentTime, 0.012);
+}
+
+function liveCoreSample(params) {
+  const wind = windVector(params);
+  const airX = state.x - wind.x * state.t;
+  const airY = state.y - wind.y * state.t;
+  return {
+    t: state.t,
+    x: state.x,
+    y: state.y,
+    airX,
+    airY,
+    z: state.z,
+    heading: state.heading,
+    turnRate: state.turnRate,
+    vario: state.vario,
+    lift: state.lift
+  };
+}
+
+function coreSamples(params) {
+  const samples = state.samples.slice();
+  const live = liveCoreSample(params);
+  if (!samples.length || live.t - samples[samples.length - 1].t > 0.02) samples.push(live);
+  return samples;
+}
+
+function sampleNow(params) {
+  const sample = liveCoreSample(params);
+  state.samples.push({
+    ...sample
+  });
+  while (state.samples.length && state.t - state.samples[0].t > coreLookbackS) state.samples.shift();
+}
+
+function updatePhysics(stepDt) {
+  const params = readParams();
+  if (!state.running || state.finished) {
+    updateAudio(stepDt);
+    return;
+  }
+  const fast = keys.has("ShiftLeft") || keys.has("ShiftRight");
+  const trimAccel = fast ? 34 : 14;
+  if (keys.has("ArrowLeft")) state.turnRate -= trimAccel * stepDt;
+  if (keys.has("ArrowRight")) state.turnRate += trimAccel * stepDt;
+  state.turnRate = clamp(state.turnRate, -maxTurnRateDps, maxTurnRateDps);
+
+  state.heading = (state.heading + state.turnRate * stepDt + 360) % 360;
+  const h = state.heading * Math.PI / 180;
+  const wind = windVector(params);
+  state.x += Math.sin(h) * baseAirspeed * stepDt + wind.x * stepDt;
+  state.y += Math.cos(h) * baseAirspeed * stepDt + wind.y * stepDt;
+
+  const liftInfo = liftAt(state.x, state.y, state.z, state.t, params);
+  state.lift = liftInfo.lift;
+  state.vario = state.lift - params.sink;
+  state.z += state.vario * stepDt;
+  state.t += stepDt;
+
+  state.centerDistanceSum += liftInfo.distance * stepDt;
+  state.centerDistanceSqSum += liftInfo.distance * liftInfo.distance * stepDt;
+  state.centerRadiusSum += liftInfo.radius * stepDt;
+  state.centerSamples += stepDt;
+
+  state.altitudeTrace.push({t: state.t, v: state.z});
+  state.varioTrace.push({t: state.t, v: state.vario});
+  while (state.altitudeTrace.length && state.t - state.altitudeTrace[0].t > 180) state.altitudeTrace.shift();
+  while (state.varioTrace.length && state.t - state.varioTrace[0].t > 90) state.varioTrace.shift();
+  if (state.t - state.lastSampleT >= 1) {
+    state.lastSampleT = state.t;
+    sampleNow(params);
+  }
+  updateAudio(stepDt);
+  if (state.t >= params.duration) finishTrial();
+}
+
+function turnStats(samples) {
+  if (samples.length < 2) return {direction: 1, turnRateDps: 0, totalTurn: 0};
+  let total = 0;
+  for (let i = 1; i < samples.length; i += 1) {
+    total += angleDeltaDeg(samples[i - 1].heading, samples[i].heading);
+  }
+  const elapsed = Math.max(1, samples[samples.length - 1].t - samples[0].t);
+  const direction = total < -5 ? -1 : total > 5 ? 1 : (state.turnRate < 0 ? -1 : 1);
+  return {
+    direction,
+    turnRateDps: Math.abs(total) / elapsed,
+    totalTurn: total
+  };
+}
+
+function estimateCoreGuidance() {
+  const samples = coreSamples(readParams());
+  const stats = turnStats(samples);
+  const direction = stats.direction || (state.turnRate < 0 ? -1 : 1);
+  const actualTurnRateDps = Math.abs(state.turnRate);
+  const result = {
+    valid: false,
+    cue: "WAIT",
+    advice: 0,
+    stats,
+    actualTurnRateDps,
+    suggestedTurnRateDps: actualTurnRateDps,
+    samples
+  };
+  if (samples.length < coreMinSamples || Math.abs(stats.totalTurn) < 120) return result;
+
+  const latest = samples[samples.length - 1];
+  const bins = Array.from({length: coreBinCount}, () => ({sum: 0, weight: 0, avgLift: NaN}));
+  for (const sample of samples) {
+    const age = latest.t - sample.t;
+    const bearing = Math.atan2(sample.airY - latest.airY, sample.airX - latest.airX);
+    const headingRad = (90 - latest.heading) * Math.PI / 180;
+    let phase = bearing - headingRad;
+    while (phase < 0) phase += Math.PI * 2;
+    while (phase >= Math.PI * 2) phase -= Math.PI * 2;
+    if (direction < 0) phase = (Math.PI * 2 - phase) % (Math.PI * 2);
+    const index = Math.floor(phase / (Math.PI * 2) * coreBinCount) % coreBinCount;
+    const weight = clamp(1 - age / coreLookbackS, 0.15, 1);
+    bins[index].sum += sample.vario * weight;
+    bins[index].weight += weight;
+  }
+  for (const bin of bins) {
+    if (bin.weight > 0) bin.avgLift = bin.sum / bin.weight;
+  }
+
+  const nowBins = [11, 0, 1].map(i => bins[(i + coreBinCount) % coreBinCount].avgLift).filter(Number.isFinite);
+  const oppBins = [5, 6, 7].map(i => bins[(i + coreBinCount) % coreBinCount].avgLift).filter(Number.isFinite);
+  const nowAvg = nowBins.length ? nowBins.reduce((a, b) => a + b, 0) / nowBins.length : latest.vario;
+  const oppAvg = oppBins.length ? oppBins.reduce((a, b) => a + b, 0) / oppBins.length : latest.vario;
+  const recent = samples.slice(-6).map(s => s.vario);
+  const trend = recent.length >= 2 ? recent[recent.length - 1] - recent[0] : 0;
+  const liftDelta = nowAvg - oppAvg;
+
+  let advice = clamp((liftDelta * 0.42) + (trend * 0.28), -1, 1);
+  if (latest.vario < -0.3 && oppAvg > nowAvg) advice -= 0.18;
+  if (actualTurnRateDps < 4) advice = Math.min(advice, -0.35);
+  advice = clamp(advice, -1, 1);
+
+  let cue = "HOLD";
+  if (advice > 0.55) cue = "WIDE++";
+  else if (advice > 0.18) cue = "WIDE";
+  else if (advice < -0.55) cue = "TIGHT++";
+  else if (advice < -0.18) cue = "TIGHT";
+  if (latest.vario < -1.3) cue = "WEAK";
+
+  result.valid = true;
+  result.cue = cue;
+  result.advice = advice;
+  result.bins = bins;
+  result.nowAvg = nowAvg;
+  result.oppositeAvg = oppAvg;
+  result.suggestedTurnRateDps = clamp(actualTurnRateDps * (1 - advice * 0.5), 0, maxTurnRateDps);
+  return result;
+}
+
+function finishTrial() {
+  if (state.finished) return;
+  state.running = false;
+  state.finished = true;
+  ui.start.textContent = "Start";
+  stopAudioTone();
+  state.finishStats = currentStats();
+  trials.unshift({
+    seed: state.seed,
+    ...state.finishStats
+  });
+  trials = trials.slice(0, 8);
+  renderTrials();
+}
+
+function currentStats() {
+  const params = readParams();
+  const gain = state.z - state.startAlt;
+  const avg = state.t > 0 ? gain / state.t : 0;
+  const meanDist = state.centerSamples > 0 ? state.centerDistanceSum / state.centerSamples : 0;
+  const meanDistSq = state.centerSamples > 0 ? state.centerDistanceSqSum / state.centerSamples : 0;
+  const avgRadius = state.centerSamples > 0 ? state.centerRadiusSum / state.centerSamples : Math.max(1, params.diameterM * 0.5);
+  const radialStd = Math.sqrt(Math.max(0, meanDistSq - meanDist * meanDist));
+  const nearScore = Math.exp(-Math.pow(meanDist / Math.max(1, avgRadius * 0.70), 2));
+  const uniformScore = Math.exp(-Math.pow(radialStd / Math.max(1, avgRadius * 0.22), 2));
+  const centering = clamp(nearScore * uniformScore, 0, 1);
+  const score = Math.max(0, Math.round(gain + centering * 180 + avg * 70));
+  return {gain, avg, centering, meanDist, radialStd, score, duration: params.duration};
+}
+
+function renderTrials() {
+  ui.trials.innerHTML = "";
+  trials.forEach((trial, i) => {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `<td>${i + 1}</td><td>${trial.seed}</td><td>${trial.gain.toFixed(0)}</td><td>${trial.avg.toFixed(1)}</td><td>${Math.round(trial.centering * 100)}%</td><td>${trial.score}</td>`;
+    ui.trials.appendChild(tr);
+  });
+}
+
+function drawText(text, x, y, size = 12, align = "left", color = "#111") {
+  ctx.fillStyle = color;
+  ctx.font = `${size}px system-ui, sans-serif`;
+  ctx.textAlign = align;
+  ctx.textBaseline = "middle";
+  ctx.fillText(text, x, y);
+}
+
+function drawArrow(x, y, heading, size, fill = "#111") {
+  ctx.save();
+  ctx.translate(x, y);
+  ctx.rotate(heading * Math.PI / 180);
+  ctx.fillStyle = fill;
+  ctx.beginPath();
+  ctx.moveTo(0, -size);
+  ctx.lineTo(size * 0.62, size * 0.72);
+  ctx.lineTo(0, size * 0.38);
+  ctx.lineTo(-size * 0.62, size * 0.72);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+function mapPoint(worldX, worldY, centerX, centerY, scale, rect) {
+  return {
+    x: rect.x + rect.w / 2 + (worldX - centerX) * scale,
+    y: rect.y + rect.h / 2 - (worldY - centerY) * scale
+  };
+}
+
+function drawMainMap(rect, estimate) {
+  const params = readParams();
+  const center = thermalCenterAt(state.t, state.z, params);
+  const profile = thermalProfileAt(state.t, state.z, params);
+  const focusX = lerp(state.x, center.x, 0.25);
+  const focusY = lerp(state.y, center.y, 0.25);
+  const scale = Math.min(rect.w, rect.h) / 330;
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(rect.x, rect.y, rect.w, rect.h);
+  ctx.clip();
+  ctx.fillStyle = "#eef2f6";
+  ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+
+  ctx.strokeStyle = "#d3d8de";
+  ctx.lineWidth = 1;
+  const grid = 50 * scale;
+  for (let gx = rect.x - 200; gx < rect.x + rect.w + 200; gx += grid) {
+    ctx.beginPath();
+    ctx.moveTo(gx, rect.y);
+    ctx.lineTo(gx, rect.y + rect.h);
+    ctx.stroke();
+  }
+  for (let gy = rect.y - 200; gy < rect.y + rect.h + 200; gy += grid) {
+    ctx.beginPath();
+    ctx.moveTo(rect.x, gy);
+    ctx.lineTo(rect.x + rect.w, gy);
+    ctx.stroke();
+  }
+
+  if (params.showThermal) {
+    const c = mapPoint(center.x, center.y, focusX, focusY, scale, rect);
+    const grd = ctx.createRadialGradient(c.x, c.y, 0, c.x, c.y, profile.radius * scale * 1.45);
+    grd.addColorStop(0, "rgba(56, 150, 80, 0.34)");
+    grd.addColorStop(0.55, "rgba(56, 150, 80, 0.15)");
+    grd.addColorStop(1, "rgba(56, 150, 80, 0)");
+    ctx.fillStyle = grd;
+    ctx.beginPath();
+    ctx.arc(c.x, c.y, profile.radius * scale * 1.45, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.strokeStyle = "rgba(20, 90, 40, 0.55)";
+    ctx.setLineDash([5, 5]);
+    ctx.beginPath();
+    ctx.arc(c.x, c.y, profile.radius * scale, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.setLineDash([]);
+  }
+
+  ctx.strokeStyle = "#333";
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  let started = false;
+  for (const sample of state.samples) {
+    const p = mapPoint(sample.x, sample.y, focusX, focusY, scale, rect);
+    if (!started) {
+      ctx.moveTo(p.x, p.y);
+      started = true;
+    } else {
+      ctx.lineTo(p.x, p.y);
+    }
+  }
+  ctx.stroke();
+
+  const p = mapPoint(state.x, state.y, focusX, focusY, scale, rect);
+  drawArrow(p.x, p.y, state.heading, 13, "#111");
+
+  const wind = windVector(params);
+  const wx = rect.x + 42;
+  const wy = rect.y + 50;
+  ctx.strokeStyle = "#111";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(wx, wy);
+  ctx.lineTo(wx + wind.x * 6, wy - wind.y * 6);
+  ctx.stroke();
+  ctx.fillStyle = "#111";
+  ctx.beginPath();
+  ctx.arc(wx + wind.x * 6, wy - wind.y * 6, 3, 0, Math.PI * 2);
+  ctx.fill();
+  drawText(`${params.windMph.toFixed(0)} mph wind`, rect.x + 10, rect.y + 18, 12, "left", "#111");
+
+  drawText(estimate.cue, rect.x + rect.w - 16, rect.y + 18, 16, "right", "#111");
+  ctx.restore();
+}
+
+function drawTape(rect, value, minValue, maxValue, label, units, active = true) {
+  ctx.save();
+  ctx.strokeStyle = "#111";
+  ctx.fillStyle = "#fff";
+  ctx.lineWidth = 1;
+  ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+  const mid = rect.y + rect.h / 2;
+  for (let i = 0; i <= 10; i += 1) {
+    const y = rect.y + rect.h - i / 10 * rect.h;
+    ctx.beginPath();
+    ctx.moveTo(rect.x, y);
+    ctx.lineTo(rect.x + (i % 5 === 0 ? 12 : 7), y);
+    ctx.stroke();
+  }
+  const t = clamp((value - minValue) / Math.max(1, maxValue - minValue), 0, 1);
+  const y = rect.y + rect.h - t * rect.h;
+  ctx.fillStyle = active ? "#111" : "#777";
+  ctx.fillRect(rect.x + 6, y - 12, rect.w - 12, 24);
+  drawText(`${value >= 0 && label === "vario" ? "+" : ""}${value.toFixed(label === "alt" ? 0 : 1)}${units}`, rect.x + rect.w / 2, y, 11, "center", "#fff");
+  drawText(label, rect.x + rect.w / 2, rect.y - 12, 11, "center", "#111");
+  ctx.restore();
+}
+
+function drawTurnRate(rect, estimate) {
+  ctx.save();
+  ctx.strokeStyle = "#111";
+  ctx.lineWidth = 1;
+  ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+  const center = rect.x + rect.w / 2;
+  ctx.beginPath();
+  ctx.moveTo(center, rect.y);
+  ctx.lineTo(center, rect.y + rect.h);
+  ctx.stroke();
+  const actualX = center + state.turnRate / maxTurnRateDps * rect.w / 2;
+  ctx.fillStyle = "#111";
+  ctx.beginPath();
+  ctx.arc(actualX, rect.y + rect.h / 2, 7, 0, Math.PI * 2);
+  ctx.fill();
+  if (estimate.valid) {
+    const sign = state.turnRate < 0 ? -1 : 1;
+    const suggestedSigned = sign * estimate.suggestedTurnRateDps;
+    const suggestedX = center + suggestedSigned / maxTurnRateDps * rect.w / 2;
+    ctx.beginPath();
+    ctx.moveTo(suggestedX, rect.y - 2);
+    ctx.lineTo(suggestedX - 5, rect.y - 10);
+    ctx.lineTo(suggestedX + 5, rect.y - 10);
+    ctx.closePath();
+    ctx.fill();
+  }
+  drawText("-30", rect.x, rect.y + rect.h + 13, 11, "left", "#111");
+  drawText("turn rate", center, rect.y - 15, 11, "center", "#111");
+  drawText("+30", rect.x + rect.w, rect.y + rect.h + 13, 11, "right", "#111");
+  ctx.restore();
+}
+
+function coreScreenPoint(sample, latest, heading, aircraftX, aircraftY, metersPerPx) {
+  const dx = sample.airX - latest.airX;
+  const dy = sample.airY - latest.airY;
+  const h = heading * Math.PI / 180;
+  const right = dx * Math.cos(h) - dy * Math.sin(h);
+  const forward = dx * Math.sin(h) + dy * Math.cos(h);
+  return {
+    x: aircraftX + right / metersPerPx,
+    y: aircraftY - forward / metersPerPx
+  };
+}
+
+function drawMaskedPlusGlyph(cx, cy) {
+  const drawPlus = (fill, armHalfW, armHalfL) => {
+    ctx.fillStyle = fill;
+    ctx.fillRect(cx - armHalfW, cy - armHalfL, armHalfW * 2, armHalfL * 2);
+    ctx.fillRect(cx - armHalfL, cy - armHalfW, armHalfL * 2, armHalfW * 2);
+  };
+  drawPlus("#f4f4f4", 4, 10);
+  drawPlus("#111", 2, 8);
+}
+
+function drawCoreTargetScale(cx, cy) {
+  ctx.fillStyle = "#f4f4f4";
+  ctx.strokeStyle = "#111";
+  ctx.lineWidth = 1;
+  const left = cx - 28;
+  const right = cx + 28;
+  const top = cy - 11;
+  const bottom = cy + 11;
+  const innerTop = cy - 4;
+  const innerBottom = cy + 4;
+  ctx.beginPath();
+  ctx.moveTo(left, innerTop);
+  ctx.lineTo(cx - 6, innerTop);
+  ctx.lineTo(cx - 6, top);
+  ctx.lineTo(cx + 6, top);
+  ctx.lineTo(cx + 6, innerTop);
+  ctx.lineTo(right, innerTop);
+  ctx.lineTo(right, innerBottom);
+  ctx.lineTo(cx + 6, innerBottom);
+  ctx.lineTo(cx + 6, bottom);
+  ctx.lineTo(cx - 6, bottom);
+  ctx.lineTo(cx - 6, innerBottom);
+  ctx.lineTo(left, innerBottom);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+}
+
+function drawCoreScreen(rect, estimate) {
+  ctx.save();
+  ctx.fillStyle = "#f4f4f4";
+  ctx.fillRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.strokeStyle = "#111";
+  ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+  ctx.translate(rect.x, rect.y);
+
+  ctx.strokeStyle = "#d0d0d0";
+  ctx.lineWidth = 1;
+  for (let x = 0; x <= leafScreenW; x += 12) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, leafScreenH);
+    ctx.stroke();
+  }
+  for (let y = 0; y <= leafScreenH; y += 12) {
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(leafScreenW, y);
+    ctx.stroke();
+  }
+
+  const direction = estimate.stats?.direction || (state.turnRate < 0 ? -1 : 1);
+  const turnSide = direction < 0 ? -1 : 1;
+  const aircraftX = direction < 0 ? 76 : 20;
+  const aircraftY = 118;
+  const ringRadius = 38;
+  const ringCx = aircraftX + turnSide * ringRadius;
+  const ringCy = aircraftY;
+  const advice = estimate.valid ? estimate.advice : 0;
+  const dynamicRadius = ringRadius * (1 + advice * 0.36);
+  const dynamicCx = aircraftX + turnSide * dynamicRadius;
+  const samples = estimate.samples || [];
+  const latest = samples[samples.length - 1] || {
+    airX: state.x,
+    airY: state.y,
+    heading: state.heading
+  };
+  const metersPerPx = 1.8;
+
+  const climbs = samples.map(p => p.vario).filter(Number.isFinite);
+  const minClimb = climbs.length ? Math.min(...climbs) : -1;
+  const maxClimb = climbs.length ? Math.max(...climbs) : 3;
+  for (const sample of samples) {
+    const p = coreScreenPoint(sample, latest, latest.heading, aircraftX, aircraftY, metersPerPx);
+    if (p.x < -6 || p.x > leafScreenW + 6 || p.y < -6 || p.y > leafScreenH + 6) continue;
+    const strength = clamp((sample.vario - minClimb) / Math.max(0.1, maxClimb - minClimb), 0, 1);
+    ctx.strokeStyle = "#111";
+    ctx.fillStyle = "#111";
+    if (strength <= 0.25) {
+      ctx.fillRect(Math.round(p.x), Math.round(p.y), 1, 1);
+    } else {
+      ctx.lineWidth = 1;
+      const diameter = strength > 0.78 ? 7 : strength > 0.52 ? 5 : 3;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, diameter / 2, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+
+  if (estimate.valid && Math.abs(advice) >= 0.08) {
+    ctx.strokeStyle = "#111";
+    ctx.lineWidth = Math.abs(advice) >= 0.55 ? 3 : 2;
+    ctx.beginPath();
+    const startAngle = turnSide > 0 ? Math.PI : 0;
+    const endAngle = startAngle + turnSide * Math.PI * 0.75;
+    ctx.arc(dynamicCx, ringCy, dynamicRadius, startAngle, endAngle, turnSide < 0);
+    ctx.stroke();
+  }
+
+  drawCoreTargetScale(ringCx, ringCy);
+  drawMaskedPlusGlyph(dynamicCx, ringCy);
+  drawArrow(aircraftX, aircraftY, 0, 11, "#111");
+
+  drawText(estimate.cue || "WAIT", 48, 13, 16, "center", "#111");
+  drawText(`now ${Number.isFinite(estimate.nowAvg) ? estimate.nowAvg.toFixed(1) : "--"} / opp ${Number.isFinite(estimate.oppositeAvg) ? estimate.oppositeAvg.toFixed(1) : "--"}`, 6, 36, 7, "left", "#111");
+  drawCoreTurnBarInLeaf(estimate);
+  ctx.restore();
+}
+
+function drawCoreTurnBarInLeaf(estimate) {
+  const x = 13;
+  const y = 49;
+  const w = 70;
+  const h = 7;
+  const direction = estimate.stats?.direction || (state.turnRate < 0 ? -1 : 1);
+  const actual = clamp(estimate.actualTurnRateDps || 0, 0, 40);
+  const suggested = clamp(estimate.suggestedTurnRateDps || 0, 0, 40);
+  const actualRatio = actual / 40;
+  const suggestedRatio = suggested / 40;
+  const actualX = direction > 0 ? x + actualRatio * w : x + (1 - actualRatio) * w;
+  const suggestedX = direction > 0 ? x + suggestedRatio * w : x + (1 - suggestedRatio) * w;
+  ctx.strokeStyle = "#111";
+  ctx.fillStyle = "#111";
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x, y, w, h);
+  ctx.beginPath();
+  ctx.arc(actualX, y + h / 2, 3, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.beginPath();
+  ctx.moveTo(suggestedX, y - 4);
+  ctx.lineTo(suggestedX - 3, y - 9);
+  ctx.lineTo(suggestedX + 3, y - 9);
+  ctx.closePath();
+  ctx.fill();
+}
+
+function drawTrace(rect, trace, minV, maxV, label) {
+  ctx.save();
+  ctx.strokeStyle = "#111";
+  ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
+  drawText(label, rect.x + 8, rect.y + 12, 11, "left", "#111");
+  if (trace.length > 1) {
+    const startT = trace[0].t;
+    const endT = trace[trace.length - 1].t;
+    ctx.beginPath();
+    trace.forEach((p, i) => {
+      const x = rect.x + (p.t - startT) / Math.max(1, endT - startT) * rect.w;
+      const y = rect.y + rect.h - clamp((p.v - minV) / Math.max(1, maxV - minV), 0, 1) * rect.h;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function draw() {
+  const estimate = estimateCoreGuidance();
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = "#e9edf1";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const map = {x: 16, y: 18, w: 690, h: 520};
+  const altTape = {x: 724, y: 18, w: 58, h: 520};
+  const varioTape = {x: 796, y: 18, w: 58, h: 520};
+  const core = {x: 872, y: 18, w: 96, h: 192};
+  const turn = {x: 872, y: 236, w: 96, h: 18};
+  drawMainMap(map, estimate);
+  drawTape(altTape, state.z, state.startAlt - 20, state.startAlt + 360, "alt", "m");
+  drawTape(varioTape, state.vario, -5, 7, "vario", "");
+  drawCoreScreen(core, estimate);
+  drawTurnRate(turn, estimate);
+  drawTrace({x: 16, y: 562, w: 460, h: 90}, state.altitudeTrace, state.startAlt - 20, state.startAlt + 360, "altitude");
+  drawTrace({x: 494, y: 562, w: 360, h: 90}, state.varioTrace, -5, 7, "vario");
+
+  const stats = currentStats();
+  drawText(`${state.running ? "RUN" : state.finished ? "DONE" : "READY"}  ${state.t.toFixed(0)}s`, 872, 306, 14, "left", "#111");
+  drawText(`alt ${state.z.toFixed(0)}m`, 872, 332, 12, "left", "#111");
+  drawText(`vario ${state.vario >= 0 ? "+" : ""}${state.vario.toFixed(1)}m/s`, 872, 354, 12, "left", "#111");
+  drawText(`turn ${state.turnRate >= 0 ? "+" : ""}${state.turnRate.toFixed(1)} deg/s`, 872, 376, 12, "left", "#111");
+  drawText(`gain ${stats.gain.toFixed(0)}m`, 872, 398, 12, "left", "#111");
+  drawText(`center ${Math.round(stats.centering * 100)}%`, 872, 420, 12, "left", "#111");
+  drawText(`score ${stats.score}`, 872, 442, 12, "left", "#111");
+  if (!state.running && !state.finished) {
+    drawText("Press Start, then fly by vario or Core.", map.x + map.w / 2, map.y + map.h / 2, 18, "center", "#111");
+  }
+}
+
+function updateOutputs() {
+  const p = readParams();
+  ui.durationOut.value = `${p.duration}s`;
+  ui.windOut.value = `${p.windMph.toFixed(0)} mph`;
+  ui.diameterOut.value = `${p.diameterM.toFixed(0)} m`;
+  ui.diameterVarianceOut.value = `+/-${Math.round(p.diameterVariance * 100)}%`;
+  ui.strengthOut.value = `${p.strength.toFixed(1)} m/s`;
+  ui.strengthVarianceOut.value = `+/-${Math.round(p.strengthVariance * 100)}%`;
+  ui.textureOut.value = `${Math.round(p.texture * 100)}%`;
+  ui.sinkOut.value = `${p.sink.toFixed(1)} m/s`;
+  ui.volumeOut.value = `${Math.round(p.volume * 100)}%`;
+  const stats = currentStats();
+  ui.gain.textContent = `${stats.gain.toFixed(0)} m`;
+  ui.avgClimb.textContent = `${stats.avg.toFixed(1)}`;
+  ui.centering.textContent = `${Math.round(stats.centering * 100)}%`;
+  ui.score.textContent = String(stats.score);
+}
+
+function loop(now) {
+  const elapsed = Math.min(0.08, (now - lastFrame) / 1000);
+  lastFrame = now;
+  accumulator += elapsed;
+  while (accumulator >= dt) {
+    updatePhysics(dt);
+    accumulator -= dt;
+  }
+  updateOutputs();
+  draw();
+  requestAnimationFrame(loop);
+}
+
+ui.start.addEventListener("click", async () => {
+  ensureAudio();
+  if (audioCtx.state === "suspended") await audioCtx.resume();
+  if (state.finished) resetTrial(state.seed);
+  state.running = !state.running;
+  ui.start.textContent = state.running ? "Pause" : "Start";
+});
+ui.reset.addEventListener("click", () => {
+  resetTrial(Number(ui.seed.value));
+  ui.start.textContent = "Start";
+});
+ui.same.addEventListener("click", () => {
+  resetTrial(state.seed);
+  ui.start.textContent = "Start";
+});
+ui.newSeed.addEventListener("click", () => {
+  newSeed();
+  ui.start.textContent = "Start";
+});
+ui.testTone.addEventListener("click", async () => {
+  ensureAudio();
+  if (audioCtx.state === "suspended") await audioCtx.resume();
+  testToneUntil = audioCtx.currentTime + 0.75;
+});
+
+for (const el of [ui.seed, ui.duration, ui.wind, ui.diameter, ui.diameterVariance, ui.strength, ui.strengthVariance, ui.texture, ui.showThermal, ui.sink, ui.volume]) {
+  el.addEventListener("input", updateOutputs);
+  el.addEventListener("change", updateOutputs);
+}
+
+window.addEventListener("keydown", event => {
+  if (["ArrowLeft", "ArrowRight", "Space", "ShiftLeft", "ShiftRight"].includes(event.code)) event.preventDefault();
+  keys.add(event.code);
+  if (event.code === "Space") {
+    state.running = !state.running;
+    ui.start.textContent = state.running ? "Pause" : "Start";
+  }
+});
+window.addEventListener("keyup", event => {
+  keys.delete(event.code);
+});
+
+updateOutputs();
+requestAnimationFrame(loop);
+</script>
+</body>
+</html>

--- a/tools and analysis/thermal_detection/thermal_core_tutorial_script.md
+++ b/tools and analysis/thermal_detection/thermal_core_tutorial_script.md
@@ -1,0 +1,357 @@
+# Thermal Core Simulator Tutorial Script
+
+This document is the source-of-truth draft for tutorial wording and teaching flow in `thermal_core_game.html`. Edit this script first when adding or revising tutorial scenarios, then update the simulator implementation to match.
+
+## Script Fields
+
+Each tutorial stage should define:
+
+- **Stage title**: Short label for the tutorial card.
+- **Initial heading**: Heading shown before the simulator starts the stage.
+- **Initial explanation**: Teaching text shown before the user presses Space.
+- **Initial goal**: The first measurable action, usually an entry or turn-start task.
+- **Flying pop-up text**: Temporary map text shown while the user is flying.
+- **Pause heading**: Heading shown when the simulator pauses for the next explanation.
+- **Pause explanation**: Teaching text shown before the user continues.
+- **Practice heading**: Heading shown during the main practice portion.
+- **Practice guidance text**: Dynamic or static text shown while the user practices.
+- **Practice goal**: Success criteria for completing the stage.
+- **Map view**: Thermal visual, rings, target turn-rate marks, and other aids shown or hidden.
+- **Completion text**: Text shown after the stage succeeds.
+
+## Shared Entry Sequence
+
+### Initial Heading
+
+Start of stage
+
+### Initial Explanation
+
+Fly straight into the lift. When the vario peaks and just begins to fade, you are about halfway through the core. That is the moment to start turning.
+
+### Initial Goal
+
+Wait for the vario peak, then turn about 90 degrees. Press Space bar to start.
+
+### Flying Pop-Up Text
+
+START TURNING NOW
+
+Turn about 90 degrees
+
+### Trigger
+
+Show the pop-up when the vario has exceeded 1.0 m/s, the run has lasted at least 6 seconds, and the current vario has dropped at least 0.25 m/s below the peak seen so far.
+
+### Pause Trigger
+
+Pause after the user's heading changes by about 90 degrees from the heading at the pop-up.
+
+## Stage 1: Center With Visual Help
+
+### Initial Heading
+
+1. Center with visual help
+
+### Initial Explanation
+
+Fly straight into the lift. When the vario peaks and just begins to fade, you are about halfway through the core. That is the moment to start turning.
+
+### Initial Goal
+
+First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start.
+
+### Pause Heading
+
+Now center the thermal
+
+### Pause Explanation
+
+Now the goal is to keep the vario constant. If it starts to drop, you are moving away from the center and need to tighten your turn. If it starts to increase, you are moving toward the center and need to widen your turn. Try to fly a few orbits centered on the thermal.
+
+### Pause Goal
+
+Press Space bar or Continue to begin the orbit practice.
+
+### Practice Heading
+
+1b. Center by sound
+
+### Practice Guidance Text
+
+Hold this turn and listen. If the beeps fade, tighten slightly. If they build, widen slightly.
+
+Dynamic alternates:
+
+- Build a smooth turn with the arrow keys.
+- Lift is improving: widen slightly so your circle moves toward the core.
+- Lift is fading: tighten slightly to avoid sliding away from the core.
+- That orbit wandered too much. Re-center and try for two smoother laps.
+
+### Practice Goal
+
+Complete 2 consecutive smooth orbits at any radius, with radial spread under 25% of the thermal diameter.
+
+### Map View
+
+- Thermal visual: shown as fuzzy green blob.
+- Outer thermal boundary: shown.
+- Concentric rings: shown.
+- Ideal turn-rate marks: hidden.
+- Thermal Core widget: shown.
+- Turn/bank inset: shown.
+
+### Completion Text
+
+Good. You used the vario trend and visual rings to move your circle toward the thermal center.
+
+## Stage 2: Core At A Target Rate
+
+### Initial Heading
+
+2. Core at a target rate
+
+### Initial Explanation
+
+This time the green target bands are back. They represent the nominal turn rate that gives an efficient target radius around the core.
+
+### Initial Goal
+
+First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start.
+
+### Pause Heading
+
+Now core the thermal
+
+### Pause Explanation
+
+Now add the target turn-rate habit. Use vario changes to slide your circle onto the center, then return toward the green target band so the bank stays efficient.
+
+### Pause Goal
+
+Press Space bar or Continue to begin the orbit practice.
+
+### Practice Heading
+
+2b. Core at target rate
+
+### Practice Guidance Text
+
+Use the green target bands as your home base. Tighten or widen just enough to move the circle, then settle back near the target.
+
+Dynamic alternates:
+
+- Build a smooth turn with the arrow keys.
+- Lift is improving: widen slightly so your circle moves toward the core.
+- Lift is fading: tighten slightly to avoid sliding away from the core.
+- That orbit missed the target radius. Re-center, return to the green band, and try again.
+
+### Practice Goal
+
+Complete 2 consecutive target-radius orbits where maximum radial error is no more than +/-10% of the thermal diameter from the specific target radius implied by the target turn rate.
+
+Target radius is:
+
+```text
+target radius = airspeed / target turn rate in radians per second
+```
+
+### Map View
+
+- Thermal visual: shown as fuzzy green blob.
+- Outer thermal boundary: shown.
+- Concentric rings: shown.
+- Ideal turn-rate marks: shown.
+- Thermal Core widget: shown.
+- Turn/bank inset: shown.
+
+### Completion Text
+
+Good. You held a radius close to the target turn-rate circle.
+
+## Stage 3: Center Without Rings
+
+### Initial Heading
+
+3. Center without rings
+
+### Initial Explanation
+
+Try the same entry and centering exercise again, but without the concentric rings. You still get the fuzzy green thermal shape, but the constant-vario path is no longer drawn for you.
+
+### Initial Goal
+
+First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start.
+
+### Pause Heading
+
+Now center without rings
+
+### Pause Explanation
+
+Same idea: keep the vario as constant as possible. Fading beeps mean tighten; building beeps mean widen.
+
+### Pause Goal
+
+Press Space bar or Continue to begin the orbit practice.
+
+### Practice Heading
+
+3b. Fuzzy-blob centering
+
+### Practice Guidance Text
+
+Use the sound first. Let the fuzzy thermal visual confirm what your ears are telling you.
+
+Dynamic alternates:
+
+- Build a smooth turn with the arrow keys.
+- Lift is improving: widen slightly so your circle moves toward the core.
+- Lift is fading: tighten slightly to avoid sliding away from the core.
+- That orbit wandered too much. Re-center and try for two smoother laps.
+
+### Practice Goal
+
+Complete 2 consecutive smooth orbits at any radius, with radial spread under 25% of the thermal diameter.
+
+### Map View
+
+- Thermal visual: shown as fuzzy green blob.
+- Outer thermal boundary: hidden.
+- Concentric rings: hidden.
+- Ideal turn-rate marks: shown.
+- Thermal Core widget: shown.
+- Turn/bank inset: shown.
+
+### Completion Text
+
+Good. You centered the thermal without the constant-radius guide rings.
+
+## Stage 4: Center By Vario Only
+
+### Initial Heading
+
+4. Center by vario only
+
+### Initial Explanation
+
+Final basic drill: the thermal visual is hidden. Fly the same technique using only the vario tone and the flight instruments.
+
+### Initial Goal
+
+First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start.
+
+### Pause Heading
+
+Now fly by sound only
+
+### Pause Explanation
+
+Trust the vario. If it fades, tighten. If it builds, widen. The goal is still a steady-radius circle centered on the lift.
+
+### Pause Goal
+
+Press Space bar or Continue to begin the orbit practice.
+
+### Practice Heading
+
+4b. Sound-only centering
+
+### Practice Guidance Text
+
+Listen for symmetry. Try to make each orbit sound boring and steady.
+
+Dynamic alternates:
+
+- Build a smooth turn with the arrow keys.
+- Lift is improving: widen slightly so your circle moves toward the core.
+- Lift is fading: tighten slightly to avoid sliding away from the core.
+- That orbit wandered too much. Re-center and try for two smoother laps.
+
+### Practice Goal
+
+Complete 2 consecutive smooth orbits at any radius, with radial spread under 25% of the thermal diameter.
+
+### Map View
+
+- Thermal visual: hidden.
+- Outer thermal boundary: hidden.
+- Concentric rings: hidden.
+- Ideal turn-rate marks: shown.
+- Thermal Core widget: shown.
+- Turn/bank inset: shown.
+
+### Completion Text
+
+Congratulations, you can center a thermal with only the vario.
+
+## Post-Tutorial Options
+
+After the basic tutorial, offer the user follow-up drills:
+
+- Try another random invisible thermal.
+- Repeat the same invisible thermal to compare attempts.
+- Enter pointed near the thermal center.
+- Enter offset toward the inner edge.
+- Enter offset toward the outer edge.
+- Cross through the middle from different approach angles.
+- Add wind, diameter variance, strength variance, and lumpiness in controlled steps.
+
+## Future Scenario Template
+
+### Stage Title
+
+TBD
+
+### Initial Heading
+
+TBD
+
+### Initial Explanation
+
+TBD
+
+### Initial Goal
+
+TBD
+
+### Flying Pop-Up Text
+
+TBD
+
+### Pause Heading
+
+TBD
+
+### Pause Explanation
+
+TBD
+
+### Pause Goal
+
+TBD
+
+### Practice Heading
+
+TBD
+
+### Practice Guidance Text
+
+TBD
+
+### Practice Goal
+
+TBD
+
+### Map View
+
+- Thermal visual: TBD.
+- Outer thermal boundary: TBD.
+- Concentric rings: TBD.
+- Ideal turn-rate marks: TBD.
+- Thermal Core widget: TBD.
+- Turn/bank inset: TBD.
+
+### Completion Text
+
+TBD

--- a/tools and analysis/thermal_detection/thermal_core_tutorial_script.md
+++ b/tools and analysis/thermal_detection/thermal_core_tutorial_script.md
@@ -1,357 +1,175 @@
-# Thermal Core Simulator Tutorial Script
+# Thermal Core Tutorial Script
 
-This document is the source-of-truth draft for tutorial wording and teaching flow in `thermal_core_game.html`. Edit this script first when adding or revising tutorial scenarios, then update the simulator implementation to match.
+Edit this script first, then update `website/public/labs/thermal-core-simulator/index.html` to match.
 
-## Script Fields
+During each step, keep the tutorial card text constant after the user starts. In-flight guidance should appear as map pop-ups, not as a second phase of tutorial-card text.
 
-Each tutorial stage should define:
+Whenever an in-flight vario guidance pop-up would be shown, net vario <= 0 overrides all prior guidance with **FIND LIFT**.
 
-- **Stage title**: Short label for the tutorial card.
-- **Initial heading**: Heading shown before the simulator starts the stage.
-- **Initial explanation**: Teaching text shown before the user presses Space.
-- **Initial goal**: The first measurable action, usually an entry or turn-start task.
-- **Flying pop-up text**: Temporary map text shown while the user is flying.
-- **Pause heading**: Heading shown when the simulator pauses for the next explanation.
-- **Pause explanation**: Teaching text shown before the user continues.
-- **Practice heading**: Heading shown during the main practice portion.
-- **Practice guidance text**: Dynamic or static text shown while the user practices.
-- **Practice goal**: Success criteria for completing the stage.
-- **Map view**: Thermal visual, rings, target turn-rate marks, and other aids shown or hidden.
-- **Completion text**: Text shown after the stage succeeds.
+## Repeated Three-Step Lesson
 
-## Shared Entry Sequence
+### Step 1
 
-### Initial Heading
+**Title:** Step 1: Find the "halfway point" into the thermal
 
-Start of stage
+**Directions:** Fly straight into the lift. Don't turn. When the vario peaks and then starts to decrease, you are about halfway through the core. That is the moment to start turning.
 
-### Initial Explanation
+**Goal:** Fly straight, wait for the vario to peak, then turn about 90 degrees.
 
-Fly straight into the lift. When the vario peaks and just begins to fade, you are about halfway through the core. That is the moment to start turning.
-
-### Initial Goal
-
-Wait for the vario peak, then turn about 90 degrees. Press Space bar to start.
-
-### Flying Pop-Up Text
-
-START TURNING NOW
+**Flying Pop Up:** START TURNING NOW
 
 Turn about 90 degrees
 
-### Trigger
+**Pop Up Trigger:** When the vario has exceeded 1.0 m/s, the run has lasted at least 6 seconds, and the current vario has dropped at least 0.25 m/s below the peak seen so far.
 
-Show the pop-up when the vario has exceeded 1.0 m/s, the run has lasted at least 6 seconds, and the current vario has dropped at least 0.25 m/s below the peak seen so far.
+**End Condition:** User has flown past a vario peak and turned >75 degrees.
 
-### Pause Trigger
+**Completion Text:** Good. You found the halfway point and started the turn soon after the vario peak.
 
-Pause after the user's heading changes by about 90 degrees from the heading at the pop-up.
+**UI:** Hide all turn-rate colors.
 
-## Stage 1: Center With Visual Help
+### Step 2
 
-### Initial Heading
+**Title:** Step 2: Turn around the center of the thermal
 
-1. Center with visual help
+**Directions:** Now the goal is to keep the vario constant. If it starts to drop, you are moving away from the center and need to tighten your turn. If it starts to increase, you are moving toward the center and need to widen your turn.
 
-### Initial Explanation
+**Goal:** Fly 2 consecutive smooth orbits around the thermal. Don't get too close to the center or the edge.
 
-Fly straight into the lift. When the vario peaks and just begins to fade, you are about halfway through the core. That is the moment to start turning.
+**Flying Pop Up:** Either 1 "VARIO STEADY - hold this turn rate" 2 "VARIO INCREASING - widen your turn to move away from the center" 3 "VARIO DECREASING - tighten your turn to keep closer to the center"
 
-### Initial Goal
+**Pop Up Trigger:** Either 1 [Vario not changing by more than .15m/s/s] 2 [vario increasing more than .15m/s/s] 3 [vario decreasing by more than .15m/s/s]
 
-First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start.
+**End Condition:** 2 consecutive successful orbits. [success criteria: user stayed within 10% and 75% of thermal radius for the orbits]
 
-### Pause Heading
+**Completion Text:** Good. You flew two centered orbits without drifting too close to the middle or the edge.
 
-Now center the thermal
+**UI:** Hide all turn-rate colors.
 
-### Pause Explanation
+### Step 3
 
-Now the goal is to keep the vario constant. If it starts to drop, you are moving away from the center and need to tighten your turn. If it starts to increase, you are moving toward the center and need to widen your turn. Try to fly a few orbits centered on the thermal.
+**Title:** Step 3: Optimize your turn rate
 
-### Pause Goal
+**Directions:** The green turn-rate bands show the efficient turning radius. Turning too steep will increase your descent rate, so don't stay in a steep turn for long. Try to center your circles around the thermal and stay as close to the optimal turn rate as you can.
 
-Press Space bar or Continue to begin the orbit practice.
+**Goal:** Fly 2 consecutive orbits staying near optimal turn-rate while staying centered on the thermal.
 
-### Practice Heading
+**Flying Pop Up:** Either 1 "CENTER THE THERMAL - listen to the vario changes and adjust your turns to line up with the circle center" 2 "SMOOTH OUT THE TURN - use a consistent turn rate near the optimum rate"
 
-1b. Center by sound
+**Trigger:** Either 1 [turn-rate is within 25% of target at least 75% of the orbit so far, but radius variation is more than 15% of thermal radius] 2 [radius variation is within 15% of thermal radius, but turn-rate is not within 25% of target at least 75% of the orbit so far]
 
-### Practice Guidance Text
+**End Condition:** 2 consecutive successful orbits where radius doesn't vary by more than 15% of the thermal radius, and turn-rate is within 25% of the target turn rate at least 75% of the time.
 
-Hold this turn and listen. If the beeps fade, tighten slightly. If they build, widen slightly.
+**Completion Text:** Good. You stayed centered while keeping the turn rate near the efficient range.
 
-Dynamic alternates:
+**Hint:** In Stage Two or Stage Three only, if the user has not completed this step after 1 minute, show a small Leaf-green "? tip" bubble above the turn-rate indicator. Clicking it pauses the sim and opens: "Pro Tip: Keep your ears on the vario beeping, and your eyes on the turn rate indicator. Try to generally hold near the optimum turn rate. If the vario starts to decrease, tighten your turn briefly until the vario feels roughly constant, then quickly come back to the optimum turn rate. If the vario starts to increase, widen your turn briefly until the vario feels roughly constant, then come back to the optimum turn rate. You're trying to make subtle shifts to your circles while holding near the optimum turn rate most of the time. By keeping your eyes on the turn rate, you're teaching yourself the exact same response you'll use when thermaling in a real paraglider." Dismissing the tip resumes the sim. For testing, pressing T forces the tip to appear.
 
-- Build a smooth turn with the arrow keys.
-- Lift is improving: widen slightly so your circle moves toward the core.
-- Lift is fading: tighten slightly to avoid sliding away from the core.
-- That orbit wandered too much. Re-center and try for two smoother laps.
+**UI:** Show turn-rate colors.
 
-### Practice Goal
+## Tutorial Stage One
 
-Complete 2 consecutive smooth orbits at any radius, with radial spread under 25% of the thermal diameter.
+**Card Title:** TUTORIAL STAGE ONE
 
-### Map View
+**Visual References:** Show fuzzy green thermal, outer boundary, and concentric rings.
 
-- Thermal visual: shown as fuzzy green blob.
-- Outer thermal boundary: shown.
-- Concentric rings: shown.
-- Ideal turn-rate marks: hidden.
-- Thermal Core widget: shown.
-- Turn/bank inset: shown.
+**Steps:** Run Step 1, Step 2, and Step 3.
 
-### Completion Text
+**After Step 3:** Great job, you centered the thermal at the optimum turn rate. Next, practice again without the visual circle help. The fuzzy green thermal is still shown, but rely on the vario sound for most of your guidance.
 
-Good. You used the vario trend and visual rings to move your circle toward the thermal center.
+## Tutorial Stage Two
 
-## Stage 2: Core At A Target Rate
+**Card Title:** TUTORIAL STAGE TWO
 
-### Initial Heading
+**Visual References:** Show fuzzy green thermal only. Hide outer boundary and concentric rings.
 
-2. Core at a target rate
+**Steps:** Run the exact same Step 1, Step 2, and Step 3.
 
-### Initial Explanation
+**After Step 3:** Now let's try again without any visual references. Just as in real-life paragliding, you'll only have the vario to guide you, so listen closely!
 
-This time the green target bands are back. They represent the nominal turn rate that gives an efficient target radius around the core.
+## Tutorial Stage Three
 
-### Initial Goal
+**Card Title:** TUTORIAL STAGE THREE
 
-First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start.
+**Visual References:** Hide thermal visual, outer boundary, and concentric rings.
 
-### Pause Heading
+**Steps:** Run the exact same Step 1, Step 2, and Step 3.
 
-Now core the thermal
+**After Step 3:** Congratulations, you used only the vario to core a thermal! Now you may want to try some of the free fly scenarios that add thermal variability and wind!
 
-### Pause Explanation
+## Tutorial Stage Four
 
-Now add the target turn-rate habit. Use vario changes to slide your circle onto the center, then return toward the green target band so the bank stays efficient.
+**Card Title:** TUTORIAL STAGE FOUR
 
-### Pause Goal
+**Theme:** Understanding Thermal Sizes
 
-Press Space bar or Continue to begin the orbit practice.
+### Step 1
 
-### Practice Heading
+**Title:** Understanding Thermal Sizes
 
-2b. Core at target rate
+**Directions:** The previous thermal we explored required us to fly straight into it for 7 to 8 seconds before we detected the middle using the vario peak. Count how many seconds it takes to find the middle of this thermal, then try to circle it like before.
 
-### Practice Guidance Text
+**Goal:** Fly straight, wait for the vario to peak, then turn about 90 degrees and try to stay in lift for 2 consecutive orbits.
 
-Use the green target bands as your home base. Tighten or widen just enough to move the circle, then settle back near the target.
+**Flying Pop Up:** START TURNING NOW
 
-Dynamic alternates:
+Turn about 90 degrees
 
-- Build a smooth turn with the arrow keys.
-- Lift is improving: widen slightly so your circle moves toward the core.
-- Lift is fading: tighten slightly to avoid sliding away from the core.
-- That orbit missed the target radius. Re-center, return to the green band, and try again.
+**Pop Up Trigger:** When the vario has exceeded 1.0 m/s, the run has lasted at least 6 seconds, and the current vario has dropped at least 0.25 m/s below the peak seen so far.
 
-### Practice Goal
+**Flow:** Continuous. After the user turns about 90 degrees, continue directly into orbit practice without pausing.
 
-Complete 2 consecutive target-radius orbits where maximum radial error is no more than +/-10% of the thermal diameter from the specific target radius implied by the target turn rate.
+**End Condition:** 2 consecutive successful orbits where the vario stays positive throughout each orbit.
 
-Target radius is:
+**Completion Text:** Great job coring a small thermal.  At this small size, it only took ~4 seconds between entering the thermal and finding the vario peak.  
 
-```text
-target radius = airspeed / target turn rate in radians per second
-```
+**UI:** Use an 80 m thermal. Show fuzzy green thermal, outer boundary, concentric rings, and turn-rate colors.
 
-### Map View
+### Step 2
 
-- Thermal visual: shown as fuzzy green blob.
-- Outer thermal boundary: shown.
-- Concentric rings: shown.
-- Ideal turn-rate marks: shown.
-- Thermal Core widget: shown.
-- Turn/bank inset: shown.
+**Title:** Step 2: Small thermal without circle guidance
 
-### Completion Text
+**Directions:** Try the same small thermal again, this time without the circle guidance. Use the fuzzy green thermal and the vario trend to stay in lift.  Remember to practice counting seconds until the peak to get a sense for how large a thermal might be.
 
-Good. You held a radius close to the target turn-rate circle.
+**Goal:** Fly straight, wait for the vario to peak, then turn about 90 degrees and try to stay in lift.
 
-## Stage 3: Center Without Rings
+**Flying Pop Up:** START TURNING NOW
 
-### Initial Heading
+Turn about 90 degrees
 
-3. Center without rings
+**Flow:** Continuous. After the user turns about 90 degrees, continue directly into orbit practice without pausing.
 
-### Initial Explanation
+**End Condition:** 2 consecutive successful orbits where the vario stays positive throughout each orbit, or a 3 minute timeout.
 
-Try the same entry and centering exercise again, but without the concentric rings. You still get the fuzzy green thermal shape, but the constant-vario path is no longer drawn for you.
+**Completion Text: (success)** Great job.  Without the guide rings, the same small lift takes more precise adjustments.
 
-### Initial Goal
+**Timeout Text:** Time limit reached. It's much harder to stay in lift when a thermal is small.
 
-First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start.
+**UI:** Use the same 80 m thermal setup. Show fuzzy green thermal and turn-rate colors. Hide outer boundary and concentric rings.
 
-### Pause Heading
+### Step 3
 
-Now center without rings
+**Title:** Step 3: Small thermal by vario only
 
-### Pause Explanation
+**Directions:** Now try the same small thermal with no visual help. In real flight, you only have the vario to go on.  For practice, keep counting seconds until the peak.  But eventually you'll start to get a "feel" for the size of the thermal without counting.
 
-Same idea: keep the vario as constant as possible. Fading beeps mean tighten; building beeps mean widen.
+**Goal:** Fly straight, wait for the vario to peak, then turn about 90 degrees and try to stay in lift.
 
-### Pause Goal
+**Flying Pop Up:** START TURNING NOW
 
-Press Space bar or Continue to begin the orbit practice.
+Turn about 90 degrees
 
-### Practice Heading
+**Flow:** Continuous. After the user turns about 90 degrees, continue directly into orbit practice without pausing.
 
-3b. Fuzzy-blob centering
+**End Condition:** 2 consecutive successful orbits where the vario stays positive throughout each orbit, or a 3 minute timeout.
 
-### Practice Guidance Text
+**Completion Text:** Great job!  This is a good lesson that a ~4 second thermal might be about the smallest you can stay in.  Any smaller and it might be worth passing by until you find a larger thermal.
 
-Use the sound first. Let the fuzzy thermal visual confirm what your ears are telling you.
+**Timeout Text:** Time limit reached. As your thermal skills improve, you may be able to stay in lift this small. But this is a good exercise to determine what thermals are worth turning in, and which ones might be worth passing by.
 
-Dynamic alternates:
+**UI:** Use the same 80 m thermal setup. Show turn-rate colors. Hide thermal visual, outer boundary, and concentric rings.
 
-- Build a smooth turn with the arrow keys.
-- Lift is improving: widen slightly so your circle moves toward the core.
-- Lift is fading: tighten slightly to avoid sliding away from the core.
-- That orbit wandered too much. Re-center and try for two smoother laps.
+## Follow-Up Free Fly
 
-### Practice Goal
-
-Complete 2 consecutive smooth orbits at any radius, with radial spread under 25% of the thermal diameter.
-
-### Map View
-
-- Thermal visual: shown as fuzzy green blob.
-- Outer thermal boundary: hidden.
-- Concentric rings: hidden.
-- Ideal turn-rate marks: shown.
-- Thermal Core widget: shown.
-- Turn/bank inset: shown.
-
-### Completion Text
-
-Good. You centered the thermal without the constant-radius guide rings.
-
-## Stage 4: Center By Vario Only
-
-### Initial Heading
-
-4. Center by vario only
-
-### Initial Explanation
-
-Final basic drill: the thermal visual is hidden. Fly the same technique using only the vario tone and the flight instruments.
-
-### Initial Goal
-
-First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start.
-
-### Pause Heading
-
-Now fly by sound only
-
-### Pause Explanation
-
-Trust the vario. If it fades, tighten. If it builds, widen. The goal is still a steady-radius circle centered on the lift.
-
-### Pause Goal
-
-Press Space bar or Continue to begin the orbit practice.
-
-### Practice Heading
-
-4b. Sound-only centering
-
-### Practice Guidance Text
-
-Listen for symmetry. Try to make each orbit sound boring and steady.
-
-Dynamic alternates:
-
-- Build a smooth turn with the arrow keys.
-- Lift is improving: widen slightly so your circle moves toward the core.
-- Lift is fading: tighten slightly to avoid sliding away from the core.
-- That orbit wandered too much. Re-center and try for two smoother laps.
-
-### Practice Goal
-
-Complete 2 consecutive smooth orbits at any radius, with radial spread under 25% of the thermal diameter.
-
-### Map View
-
-- Thermal visual: hidden.
-- Outer thermal boundary: hidden.
-- Concentric rings: hidden.
-- Ideal turn-rate marks: shown.
-- Thermal Core widget: shown.
-- Turn/bank inset: shown.
-
-### Completion Text
-
-Congratulations, you can center a thermal with only the vario.
-
-## Post-Tutorial Options
-
-After the basic tutorial, offer the user follow-up drills:
-
-- Try another random invisible thermal.
-- Repeat the same invisible thermal to compare attempts.
-- Enter pointed near the thermal center.
-- Enter offset toward the inner edge.
-- Enter offset toward the outer edge.
-- Cross through the middle from different approach angles.
-- Add wind, diameter variance, strength variance, and lumpiness in controlled steps.
-
-## Future Scenario Template
-
-### Stage Title
-
-TBD
-
-### Initial Heading
-
-TBD
-
-### Initial Explanation
-
-TBD
-
-### Initial Goal
-
-TBD
-
-### Flying Pop-Up Text
-
-TBD
-
-### Pause Heading
-
-TBD
-
-### Pause Explanation
-
-TBD
-
-### Pause Goal
-
-TBD
-
-### Practice Heading
-
-TBD
-
-### Practice Guidance Text
-
-TBD
-
-### Practice Goal
-
-TBD
-
-### Map View
-
-- Thermal visual: TBD.
-- Outer thermal boundary: TBD.
-- Concentric rings: TBD.
-- Ideal turn-rate marks: TBD.
-- Thermal Core widget: TBD.
-- Turn/bank inset: TBD.
-
-### Completion Text
-
-TBD
+- Easy default scenario loads when the page opens.
+- Medium, Hard, and Expert add thermal variability and wind.
+- Future drills: random invisible thermal, repeat same invisible thermal, center/edge entry offsets, and crossing entries from different approach angles.

--- a/website/public/labs/thermal-core-simulator/index.html
+++ b/website/public/labs/thermal-core-simulator/index.html
@@ -178,6 +178,19 @@
     font: inherit;
     font-weight: 700;
   }
+  .seed-row {
+    grid-template-columns: 1fr 96px auto;
+  }
+  .seed-row label {
+    grid-column: 1;
+  }
+  .seed-row input {
+    grid-column: 2;
+  }
+  .seed-row button {
+    grid-column: 3;
+    white-space: nowrap;
+  }
   button {
     appearance: none;
     border: 1px solid var(--border);
@@ -206,6 +219,23 @@
     color: #0b0d0b;
     background: var(--accent);
     border-color: var(--accent);
+  }
+  button:disabled,
+  input:disabled {
+    cursor: not-allowed;
+    opacity: 0.42;
+    filter: grayscale(0.9);
+  }
+  .tutorial-active .free-fly-card,
+  .tutorial-active .config-side .card:not(.audio-card) {
+    opacity: 0.48;
+  }
+  .tutorial-active #tutorialStart {
+    color: #0b0d0b;
+    background: var(--accent);
+    border-color: var(--accent);
+    opacity: 1;
+    filter: none;
   }
   .buttons {
     display: flex;
@@ -252,6 +282,38 @@
   }
   .tutorial-card[hidden] {
     display: none;
+  }
+  .tutorial-control-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .tutorial-stage-picker {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  body:not(.tutorial-active) .tutorial-stage-picker {
+    display: none;
+  }
+  .stage-arrow {
+    display: inline-grid;
+    place-items: center;
+    min-width: 30px;
+    width: 30px;
+    min-height: 30px;
+    padding: 0;
+    color: #0b0d0b;
+    background: var(--accent);
+    border-color: var(--accent);
+    font-size: 16px;
+  }
+  .stage-readout {
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 800;
+    text-transform: uppercase;
   }
   .tutorial-title {
     margin: 0 0 6px;
@@ -312,8 +374,7 @@
       display: contents;
     }
     .info-side .intro-card,
-    .info-side .scenario-card,
-    .info-side .trial-card,
+    .info-side .free-fly-card,
     .info-side .score-card,
     .info-side .trials-card {
       grid-column: 1 / -1;
@@ -360,24 +421,33 @@
       <p class="hint">Left/right arrows ramp turn rate. Hold Shift for faster trim. Space pauses. The seed makes the same thermal repeatable.</p>
     </section>
 
-    <section class="card scenario-card">
-      <h2>Scenario</h2>
+    <section class="card tutorial-start-card">
+      <h2>Guided Tutorial</h2>
+      <div class="tutorial-control-row">
+        <button id="tutorialStart" type="button">Start Tutorial</button>
+        <div class="tutorial-stage-picker">
+          <button id="tutorialPrevStage" class="stage-arrow" type="button" aria-label="Previous tutorial stage">&lt;</button>
+          <span id="tutorialStageReadout" class="stage-readout">Stage 1 of 3</span>
+          <button id="tutorialNextStage" class="stage-arrow" type="button" aria-label="Next tutorial stage">&gt;</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="card free-fly-card">
+      <h2>Free Fly Trials</h2>
+      <div class="row">
+        <span class="label">Difficulty presets</span>
+      </div>
       <div class="buttons">
         <button class="preset" type="button" data-preset="easy">Easy</button>
         <button class="preset" type="button" data-preset="medium">Med</button>
         <button class="preset" type="button" data-preset="hard">Hard</button>
         <button class="preset" type="button" data-preset="expert">Expert</button>
       </div>
-      <div class="buttons">
-        <button id="tutorialStart" type="button">Start Tutorial</button>
-      </div>
-    </section>
-
-    <section class="card trial-card">
-      <h2>Trial</h2>
-      <div class="row">
+      <div class="row seed-row">
         <label for="seed">Seed</label>
         <input id="seed" type="number" value="2641" step="1">
+        <button id="newSeed" type="button">New seed</button>
       </div>
       <div class="row">
         <label for="duration">Duration</label><output id="durationOut"></output>
@@ -387,7 +457,6 @@
         <button id="start" class="primary" type="button">Start</button>
         <button id="reset" type="button">Reset</button>
         <button id="same" type="button">Repeat</button>
-        <button id="newSeed" type="button">New seed</button>
       </div>
     </section>
 
@@ -412,19 +481,16 @@
 
   <section class="stage">
     <section id="tutorialCard" class="card tutorial-card" hidden>
-      <h2>Tutorial</h2>
+      <h2 id="tutorialStageTitle">Tutorial</h2>
       <p id="tutorialTitle" class="tutorial-title"></p>
       <p id="tutorialMessage" class="tutorial-message"></p>
       <p id="tutorialGoal" class="tutorial-goal"></p>
-      <div class="buttons">
-        <button id="tutorialContinue" class="primary" type="button">Continue</button>
-      </div>
     </section>
     <canvas id="sim" width="980" height="680" aria-label="Thermal core simulator"></canvas>
   </section>
 
   <aside class="side config-side">
-    <section class="card">
+    <section class="card audio-card">
       <h2>Audio</h2>
       <div class="row">
         <label for="volume">Vario volume</label><output id="volumeOut"></output>
@@ -500,10 +566,13 @@ const ui = {
   testTone: document.getElementById("testTone"),
   tutorialStart: document.getElementById("tutorialStart"),
   tutorialCard: document.getElementById("tutorialCard"),
+  tutorialStageTitle: document.getElementById("tutorialStageTitle"),
+  tutorialPrevStage: document.getElementById("tutorialPrevStage"),
+  tutorialNextStage: document.getElementById("tutorialNextStage"),
+  tutorialStageReadout: document.getElementById("tutorialStageReadout"),
   tutorialTitle: document.getElementById("tutorialTitle"),
   tutorialMessage: document.getElementById("tutorialMessage"),
   tutorialGoal: document.getElementById("tutorialGoal"),
-  tutorialContinue: document.getElementById("tutorialContinue"),
   durationOut: document.getElementById("durationOut"),
   windOut: document.getElementById("windOut"),
   diameterOut: document.getElementById("diameterOut"),
@@ -523,6 +592,7 @@ const ui = {
 const leafScreenW = 96;
 const leafScreenH = 192;
 const maxTurnRateDps = 30;
+const nominalTargetTurnRateDps = 20;
 const baseAirspeed = 10.0;
 const dt = 1 / 60;
 const coreLookbackS = 40;
@@ -540,7 +610,9 @@ let lastFrame = performance.now();
 let accumulator = 0;
 let trials = [];
 let keys = new Set();
-let activeTargetTurnRateDps = 19;
+let activeTargetTurnRateDps = nominalTargetTurnRateDps;
+let corePrototypeVisible = false;
+let corePrototypeHeaderRect = null;
 let tutorial = {
   active: false,
   step: 0,
@@ -556,83 +628,197 @@ let tutorial = {
   orbitMinRadius: Infinity,
   orbitMaxRadius: 0,
   orbitMaxError: 0,
+  orbitMinVario: Infinity,
+  orbitTime: 0,
+  orbitTargetTime: 0,
   orbitLastBearing: null,
   lastOrbitFailed: false,
-  lastInstruction: ""
+  lastInstruction: "",
+  stepStartedAt: 0,
+  hintOpen: false,
+  hintBubbleRect: null,
+  hintBoxRect: null,
+  hintPausedRun: false,
+  hintForced: false,
+  userPaused: false
 };
 
-const tutorialSteps = [
+const stageConfigs = [
   {
-    title: "1. Center with visual help",
-    briefTitle: "Now center the thermal",
-    practiceTitle: "1b. Center by sound",
-    completeTitle: "Visual centering complete",
+    title: "TUTORIAL STAGE ONE",
     showThermal: true,
     showRings: true,
-    showTargetMarkers: false,
-    targetRadius: false,
-    intro:
-      "Fly straight into the lift. When the vario peaks and just begins to fade, you are about halfway through the core. That is the moment to start turning.",
-    brief:
-      "Now the goal is to keep the vario constant. If it starts to drop, you are moving away from the center and need to tighten your turn. If it starts to increase, you are moving toward the center and need to widen your turn. Try to fly a few orbits centered on the thermal.",
-    practice:
-      "Hold this turn and listen. If the beeps fade, tighten slightly. If they build, widen slightly.",
-    complete:
-      "Good. You used the vario trend and visual rings to move your circle toward the thermal center."
+    visualHelp: "Show fuzzy green thermal, outer boundary, and concentric rings.",
+    stageComplete:
+      "Great job, you centered the thermal at the optimum turn rate. Next, practice again without the visual circle help. The fuzzy green thermal is still shown, but rely on the vario sound for most of your guidance."
   },
   {
-    title: "2. Core at a target rate",
-    briefTitle: "Now core the thermal",
-    practiceTitle: "2b. Core at target rate",
-    completeTitle: "Target-rate coring complete",
-    showThermal: true,
-    showRings: true,
-    showTargetMarkers: true,
-    targetRadius: true,
-    intro:
-      "This time the green target bands are back. They represent the nominal turn rate that gives an efficient target radius around the core.",
-    brief:
-      "Now add the target turn-rate habit. Use vario changes to slide your circle onto the center, then return toward the green target band so the bank stays efficient.",
-    practice:
-      "Use the green target bands as your home base. Tighten or widen just enough to move the circle, then settle back near the target.",
-    complete:
-      "Good. You held a radius close to the target turn-rate circle."
-  },
-  {
-    title: "3. Center without rings",
-    briefTitle: "Now center without rings",
-    practiceTitle: "3b. Fuzzy-blob centering",
-    completeTitle: "Blob-only centering complete",
+    title: "TUTORIAL STAGE TWO",
     showThermal: true,
     showRings: false,
-    showTargetMarkers: true,
-    targetRadius: false,
-    intro:
-      "Try the same entry and centering exercise again, but without the concentric rings. You still get the fuzzy green thermal shape, but the constant-vario path is no longer drawn for you.",
-    brief:
-      "Same idea: keep the vario as constant as possible. Fading beeps mean tighten; building beeps mean widen.",
-    practice:
-      "Use the sound first. Let the fuzzy thermal visual confirm what your ears are telling you.",
-    complete:
-      "Good. You centered the thermal without the constant-radius guide rings."
+    visualHelp: "Show fuzzy green thermal only. Hide outer boundary and concentric rings.",
+    stageComplete:
+      "Now let's try again without any visual references. Just as in real-life paragliding, you'll only have the vario to guide you, so listen closely!"
   },
   {
-    title: "4. Center by vario only",
-    briefTitle: "Now fly by sound only",
-    practiceTitle: "4b. Sound-only centering",
-    completeTitle: "Sound-only centering complete",
+    title: "TUTORIAL STAGE THREE",
     showThermal: false,
     showRings: false,
-    showTargetMarkers: true,
-    targetRadius: false,
-    intro:
-      "Final basic drill: the thermal visual is hidden. Fly the same technique using only the vario tone and the flight instruments.",
-    brief:
-      "Trust the vario. If it fades, tighten. If it builds, widen. The goal is still a steady-radius circle centered on the lift.",
-    practice:
-      "Listen for symmetry. Try to make each orbit sound boring and steady.",
+    visualHelp: "Hide thermal visual, outer boundary, and concentric rings.",
+    stageComplete:
+      "Congratulations, you used only the vario to core a thermal! Now you may want to try some of the free fly scenarios that add thermal variability and wind!"
+  },
+  {
+    title: "TUTORIAL STAGE FOUR",
+    showThermal: true,
+    showRings: true,
+    visualHelp: "Use an 80 m thermal and progressively remove visual help.",
+    stageComplete:
+      "Good experiment. Small lift can make the vario beep, but it may not be large enough to justify circling."
+  }
+];
+
+const baseTutorialSteps = [
+  {
+    title: 'Step 1: Find the "halfway point" into the thermal',
+    practiceTitle: "Step 1: Find the halfway point",
+    completeTitle: "Halfway point found",
+    showTargetMarkers: false,
+    successType: "entryTurn",
+    directions:
+      "Fly straight into the lift. Don't turn. When the vario peaks and then starts to decrease, you are about halfway through the core. That is the moment to start turning.",
+    goal:
+      "Goal: fly straight, wait for the vario to peak, then turn about 90 degrees. Press Space bar to start.",
     complete:
-      "Congratulations, you can center a thermal with only the vario."
+      "Good. You found the halfway point and started the turn soon after the vario peak."
+  },
+  {
+    title: "Step 2: Turn around the center of the thermal",
+    practiceTitle: "Step 2: Turn around the center",
+    completeTitle: "Centered orbits complete",
+    showTargetMarkers: false,
+    successType: "radiusBand",
+    directions:
+      "Now the goal is to keep the vario constant. If it starts to drop, you are moving away from the center and need to tighten your turn. If it starts to increase, you are moving toward the center and need to widen your turn.",
+    goal:
+      "Goal: fly 2 consecutive smooth orbits around the thermal. Don't get too close to the center or the edge.",
+    complete:
+      "Good. You flew two centered orbits without drifting too close to the middle or the edge."
+  },
+  {
+    title: "Step 3: Optimize your turn rate",
+    practiceTitle: "Step 3: Optimize your turn rate",
+    completeTitle: "Optimized turn-rate complete",
+    showTargetMarkers: true,
+    successType: "optimizedTurn",
+    directions:
+      "The green turn-rate bands show the efficient turning radius. Turning too steep will increase your descent rate, so don't stay in a steep turn for long. Try to center your circles around the thermal and stay as close to the optimal turn rate as you can.",
+    goal:
+      "Goal: fly 2 consecutive orbits staying near optimal turn-rate while staying centered on the thermal.",
+    complete:
+      "Good. You stayed centered while keeping the turn rate near the efficient range."
+  }
+];
+
+const repeatedTutorialSteps = stageConfigs.slice(0, 3).flatMap((stage, stageIndex) =>
+  baseTutorialSteps.map((step, stepIndex) => ({
+    ...step,
+    stageIndex,
+    stepInStage: stepIndex,
+    stageTitle: stage.title,
+    showThermal: stage.showThermal,
+    showRings: stage.showRings,
+    visualHelp: stage.visualHelp,
+    stageComplete: stage.stageComplete
+  }))
+);
+
+const tutorialSteps = [
+  ...repeatedTutorialSteps,
+  {
+    title: "Understanding Thermal Sizes",
+    practiceTitle: "Step 1: Circle the small thermal",
+    completeTitle: "Small thermal with visual help complete",
+    showTargetMarkers: true,
+    successType: "thermalSize",
+    diameterM: 80,
+    resetOnEnter: true,
+    stageIndex: 3,
+    stepInStage: 0,
+    stageTitle: stageConfigs[3].title,
+    showThermal: true,
+    showRings: true,
+    visualHelp: stageConfigs[3].visualHelp,
+    stageComplete: stageConfigs[3].stageComplete,
+    directions:
+      "The previous thermal we explored required us to fly straight into it for 7 to 8 seconds before we detected the middle using the vario peak. Count how many seconds it takes to find the middle of this thermal, then try to circle it like before.",
+    goal:
+      "Goal: fly straight, wait for the vario to peak, then turn about 90 degrees and try to stay in lift for 2 consecutive orbits. Press Space bar to start.",
+    practiceDirections:
+      "Now try to circle this small thermal like before. The goal is not a perfect centered turn; just see whether you can stay in lift for 2 full orbits.",
+    practiceGoal:
+      "Goal: fly 2 consecutive orbits without leaving the lift.",
+    complete:
+      "Great job coring a small thermal. At this small size, it only took ~4 seconds between entering the thermal and finding the vario peak."
+  },
+  {
+    title: "Step 2: Small thermal without circle guidance",
+    practiceTitle: "Step 2: Fuzzy thermal only",
+    completeTitle: "Fuzzy-only small thermal complete",
+    showTargetMarkers: true,
+    successType: "thermalSize",
+    diameterM: 80,
+    timeoutSeconds: 180,
+    resetOnEnter: true,
+    stageIndex: 3,
+    stepInStage: 1,
+    stageTitle: stageConfigs[3].title,
+    showThermal: true,
+    showRings: false,
+    visualHelp: "Show fuzzy green thermal only. Hide outer boundary and concentric rings.",
+    stageComplete: stageConfigs[3].stageComplete,
+    directions:
+      "Try the same small thermal again, this time without the circle guidance. Use the fuzzy green thermal and the vario trend to stay in lift. Remember to practice counting seconds until the peak to get a sense for how large a thermal might be.",
+    goal:
+      "Goal: fly straight, wait for the vario to peak, then turn about 90 degrees and try to stay in lift. Press Space bar to start.",
+    practiceDirections:
+      "Now try to circle the small thermal using the fuzzy thermal shape and the vario. If it is too small to hold cleanly, keep flying and notice how quickly the lift fades.",
+    practiceGoal:
+      "Goal: fly 2 consecutive orbits without leaving the lift, or continue for 3 minutes.",
+    complete:
+      "Great job. Without the guide rings, the same small lift takes more precise adjustments.",
+    timeoutComplete:
+      "Time limit reached. It's much harder to stay in lift when a thermal is small."
+  },
+  {
+    title: "Step 3: Small thermal by vario only",
+    practiceTitle: "Step 3: Vario-only small thermal",
+    completeTitle: "Vario-only small thermal complete",
+    showTargetMarkers: true,
+    successType: "thermalSize",
+    diameterM: 80,
+    timeoutSeconds: 180,
+    resetOnEnter: true,
+    stageIndex: 3,
+    stepInStage: 2,
+    stageTitle: stageConfigs[3].title,
+    showThermal: false,
+    showRings: false,
+    visualHelp: "Hide thermal visual, outer boundary, and concentric rings.",
+    stageComplete: stageConfigs[3].stageComplete,
+    stageEndUsesStepComplete: true,
+    directions:
+      "Now try the same small thermal with no visual help. In real flight, you only have the vario to go on. For practice, keep counting seconds until the peak. But eventually you'll start to get a \"feel\" for the size of the thermal without counting.",
+    goal:
+      "Goal: fly straight, wait for the vario to peak, then turn about 90 degrees and try to stay in lift. Press Space bar to start.",
+    practiceDirections:
+      "Circle by sound only. If the lift fades too quickly to hold, that is the lesson: some thermals are real, but still too small to use.",
+    practiceGoal:
+      "Goal: fly 2 consecutive orbits without leaving the lift, or continue for 3 minutes.",
+    complete:
+      "Great job! This is a good lesson that a ~4 second thermal might be about the smallest you can stay in. Any smaller and it might be worth passing by until you find a larger thermal.",
+    timeoutComplete:
+      "Time limit reached. As your thermal skills improve, you may be able to stay in lift this small. But this is a good exercise to determine what thermals are worth turning in, and which ones might be worth passing by."
   }
 ];
 
@@ -648,7 +834,7 @@ const thermalPresets = {
     strengthVariance: 0,
     texture: 0,
     sink: 1,
-    targetTurnRate: 15
+    targetTurnRate: nominalTargetTurnRateDps
   },
   medium: {
     showThermal: true,
@@ -659,7 +845,7 @@ const thermalPresets = {
     strengthVariance: 15,
     texture: 15,
     sink: 1,
-    targetTurnRate: 17
+    targetTurnRate: nominalTargetTurnRateDps
   },
   hard: {
     showThermal: false,
@@ -670,7 +856,7 @@ const thermalPresets = {
     strengthVariance: 30,
     texture: 30,
     sink: 1,
-    targetTurnRate: 19
+    targetTurnRate: nominalTargetTurnRateDps
   },
   expert: {
     showThermal: false,
@@ -681,7 +867,7 @@ const thermalPresets = {
     strengthVariance: 50,
     texture: 50,
     sink: 1,
-    targetTurnRate: 21
+    targetTurnRate: nominalTargetTurnRateDps
   }
 };
 
@@ -818,7 +1004,7 @@ function newSeed() {
   resetTrial(seed);
 }
 
-function applyThermalPreset(name) {
+function applyThermalPreset(name, resetIdleState = true) {
   const preset = thermalPresets[name];
   if (!preset) return;
   ui.showThermal.checked = preset.showThermal;
@@ -833,18 +1019,38 @@ function applyThermalPreset(name) {
   document.querySelectorAll(".preset").forEach(button => {
     button.setAttribute("aria-pressed", button.dataset.preset === name ? "true" : "false");
   });
-  if (!state.running) {
+  if (resetIdleState && !state.running) {
     state = freshState(Number(ui.seed.value));
   }
   updateOutputs();
 }
 
-function setTutorialText(title, message, goal = "", canContinue = false) {
+function setTutorialText(title, message, goal = "") {
+  const lesson = tutorialSteps[tutorial.step];
   ui.tutorialCard.hidden = !tutorial.active;
+  ui.tutorialStageTitle.textContent = lesson?.stageTitle || "Tutorial";
+  updateTutorialStageControls();
   ui.tutorialTitle.textContent = title;
   ui.tutorialMessage.textContent = message;
   ui.tutorialGoal.textContent = goal;
-  ui.tutorialContinue.hidden = !canContinue;
+}
+
+function updateTutorialStageControls() {
+  const lesson = tutorialSteps[tutorial.step];
+  const stageIndex = lesson?.stageIndex ?? 0;
+  ui.tutorialStageReadout.textContent = `Stage ${stageIndex + 1} of ${stageConfigs.length}`;
+  ui.tutorialPrevStage.disabled = stageIndex <= 0;
+  ui.tutorialNextStage.disabled = stageIndex >= stageConfigs.length - 1;
+}
+
+function setTutorialUiLocked(locked) {
+  document.body.classList.toggle("tutorial-active", locked);
+  const allowed = new Set(["tutorialStart", "tutorialPrevStage", "tutorialNextStage", "volume", "testTone"]);
+  document.querySelectorAll("button, input").forEach(control => {
+    control.disabled = locked && !allowed.has(control.id);
+  });
+  ui.tutorialStart.classList.toggle("primary", locked);
+  if (locked) updateTutorialStageControls();
 }
 
 function resetTutorialOrbitProgress() {
@@ -854,47 +1060,81 @@ function resetTutorialOrbitProgress() {
   tutorial.orbitMinRadius = Infinity;
   tutorial.orbitMaxRadius = 0;
   tutorial.orbitMaxError = 0;
+  tutorial.orbitMinVario = Infinity;
+  tutorial.orbitTime = 0;
+  tutorial.orbitTargetTime = 0;
   tutorial.orbitLastBearing = null;
   tutorial.lastOrbitFailed = false;
 }
 
+function firstTutorialStepForStage(stageIndex) {
+  const stepIndex = tutorialSteps.findIndex(step => step.stageIndex === stageIndex);
+  return stepIndex >= 0 ? stepIndex : 0;
+}
+
+function isLastTutorialStepInStage(stepIndex) {
+  const lesson = tutorialSteps[stepIndex];
+  const nextLesson = tutorialSteps[stepIndex + 1];
+  return !nextLesson || nextLesson.stageIndex !== lesson.stageIndex;
+}
+
 function tutorialGoalText(metrics = null) {
   const lesson = tutorialSteps[tutorial.step] || tutorialSteps[0];
-  if (!metrics) {
-    return lesson.targetRadius
-      ? "Goal: complete 2 consecutive orbits within +/-10% of the thermal diameter from the target turn-rate radius."
-      : "Goal: complete 2 consecutive smooth orbits at any radius, with radial spread under 25% of the thermal diameter.";
+  if (!metrics) return lesson.goal;
+  if (lesson.successType === "radiusBand") {
+    return `Goal progress: ${tutorial.orbitCount}/2 centered orbits. Radius range: ${Math.round(metrics.minRadius)}-${Math.round(metrics.maxRadius)}m.`;
   }
-  if (lesson.targetRadius) {
-    return `Goal progress: ${tutorial.orbitCount}/2 target-radius orbits. Max radius error: ${Math.round(metrics.error)}m / ${Math.round(metrics.allowedError)}m.`;
+  if (lesson.successType === "optimizedTurn") {
+    return `Goal progress: ${tutorial.orbitCount}/2 optimized orbits. Spread: ${Math.round(metrics.spread)}m / ${Math.round(metrics.allowedSpread)}m. Target-rate time: ${Math.round(metrics.targetRatio * 100)}%.`;
+  }
+  if (lesson.successType === "thermalSize") {
+    const timeoutText = lesson.timeoutSeconds
+      ? ` Time limit: ${Math.max(0, Math.ceil(lesson.timeoutSeconds - (state.t - tutorial.stepStartedAt)))}s.`
+      : "";
+    return `Goal progress: ${tutorial.orbitCount}/2 lift orbits. Weakest vario this orbit: ${metrics.minVario.toFixed(1)} m/s.${timeoutText}`;
   }
   return `Goal progress: ${tutorial.orbitCount}/2 smooth orbits. Current radius spread: ${Math.round(metrics.spread)}m / ${Math.round(metrics.allowedSpread)}m.`;
 }
 
-function configureTutorialStep(step) {
+function configureTutorialStep(step, resetState = true) {
   const lesson = tutorialSteps[step] || tutorialSteps[0];
   tutorial.step = step;
-  tutorial.phase = "entry";
+  tutorial.phase = ["entryTurn", "thermalSize"].includes(lesson.successType) ? "entry" : "ready-practice";
   tutorial.pauseForCallout = false;
   tutorial.turnPromptHeading = null;
   tutorial.peakVario = -Infinity;
   resetTutorialOrbitProgress();
   tutorial.lastInstruction = "";
-  applyThermalPreset("easy");
+  tutorial.stepStartedAt = state.t;
+  tutorial.hintOpen = false;
+  tutorial.hintPausedRun = false;
+  tutorial.hintForced = false;
+  tutorial.userPaused = false;
+  applyThermalPreset("easy", false);
+  if (lesson.diameterM) ui.diameter.value = lesson.diameterM;
   ui.showThermal.checked = lesson.showThermal;
   tutorial.showThermalRings = lesson.showRings;
   tutorial.showTargetMarkers = lesson.showTargetMarkers;
   ui.duration.value = 480;
-  state = freshState(Number(ui.seed.value));
+  if (resetState) state = freshState(Number(ui.seed.value));
   state.running = false;
   state.finished = false;
   ui.start.textContent = "Start";
   updateOutputs();
   setTutorialText(
     lesson.title,
-    lesson.intro,
-    "First goal: wait for the peak, then turn about 90 degrees. Press Space bar to start."
+    lesson.directions,
+    lesson.goal.includes("Press Space") ? lesson.goal : `${lesson.goal} Press Space bar to start.`
   );
+}
+
+function jumpTutorialStage(delta) {
+  if (!tutorial.active) return;
+  const current = tutorialSteps[tutorial.step] || tutorialSteps[0];
+  const nextStage = clamp(current.stageIndex + delta, 0, stageConfigs.length - 1);
+  if (nextStage === current.stageIndex) return;
+  configureTutorialStep(firstTutorialStepForStage(nextStage), true);
+  setTutorialUiLocked(true);
 }
 
 function startTutorial() {
@@ -902,16 +1142,22 @@ function startTutorial() {
   ui.tutorialCard.hidden = false;
   ui.tutorialStart.textContent = "Exit Tutorial";
   configureTutorialStep(0);
+  setTutorialUiLocked(true);
 }
 
 function exitTutorial() {
   tutorial.active = false;
   tutorial.showTargetMarkers = true;
   tutorial.showThermalRings = true;
+  tutorial.hintOpen = false;
+  tutorial.hintPausedRun = false;
+  tutorial.hintForced = false;
   ui.tutorialCard.hidden = true;
   ui.tutorialStart.textContent = "Start Tutorial";
   state.running = false;
   ui.start.textContent = "Start";
+  tutorial.userPaused = false;
+  setTutorialUiLocked(false);
   stopAudioTone();
 }
 
@@ -919,32 +1165,37 @@ function continueTutorial() {
   if (!tutorial.active) return;
   const lesson = tutorialSteps[tutorial.step] || tutorialSteps[0];
   tutorial.pauseForCallout = false;
-  if (tutorial.phase === "centering-brief") {
-    tutorial.phase = lesson.targetRadius ? "coring" : "centering";
+  if (tutorial.phase === "ready-practice") {
+    tutorial.phase = "practice";
     resetTutorialOrbitProgress();
     tutorial.lastInstruction = "";
+    tutorial.stepStartedAt = state.t;
+    tutorial.hintOpen = false;
+    tutorial.hintPausedRun = false;
+    tutorial.hintForced = false;
+    tutorial.userPaused = false;
     state.running = true;
     ui.start.textContent = "Pause";
-    setTutorialText(
-      lesson.practiceTitle,
-      lesson.practice,
-      tutorialGoalText()
-    );
     return;
   }
   if (tutorial.phase === "step-complete") {
-    if (tutorial.step < tutorialSteps.length - 1) configureTutorialStep(tutorial.step + 1);
+    if (tutorial.step < tutorialSteps.length - 1) {
+      const nextStep = tutorial.step + 1;
+      configureTutorialStep(nextStep, tutorialSteps[nextStep]?.stepInStage === 0 || tutorialSteps[nextStep]?.resetOnEnter);
+    }
     else {
       setTutorialText(
         "Tutorial complete",
-        "Congratulations, you can center a thermal with only the vario.",
-        "Next: try more random invisible thermals, then practice different entries such as aimed at the center, offset toward the edge, or crossing through the middle.",
+        lesson.stageComplete,
+        "Try Easy, Medium, Hard, or Expert in Free Fly Scenario.",
         false
       );
       tutorial.active = false;
       ui.tutorialStart.textContent = "Start Tutorial";
       state.running = false;
+      tutorial.userPaused = false;
       ui.start.textContent = "Start";
+      setTutorialUiLocked(false);
     }
   }
 }
@@ -1025,8 +1276,13 @@ async function unlockAudio(warmup = false) {
 
 async function toggleRun() {
   await unlockAudio(true);
+  if (tutorial.active && tutorial.phase === "ready-practice" && !state.running) {
+    continueTutorial();
+    return;
+  }
   if (state.finished) resetTrial(state.seed);
   state.running = !state.running;
+  if (tutorial.active) tutorial.userPaused = !state.running;
   ui.start.textContent = state.running ? "Pause" : "Start";
 }
 
@@ -1147,75 +1403,82 @@ function updateTutorial(stepDt) {
     if (tutorial.peakVario > 1.0 && state.t > 6 && state.vario < tutorial.peakVario - 0.25) {
       tutorial.phase = "turn-callout";
       tutorial.turnPromptHeading = state.heading;
-      setTutorialText(
-        tutorial.step === 0 ? "Start turning now" : "Turn now",
-        "The vario just peaked and began to fade. You have crossed into the useful part of the thermal. Start a smooth turn now.",
-        "First goal: turn about 90 degrees soon after the peak."
-      );
     }
     return;
   }
 
   if (tutorial.phase === "turn-callout") {
-    if (tutorial.turnPromptHeading != null && Math.abs(angleDeltaDeg(tutorial.turnPromptHeading, state.heading)) >= 90) {
-      tutorial.phase = "centering-brief";
+    if (tutorial.turnPromptHeading != null && Math.abs(angleDeltaDeg(tutorial.turnPromptHeading, state.heading)) >= 75) {
       tutorial.turnPromptHeading = null;
       tutorial.pauseForCallout = true;
       state.running = false;
+      tutorial.userPaused = false;
       ui.start.textContent = "Start";
+      if (lesson.successType === "thermalSize") {
+        tutorial.phase = "practice";
+        tutorial.pauseForCallout = false;
+        resetTutorialOrbitProgress();
+        tutorial.lastInstruction = "";
+        tutorial.stepStartedAt = state.t;
+        state.running = true;
+        ui.start.textContent = "Pause";
+        return;
+      }
+      tutorial.phase = "step-complete";
       setTutorialText(
-        lesson.briefTitle,
-        lesson.brief,
-        "Press Space bar or Continue to begin the orbit practice.",
-        true
+        lesson.completeTitle,
+        lesson.complete,
+        "Press Space to continue."
       );
     }
     return;
   }
 
   const recent = state.varioTrace.slice(-50);
-  const varioTrend = recent.length >= 2 ? recent[recent.length - 1].v - recent[0].v : 0;
-  if (tutorial.phase === "centering" || tutorial.phase === "coring") {
-    let instruction = "Hold this turn and listen for a steady beep.";
-    if (Math.abs(state.turnRate) < 6) {
-      instruction = "Build a smooth turn with the arrow keys.";
-    } else if (varioTrend > 0.18) {
-      instruction = "Lift is improving: widen slightly so your circle moves toward the core.";
-    } else if (varioTrend < -0.18) {
-      instruction = "Lift is fading: tighten slightly to avoid sliding away from the core.";
-    }
-    const orbit = updateTutorialOrbitProgress(readParams());
-    if (orbit.failed) {
-      instruction = lesson.targetRadius
-        ? "That orbit missed the target radius. Re-center, return to the green band, and try again."
-        : "That orbit wandered too much. Re-center and try for two smoother laps.";
-    }
-
-    if (instruction !== tutorial.lastInstruction || orbit.changed) {
+  const elapsed = recent.length >= 2 ? Math.max(0.1, recent[recent.length - 1].t - recent[0].t) : 1;
+  const varioTrend = recent.length >= 2 ? (recent[recent.length - 1].v - recent[0].v) / elapsed : 0;
+  if (tutorial.phase === "practice") {
+    if (state.vario <= 0) {
+      tutorial.lastInstruction = "FIND LIFT";
+    } else if (["radiusBand", "thermalSize"].includes(lesson.successType)) {
+      let instruction;
+      if (varioTrend > 0.15) instruction = "VARIO INCREASING - widen your turn to move away from the center.";
+      else if (varioTrend < -0.15) instruction = "VARIO DECREASING - tighten your turn to keep closer to the center.";
+      else instruction = "VARIO STEADY - hold this turn rate.";
       tutorial.lastInstruction = instruction;
-      setTutorialText(
-        lesson.practiceTitle,
-        instruction,
-        tutorialGoalText(orbit)
-      );
+    }
+    const orbit = updateTutorialOrbitProgress(readParams(), stepDt);
+    const timedOut = lesson.timeoutSeconds && state.t - tutorial.stepStartedAt >= lesson.timeoutSeconds;
+    if (lesson.successType === "optimizedTurn" && state.vario > 0) {
+      const centeredEnough = orbit.spread <= orbit.allowedSpread;
+      const turnRateGood = orbit.targetRatio >= 0.75;
+      if (!centeredEnough && turnRateGood) {
+        tutorial.lastInstruction = "CENTER THE THERMAL - listen to the vario changes and adjust your turns to line up with the circle center.";
+      } else if (centeredEnough && !turnRateGood) {
+        tutorial.lastInstruction = "SMOOTH OUT THE TURN - use a consistent turn rate near the optimum rate.";
+      } else {
+        tutorial.lastInstruction = "";
+      }
     }
 
-    if (tutorial.orbitCount >= 2) {
+    if (tutorial.orbitCount >= 2 || timedOut) {
       tutorial.phase = "step-complete";
       tutorial.pauseForCallout = true;
       state.running = false;
       ui.start.textContent = "Start";
+      const useStageComplete = isLastTutorialStepInStage(tutorial.step) && !lesson.stageEndUsesStepComplete;
       setTutorialText(
-        lesson.completeTitle,
-        lesson.complete,
-        tutorial.step < tutorialSteps.length - 1 ? "Press Continue for the next drill." : "Press Continue to finish.",
-        true
+        useStageComplete ? lesson.stageTitle : lesson.completeTitle,
+        timedOut
+          ? lesson.timeoutComplete || "Time limit reached. That still counts here: the point is learning when lift is too small or fleeting to be worth circling."
+          : useStageComplete ? lesson.stageComplete : lesson.complete,
+        tutorial.step < tutorialSteps.length - 1 ? "Press Space to continue." : "Press Space to finish."
       );
     }
   }
 }
 
-function updateTutorialOrbitProgress(params) {
+function updateTutorialOrbitProgress(params, stepDt) {
   const lesson = tutorialSteps[tutorial.step] || tutorialSteps[0];
   const center = thermalCenterAt(state.t, state.z, params);
   const profile = thermalProfileAt(state.t, state.z, params);
@@ -1224,19 +1487,24 @@ function updateTutorialOrbitProgress(params) {
   const radius = Math.hypot(dx, dy);
   const bearing = (Math.atan2(dx, dy) * 180 / Math.PI + 360) % 360;
   const allowedSpread = profile.radius * 2 * 0.25;
+  const optimizedAllowedSpread = profile.radius * 0.15;
   const targetRadius = baseAirspeed / Math.max(0.01, activeTargetTurnRateDps * Math.PI / 180);
   const allowedError = profile.radius * 2 * 0.10;
   const radiusError = Math.abs(radius - targetRadius);
+  const turnRateTargetGood = Math.abs(Math.abs(state.turnRate) - activeTargetTurnRateDps) <= activeTargetTurnRateDps * 0.25;
   let changed = false;
   let failed = false;
 
   tutorial.orbitMinRadius = Math.min(tutorial.orbitMinRadius, radius);
   tutorial.orbitMaxRadius = Math.max(tutorial.orbitMaxRadius, radius);
   tutorial.orbitMaxError = Math.max(tutorial.orbitMaxError, radiusError);
+  tutorial.orbitMinVario = Math.min(tutorial.orbitMinVario, state.vario);
+  tutorial.orbitTime += stepDt;
+  if (turnRateTargetGood) tutorial.orbitTargetTime += stepDt;
 
   if (tutorial.orbitLastBearing == null) {
     tutorial.orbitLastBearing = bearing;
-    return {spread: 0, allowedSpread, error: radiusError, allowedError, targetRadius, changed, failed};
+    return {spread: 0, allowedSpread, optimizedAllowedSpread, error: radiusError, allowedError, targetRadius, minRadius: radius, maxRadius: radius, minVario: state.vario, targetRatio: 0, changed, failed};
   }
 
   const delta = Math.abs(angleDeltaDeg(tutorial.orbitLastBearing, bearing));
@@ -1245,8 +1513,16 @@ function updateTutorialOrbitProgress(params) {
 
   let spread = tutorial.orbitMaxRadius - tutorial.orbitMinRadius;
   let error = tutorial.orbitMaxError;
+  let targetRatio = tutorial.orbitTime > 0 ? tutorial.orbitTargetTime / tutorial.orbitTime : 0;
   while (tutorial.orbitAngle >= 360) {
-    const orbitPassed = lesson.targetRadius ? error <= allowedError : spread <= allowedSpread;
+    const orbitPassed =
+      lesson.successType === "radiusBand"
+        ? tutorial.orbitMinRadius >= profile.radius * 0.10 && tutorial.orbitMaxRadius <= profile.radius * 0.75
+        : lesson.successType === "optimizedTurn"
+          ? spread <= optimizedAllowedSpread && targetRatio >= 0.75
+          : lesson.successType === "thermalSize"
+            ? tutorial.orbitMinVario > 0
+            : spread <= allowedSpread;
     if (orbitPassed) {
       tutorial.orbitCount += 1;
       tutorial.lastOrbitFailed = false;
@@ -1259,12 +1535,29 @@ function updateTutorialOrbitProgress(params) {
     tutorial.orbitMinRadius = radius;
     tutorial.orbitMaxRadius = radius;
     tutorial.orbitMaxError = radiusError;
+    tutorial.orbitMinVario = state.vario;
+    tutorial.orbitTime = 0;
+    tutorial.orbitTargetTime = 0;
     spread = 0;
     error = radiusError;
+    targetRatio = turnRateTargetGood ? 1 : 0;
     changed = true;
   }
 
-  return {spread, allowedSpread, error, allowedError, targetRadius, changed, failed};
+  return {
+    spread,
+    allowedSpread: lesson.successType === "optimizedTurn" ? optimizedAllowedSpread : allowedSpread,
+    optimizedAllowedSpread,
+    error,
+    allowedError,
+    targetRadius,
+    minRadius: tutorial.orbitMinRadius,
+    maxRadius: tutorial.orbitMaxRadius,
+    minVario: tutorial.orbitMinVario,
+    targetRatio,
+    changed,
+    failed
+  };
 }
 
 function turnStats(samples) {
@@ -1409,6 +1702,34 @@ function drawArrow(x, y, heading, size, fill = "#111") {
   ctx.restore();
 }
 
+function turnRateCueColor(turnRateDps, alpha = 1) {
+  const danger = clamp((Math.abs(turnRateDps) - 24) / 6, 0, 1);
+  const r = Math.round(216 + (224 - 216) * danger);
+  const g = Math.round(255 + (56 - 255) * danger);
+  const b = Math.round(0 + (45 - 0) * danger);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function turnRateGlowColor(turnRateDps, alphaScale = 1) {
+  const rate = Math.abs(turnRateDps);
+  const target = clamp(activeTargetTurnRateDps, 0, maxTurnRateDps);
+  const targetGlow = clamp(1 - Math.abs(rate - target) / 7.5, 0, 1);
+  const danger = clamp((rate - 24) / 6, 0, 1);
+  if (danger > 0) {
+    return {
+      color: turnRateCueColor(turnRateDps, (0.25 + danger * 0.68) * alphaScale),
+      active: true
+    };
+  }
+  if (targetGlow > 0) {
+    return {
+      color: `rgba(216, 255, 0, ${targetGlow * 0.86 * alphaScale})`,
+      active: true
+    };
+  }
+  return {color: "rgba(32, 36, 35, 0)", active: false};
+}
+
 function drawTurnPreview(x, y, headingDeg, turnRateDps, scale) {
   const previewSeconds = 2.2;
   const steps = 28;
@@ -1417,10 +1738,10 @@ function drawTurnPreview(x, y, headingDeg, turnRateDps, scale) {
   let heading = headingDeg * Math.PI / 180;
   let px = x + Math.sin(heading) * startOffsetM * scale;
   let py = y - Math.cos(heading) * startOffsetM * scale;
+  const showTurnColors = !tutorial.active || tutorial.showTargetMarkers;
+  const glow = showTurnColors ? turnRateGlowColor(turnRateDps, 1) : {active: false};
 
   ctx.save();
-  ctx.strokeStyle = "rgba(216, 255, 0, 0.92)";
-  ctx.lineWidth = 3;
   ctx.lineCap = "round";
   ctx.lineJoin = "round";
   ctx.beginPath();
@@ -1432,28 +1753,17 @@ function drawTurnPreview(x, y, headingDeg, turnRateDps, scale) {
     py -= Math.cos(heading) * baseAirspeed * dtStep * scale;
     ctx.lineTo(px, py);
   }
-  ctx.stroke();
+  if (glow.active) {
+    ctx.strokeStyle = glow.color;
+    ctx.lineWidth = 11;
+    ctx.stroke();
+  }
 
   ctx.strokeStyle = "rgba(32, 36, 35, 0.92)";
-  ctx.lineWidth = 1;
+  ctx.lineWidth = 2.4;
+  ctx.setLineDash([1, 6]);
   ctx.stroke();
-
-  ctx.fillStyle = "#d8ff00";
-  for (const seconds of [1, 2]) {
-    let tickHeading = headingDeg * Math.PI / 180;
-    let tx = x + Math.sin(tickHeading) * startOffsetM * scale;
-    let ty = y - Math.cos(tickHeading) * startOffsetM * scale;
-    const tickSteps = Math.round(steps * seconds / previewSeconds);
-    for (let i = 1; i <= tickSteps; i++) {
-      const dtStep = previewSeconds / steps;
-      tickHeading += rateRad * dtStep;
-      tx += Math.sin(tickHeading) * baseAirspeed * dtStep * scale;
-      ty -= Math.cos(tickHeading) * baseAirspeed * dtStep * scale;
-    }
-    ctx.beginPath();
-    ctx.arc(tx, ty, 2.2, 0, Math.PI * 2);
-    ctx.fill();
-  }
+  ctx.setLineDash([]);
   ctx.restore();
 }
 
@@ -1545,7 +1855,6 @@ function drawMainMap(rect, estimate) {
   ctx.fill();
   drawText(`${params.windMph.toFixed(0)} mph wind`, rect.x + 10, rect.y + 18, 12, "left", "#202423");
 
-  drawText(estimate.cue, rect.x + rect.w - 16, rect.y + 18, 16, "right", "#202423");
   ctx.restore();
 }
 
@@ -1634,31 +1943,52 @@ function drawTurnRate(rect, estimate) {
   ctx.lineWidth = 1;
   ctx.strokeRect(rect.x, rect.y, rect.w, rect.h);
   const center = rect.x + rect.w / 2;
-  ctx.beginPath();
-  ctx.moveTo(center, rect.y);
-  ctx.lineTo(center, rect.y + rect.h);
-  ctx.stroke();
-  if (!tutorial.active || tutorial.showTargetMarkers) {
-    const target = clamp(activeTargetTurnRateDps, 0, maxTurnRateDps);
+  const rateX = rate => center + clamp(rate, -maxTurnRateDps, maxTurnRateDps) / maxTurnRateDps * rect.w / 2;
+  const target = clamp(activeTargetTurnRateDps, 0, maxTurnRateDps);
+  const showTurnColors = !tutorial.active || tutorial.showTargetMarkers;
+  if (showTurnColors) {
     for (const side of [-1, 1]) {
-      const targetX = center + side * target / maxTurnRateDps * rect.w / 2;
-      const gradient = ctx.createLinearGradient(targetX - 14, rect.y, targetX + 14, rect.y);
-      gradient.addColorStop(0, "rgba(0, 0, 0, 0)");
-      gradient.addColorStop(0.42, "rgba(216, 255, 0, 0.18)");
-      gradient.addColorStop(0.5, "rgba(216, 255, 0, 0.72)");
-      gradient.addColorStop(0.58, "rgba(216, 255, 0, 0.18)");
-      gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
+      const dangerStartX = rateX(side * 24);
+      const dangerEndX = rateX(side * maxTurnRateDps);
+      const dangerGradient = ctx.createLinearGradient(dangerStartX, rect.y, dangerEndX, rect.y);
+      dangerGradient.addColorStop(0, "rgba(224, 56, 45, 0)");
+      dangerGradient.addColorStop(1, "rgba(224, 56, 45, 0.76)");
+      ctx.fillStyle = dangerGradient;
+      ctx.fillRect(Math.min(dangerStartX, dangerEndX), rect.y + 1, Math.abs(dangerEndX - dangerStartX), rect.h - 2);
+    }
+    for (const side of [-1, 1]) {
+      const targetX = rateX(side * target);
+      const bandHalfWidth = rect.w * 0.13;
+      const gradient = ctx.createLinearGradient(targetX - bandHalfWidth, rect.y, targetX + bandHalfWidth, rect.y);
+      gradient.addColorStop(0, "rgba(216, 255, 0, 0)");
+      gradient.addColorStop(0.35, "rgba(216, 255, 0, 0.18)");
+      gradient.addColorStop(0.5, "rgba(216, 255, 0, 0.78)");
+      gradient.addColorStop(0.65, "rgba(216, 255, 0, 0.18)");
+      gradient.addColorStop(1, "rgba(216, 255, 0, 0)");
       ctx.fillStyle = gradient;
-      ctx.fillRect(targetX - 14, rect.y + 1, 28, rect.h - 2);
-      ctx.strokeStyle = "rgba(216, 255, 0, 0.78)";
+      ctx.fillRect(targetX - bandHalfWidth, rect.y + 1, bandHalfWidth * 2, rect.h - 2);
+      ctx.strokeStyle = "rgba(216, 255, 0, 0.92)";
       ctx.beginPath();
       ctx.moveTo(targetX, rect.y + 1);
       ctx.lineTo(targetX, rect.y + rect.h - 1);
       ctx.stroke();
     }
+    for (const side of [-1, 1]) {
+      const warningX = rateX(side * 24);
+      ctx.strokeStyle = "rgba(224, 56, 45, 0.62)";
+      ctx.beginPath();
+      ctx.moveTo(warningX, rect.y + 3);
+      ctx.lineTo(warningX, rect.y + rect.h - 3);
+      ctx.stroke();
+    }
   }
-  const actualX = center + state.turnRate / maxTurnRateDps * rect.w / 2;
-  ctx.strokeStyle = "#d8ff00";
+  ctx.strokeStyle = "#dce5d6";
+  ctx.beginPath();
+  ctx.moveTo(center, rect.y);
+  ctx.lineTo(center, rect.y + rect.h);
+  ctx.stroke();
+  const actualX = rateX(state.turnRate);
+  ctx.strokeStyle = showTurnColors ? turnRateCueColor(state.turnRate, 1) : "#dce5d6";
   ctx.lineWidth = 3;
   ctx.beginPath();
   ctx.arc(actualX, rect.y + rect.h / 2, 7, 0, Math.PI * 2);
@@ -1924,6 +2254,22 @@ function drawCoreTurnBarInLeaf(estimate) {
   ctx.fill();
 }
 
+function drawCorePrototypePanel(header, screen, estimate) {
+  corePrototypeHeaderRect = header;
+  ctx.save();
+  ctx.fillStyle = "#202423";
+  ctx.strokeStyle = "rgba(216, 255, 0, 0.45)";
+  ctx.lineWidth = 1;
+  drawRoundedRect(header.x, header.y, header.w, header.h, 6);
+  ctx.fill();
+  ctx.stroke();
+  drawText("ThermalCore Prototype Page", header.x + 10, header.y + header.h / 2, 11, "left", "#dce5d6");
+  drawText(corePrototypeVisible ? "^" : "v", header.x + header.w - 12, header.y + header.h / 2, 14, "center", "#d8ff00");
+  ctx.restore();
+
+  if (corePrototypeVisible) drawCoreScreen(screen, estimate);
+}
+
 function drawTrace(rect, trace, minV, maxV, label) {
   ctx.save();
   ctx.fillStyle = "#eef4ee";
@@ -1948,6 +2294,151 @@ function drawTrace(rect, trace, minV, maxV, label) {
   ctx.restore();
 }
 
+function shouldShowTutorialHint() {
+  const lesson = tutorialSteps[tutorial.step];
+  if (tutorial.hintForced) return true;
+  return Boolean(
+    tutorial.active &&
+    tutorial.phase === "practice" &&
+    lesson?.successType === "optimizedTurn" &&
+    lesson.stageIndex >= 1 &&
+    state.t - tutorial.stepStartedAt >= 60 &&
+    tutorial.orbitCount < 2
+  );
+}
+
+function drawRoundedRect(x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+}
+
+function wrapTextLines(text, maxWidth) {
+  const paragraphs = text.split("\n");
+  const lines = [];
+  for (const paragraph of paragraphs) {
+    if (!paragraph) {
+      lines.push("");
+      continue;
+    }
+    const words = paragraph.split(/\s+/);
+    let line = "";
+    for (const word of words) {
+      const testLine = line ? `${line} ${word}` : word;
+      if (ctx.measureText(testLine).width > maxWidth && line) {
+        lines.push(line);
+        line = word;
+      } else {
+        line = testLine;
+      }
+    }
+    if (line) lines.push(line);
+    lines.push("");
+  }
+  if (lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+function drawWrappedLines(lines, x, y, lineHeight) {
+  let lineY = y;
+  for (const line of lines) {
+    if (line) ctx.fillText(line, x, lineY);
+    lineY += line ? lineHeight : lineHeight * 0.75;
+  }
+  return lineY - y;
+}
+
+function drawTutorialHint(turnModule) {
+  tutorial.hintBubbleRect = null;
+  tutorial.hintBoxRect = null;
+  if (!shouldShowTutorialHint()) {
+    if (tutorial.hintOpen) closeTutorialHint(false);
+    return;
+  }
+
+  ctx.save();
+  if (tutorial.hintOpen) {
+    const tipText =
+      "Keep your ears on the vario beeping, and your eyes on the turn rate indicator. Try to generally hold near the optimum turn rate.\n\n" +
+      "If the vario starts to decrease, tighten your turn briefly until the vario feels roughly constant, then quickly come back to the optimum turn rate.\n\n" +
+      "If the vario starts to increase, widen your turn briefly until the vario feels roughly constant, then come back to the optimum turn rate.\n\n" +
+      "You're trying to make subtle shifts to your circles while holding near the optimum turn rate most of the time. By keeping your eyes on the turn rate, you're teaching yourself the exact same response you'll use when thermaling in a real paraglider.";
+    const boxW = turnModule.w + 104;
+    const textW = boxW - 24;
+    const lineH = 10.8;
+    ctx.font = "9px system-ui, sans-serif";
+    const lines = wrapTextLines(tipText, textW);
+    const textH = lines.reduce((sum, line) => sum + (line ? lineH : lineH * 0.75), 0);
+    const titleH = 28;
+    const boxH = Math.ceil(titleH + 18 + textH + 12);
+    const box = {x: turnModule.x + turnModule.w - boxW, y: Math.max(18, turnModule.y - boxH - 14), w: boxW, h: boxH};
+    tutorial.hintBoxRect = box;
+    ctx.fillStyle = "rgba(238, 244, 238, 0.96)";
+    ctx.strokeStyle = "#202423";
+    ctx.lineWidth = 1.5;
+    drawRoundedRect(box.x, box.y, box.w, box.h, 6);
+    ctx.fill();
+    ctx.stroke();
+    ctx.fillStyle = "#d8ff00";
+    ctx.beginPath();
+    ctx.moveTo(box.x + 6, box.y);
+    ctx.lineTo(box.x + box.w - 6, box.y);
+    ctx.quadraticCurveTo(box.x + box.w, box.y, box.x + box.w, box.y + 6);
+    ctx.lineTo(box.x + box.w, box.y + titleH);
+    ctx.lineTo(box.x, box.y + titleH);
+    ctx.lineTo(box.x, box.y + 6);
+    ctx.quadraticCurveTo(box.x, box.y, box.x + 6, box.y);
+    ctx.closePath();
+    ctx.fill();
+    drawText("Pro Tip:", box.x + 12, box.y + titleH / 2, 13, "left", "#202423");
+    ctx.fillStyle = "#202423";
+    ctx.font = "9px system-ui, sans-serif";
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    drawWrappedLines(lines, box.x + 12, box.y + titleH + 10, lineH);
+  } else {
+    const bubble = {x: turnModule.x + turnModule.w - 48, y: turnModule.y - 38, w: 44, h: 24};
+    tutorial.hintBubbleRect = bubble;
+    ctx.fillStyle = "#d8ff00";
+    ctx.strokeStyle = "#202423";
+    ctx.lineWidth = 1;
+    drawRoundedRect(bubble.x, bubble.y, bubble.w, bubble.h, 12);
+    ctx.fill();
+    ctx.stroke();
+    drawText("? tip", bubble.x + bubble.w / 2, bubble.y + bubble.h / 2, 11, "center", "#202423");
+  }
+  ctx.restore();
+}
+
+function openTutorialHint() {
+  tutorial.hintOpen = true;
+  tutorial.hintPausedRun = state.running;
+  if (state.running) {
+    state.running = false;
+    ui.start.textContent = "Start";
+    stopAudioTone();
+  }
+}
+
+function closeTutorialHint(resume = true) {
+  const shouldResume = tutorial.hintOpen && tutorial.hintPausedRun;
+  tutorial.hintOpen = false;
+  tutorial.hintPausedRun = false;
+  tutorial.hintForced = false;
+  if (resume && shouldResume && tutorial.active && tutorial.phase === "practice") {
+    state.running = true;
+    ui.start.textContent = "Pause";
+  }
+}
+
 function draw() {
   resizeCanvasForDisplay();
   const estimate = estimateCoreGuidance();
@@ -1957,13 +2448,15 @@ function draw() {
   const map = {x: 16, y: 18, w: 520, h: 520};
   const altitudeBox = {x: 560, y: 18, w: 96, h: 58};
   const varioTape = {x: 570, y: 108, w: 74, h: 430};
-  const core = {x: 872, y: 18, w: 96, h: 192};
+  const coreHeader = {x: 782, y: 18, w: 186, h: 24};
+  const core = {x: 872, y: 48, w: 96, h: 192};
   const turnModule = {x: map.x + map.w - 128, y: map.y + map.h - 184, w: 112, h: 166};
   drawMainMap(map, estimate);
   drawAltitudeBox(altitudeBox, state.z);
   drawVarioBar(varioTape, state.vario);
-  drawCoreScreen(core, estimate);
+  drawCorePrototypePanel(coreHeader, core, estimate);
   drawTurnRateModule(turnModule, estimate);
+  drawTutorialHint(turnModule);
   drawTrace({x: 16, y: 562, w: 460, h: 90}, state.altitudeTrace, state.startAlt - 20, state.startAlt + 360, "altitude");
   drawTrace({x: 494, y: 562, w: 340, h: 90}, state.varioTrace, -5, 7, "vario");
 
@@ -1984,7 +2477,34 @@ function draw() {
     ctx.fillText("Turn about 90 degrees", map.x + map.w / 2, map.y + map.h * 0.34 + 28);
     ctx.restore();
   }
-  if (!state.running && !state.finished && !(tutorial.active && tutorial.phase === "turn-callout")) {
+  if (
+    tutorial.active &&
+    tutorial.phase === "practice" &&
+    ["radiusBand", "optimizedTurn", "thermalSize"].includes(tutorialSteps[tutorial.step]?.successType) &&
+    tutorial.lastInstruction
+  ) {
+    const parts = tutorial.lastInstruction.split(" - ");
+    ctx.save();
+    ctx.font = "18px system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.lineWidth = 5;
+    ctx.strokeStyle = "rgba(238, 244, 238, 0.92)";
+    ctx.strokeText(parts[0], map.x + map.w / 2, map.y + map.h * 0.27);
+    ctx.fillStyle = "#202423";
+    ctx.fillText(parts[0], map.x + map.w / 2, map.y + map.h * 0.27);
+    if (parts[1]) {
+      ctx.font = "12px system-ui, sans-serif";
+      ctx.lineWidth = 4;
+      ctx.strokeText(parts[1], map.x + map.w / 2, map.y + map.h * 0.27 + 24);
+      ctx.fillText(parts[1], map.x + map.w / 2, map.y + map.h * 0.27 + 24);
+    }
+    ctx.restore();
+  }
+  const showMapStartPrompt = !state.running && !state.finished && (
+    !tutorial.active || tutorial.userPaused
+  );
+  if (showMapStartPrompt) {
     drawText("Press Space to start", map.x + map.w / 2, map.y + map.h / 2, 18, "center", "#202423");
   }
 }
@@ -2043,7 +2563,39 @@ ui.tutorialStart.addEventListener("click", () => {
   if (tutorial.active) exitTutorial();
   else startTutorial();
 });
-ui.tutorialContinue.addEventListener("click", continueTutorial);
+ui.tutorialPrevStage.addEventListener("click", () => jumpTutorialStage(-1));
+ui.tutorialNextStage.addEventListener("click", () => jumpTutorialStage(1));
+canvas.addEventListener("click", event => {
+  const rect = canvas.getBoundingClientRect();
+  const x = (event.clientX - rect.left) / Math.max(1, rect.width) * simW;
+  const y = (event.clientY - rect.top) / Math.max(1, rect.height) * simH;
+  const bubble = tutorial.hintBubbleRect;
+  const box = tutorial.hintBoxRect;
+  const coreHeader = corePrototypeHeaderRect;
+  const inCoreHeader = coreHeader &&
+    x >= coreHeader.x &&
+    x <= coreHeader.x + coreHeader.w &&
+    y >= coreHeader.y &&
+    y <= coreHeader.y + coreHeader.h;
+  const inBubble = bubble &&
+    x >= bubble.x &&
+    x <= bubble.x + bubble.w &&
+    y >= bubble.y &&
+    y <= bubble.y + bubble.h;
+  const inBox = box &&
+    x >= box.x &&
+    x <= box.x + box.w &&
+    y >= box.y &&
+    y <= box.y + box.h;
+  if (inCoreHeader) {
+    corePrototypeVisible = !corePrototypeVisible;
+  } else if (inBubble) {
+    if (tutorial.hintOpen) closeTutorialHint();
+    else openTutorialHint();
+  } else if (tutorial.hintOpen && !inBox) {
+    closeTutorialHint();
+  }
+});
 document.querySelectorAll(".preset").forEach(button => {
   button.addEventListener("click", () => {
     if (tutorial.active) exitTutorial();
@@ -2057,7 +2609,16 @@ for (const el of [ui.seed, ui.duration, ui.wind, ui.diameter, ui.diameterVarianc
 }
 
 window.addEventListener("keydown", event => {
-  if (["ArrowLeft", "ArrowRight", "Space", "ShiftLeft", "ShiftRight"].includes(event.code)) event.preventDefault();
+  if (["ArrowLeft", "ArrowRight", "Space", "ShiftLeft", "ShiftRight", "KeyT"].includes(event.code)) event.preventDefault();
+  if (event.code === "KeyT" && event.repeat) return;
+  if (event.code === "KeyT") {
+    if (tutorial.hintOpen) closeTutorialHint();
+    else {
+      tutorial.hintForced = true;
+      openTutorialHint();
+    }
+    return;
+  }
   if (event.code === "Space" && event.repeat) return;
   keys.add(event.code);
   if (event.code === "Space") {
@@ -2072,7 +2633,7 @@ window.addEventListener("keyup", event => {
   keys.delete(event.code);
 });
 
-applyThermalPreset("hard");
+applyThermalPreset("easy");
 requestAnimationFrame(loop);
 </script>
 </body>


### PR DESCRIPTION
**Summary**
This PR adds the first prototype workflow for Thermal Core guidance, including replay visualization, a standalone training simulator, tutorial scripting, and a hosted GitHub Pages entry point.

**Changes**
- Added a Thermal Core backlog/design note covering the proposed LCD guidance mode and underlying estimation ideas.
- Added Thermal Core and Thermal Track picture-in-picture displays to the IGC thermal replay tool.
- Added wind-compensated Thermal Core guidance experiments, turn-rate guidance, target arc display, breadcrumbs, and Leaf LCD-style mock display.
- Added firmware-side Thermal Track display control updates and Leaf Labs menu integration.
- Built a standalone Thermal Core simulator/trainer with:
  - Adjustable thermal size, strength, variance, wind, sink, and visibility.
  - Keyboard-controlled paraglider turn-rate model.
  - Audio vario tones and volume/test-tone controls.
  - Altitude/vario instrumentation, turn-rate indicator, bank visualization, score/trial history.
  - Easy/Medium/Hard/Expert presets.
  - Guided tutorial stages for centering, coring, visual-aid removal, and small-thermal judgment.
- Added tutorial script documentation for future wording and scenario updates.
- Moved the simulator into the website public tree so it can be hosted at:
  - `https://leafvario.com/labs/thermal-core-simulator/`

**Validation**
- Ran JavaScript parse checks on the simulator page: `script ok`.
- Built/flashed firmware during earlier branch work for v3.2.6.

**Notes**
- The simulator is currently a standalone static HTML page under `website/public/labs/thermal-core-simulator/index.html`.
- Future work can convert it to an Astro page if we want deeper website navigation, shared styling, or a polished public landing entry.