### PR TITLE
Stabilize SD ownership and USB mass storage

### DIFF
--- a/docs/dev-references/backlog/usb-mass-storage-power-on-ownership.md
+++ b/docs/dev-references/backlog/usb-mass-storage-power-on-ownership.md
@@ -5,7 +5,7 @@ description: Decide how Leaf should enter normal powered-on operation while a co
 
 # USB Mass-storage Ownership During Power-on Backlog
 
-Status: behavior and implementation approach require a separate product decision.
+Status: product behavior selected; implementation in progress on the Leaf Log ownership follow-up.
 
 ## Problem
 
@@ -20,6 +20,22 @@ it does not provide exclusive filesystem ownership and can risk filesystem corru
 
 USB suspend, a stop/spindown command, or a period without MSC activity does not prove that the host
 has released the filesystem. Only an explicit eject or USB disconnect is a safe ownership handoff.
+
+## Selected behavior
+
+- Normal powered-on operation always retains exclusive firmware ownership of the SD card. Plugging
+  USB into an operating Leaf provides power and charging but does not present the SD LUN.
+- Turning Leaf off while it remains plugged in closes firmware files, enters charging mode, runs a
+  fresh Leaf Log upload session when enabled, and presents mass storage afterward.
+- Holding center during Leaf Log activity cancels directly into powered-on operation without first
+  presenting the SD card. A short center press cancels to USB mass storage; directional presses do
+  not interrupt Leaf Log.
+- Holding center after mass storage is already present deliberately removes the SD medium, rejects
+  new host operations, drains in-flight MSC callbacks, remounts the filesystem, and powers on.
+  Because a USB device cannot flush unsent host caches, this last transition remains a deliberate
+  forced-removal operation and should be treated as uncommon.
+- Firmware performs no filesystem access while the host owns the SD card. SD-backed diagnostics are
+  paused rather than buffered or written concurrently.
 
 ## Scope
 
@@ -64,17 +80,15 @@ each affected feature behaves without storage.
 Ask the user to eject the drive or deliberately continue with storage unavailable. This makes the
 tradeoff visible but adds a new transition UI and still requires the no-SD operating mode.
 
-Leaf must not silently revoke a mounted medium from the host or infer ownership release from MSC
-inactivity.
+Leaf must not revoke a mounted medium in the background or infer ownership release from MSC
+inactivity. The explicit center-hold power-on action is the only deliberate forced-removal path.
 
-## Decisions required
+## Decisions resolved
 
-- Which power-on behavior should become the long-term product behavior?
-- If power-on without firmware SD access is allowed, which features are disabled and how is that
-  state represented on-device?
-- Does a center-button request remain pending until eject, or must the user press the button again?
-- After firmware reacquires the card, should it automatically continue power-on and resume all
-  storage-dependent services?
+- Powered-on operation does not expose the SD LUN.
+- Power-on never proceeds without firmware SD ownership.
+- A center hold is a deliberate request to reclaim the card and continue power-on automatically.
+- Returning to charging mode starts Leaf Log before presenting mass storage.
 
 ## Suggested implementation boundaries
 

--- a/src/vario/comms/leaf_log_sync.cpp
+++ b/src/vario/comms/leaf_log_sync.cpp
@@ -14,6 +14,7 @@
 
 namespace {
   constexpr time_t VALID_TIME_EPOCH = 1704067200;
+  constexpr uint32_t CENTER_POWER_ON_HOLD_MS = 900;
   constexpr uint32_t RETRY_DELAYS_MS[] = {5UL * 60 * 1000, 15UL * 60 * 1000, 60UL * 60 * 1000};
 }  // namespace
 
@@ -45,7 +46,7 @@ void LeafLogSync::update() {
   if (state_ == State::Idle) {
     if (sdcard.takeExplicitEject())
       beginSession(true);
-    else if (sdcard.ownership() == SDCardOwnership::FirmwareReserved)
+    else if (sdcard.isMounted() && sdcard.ownership() == SDCardOwnership::FirmwareReserved)
       beginSession(false);
     else
       state_ = State::HostOwned;
@@ -53,14 +54,28 @@ void LeafLogSync::update() {
   }
 
   if (state_ == State::HostOwned) {
-    if (sdcard.takeExplicitEject()) beginSession(true);
+    if (sdcard.takeExplicitEject())
+      beginSession(true);
+    else if (sdcard.isMounted() && sdcard.ownership() == SDCardOwnership::FirmwareReserved)
+      beginSession(false);
+    return;
+  }
+
+  if (state_ == State::Ejected) {
+    // Windows may send more than one eject command. Consume duplicates without starting another
+    // Leaf Log session, and remain ejected until the card is physically removed or Leaf powers on.
+    sdcard.takeExplicitEject();
+    if (!SDCard::isCardPresent()) {
+      resumedAfterEject_ = false;
+      state_ = State::Idle;
+    }
     return;
   }
 
   if (buttons.urgentPressLatched()) requestCancel();
 
   if (cancelRequested_.load(std::memory_order_acquire) && state_ != State::Uploading) {
-    finishToMassStorage();
+    finishRequestedExit();
     return;
   }
 
@@ -179,7 +194,7 @@ void LeafLogSync::update() {
         retryIndex_ = 0;
         beginEligibilityScan();
       } else if (result.outcome == leaf_log_client::UploadOutcome::Cancelled) {
-        finishToMassStorage();
+        finishRequestedExit();
       } else {
         handleTransientFailure(result.diagnostic, result.httpStatus, result.elapsedMs,
                                result.fileSize, result.responseSize);
@@ -189,13 +204,75 @@ void LeafLogSync::update() {
     case State::Backoff:
       if (static_cast<int32_t>(millis() - retryAtMs_) >= 0) beginEligibilityScan();
       break;
+    case State::AwaitingCenterIntent:
+      finishRequestedExit();
+      break;
     case State::Finishing:
       finishToMassStorage();
       break;
+    case State::MassStorageUnavailable:
+    case State::Ejected:
     case State::Idle:
     case State::HostOwned:
       break;
   }
+}
+
+void LeafLogSync::prepareForCharging() {
+  if (scanDirectory_) scanDirectory_.close();
+  buttons.disarmUrgentPressCapture();
+  cancelRequested_.store(false, std::memory_order_release);
+  powerOnRequested_.store(false, std::memory_order_release);
+  powerOnReady_.store(false, std::memory_order_release);
+  centerIntentStartedMs_ = 0;
+  resumedAfterEject_ = false;
+  state_ = State::Idle;
+}
+
+void LeafLogSync::prepareForOperating() {
+  if (scanDirectory_) scanDirectory_.close();
+  buttons.disarmUrgentPressCapture();
+  cancelRequested_.store(false, std::memory_order_release);
+  powerOnRequested_.store(false, std::memory_order_release);
+  centerIntentStartedMs_ = 0;
+  resumedAfterEject_ = false;
+  state_ = State::Idle;
+}
+
+void LeafLogSync::finishRequestedExit() {
+  if (powerOnRequested_.load(std::memory_order_acquire)) {
+    finishForPowerOn();
+    return;
+  }
+
+  if (buttons.inspectPins() == Button::CENTER) {
+    if (centerIntentStartedMs_ == 0) centerIntentStartedMs_ = millis();
+    if (millis() - centerIntentStartedMs_ >= CENTER_POWER_ON_HOLD_MS) {
+      finishForPowerOn();
+    } else {
+      state_ = State::AwaitingCenterIntent;
+    }
+    return;
+  }
+
+  finishToMassStorage();
+}
+
+void LeafLogSync::finishForPowerOn() {
+  buttons.disarmUrgentPressCapture();
+  buttons.suppressEventsUntilRelease();
+  if (scanDirectory_) scanDirectory_.close();
+  leaf_wifi::disconnectFromNetwork();
+  cancelRequested_.store(false, std::memory_order_release);
+  centerIntentStartedMs_ = 0;
+  resumedAfterEject_ = false;
+  if (!sdcard.acquireForFirmwareUse(0, true)) {
+    state_ = State::AwaitingCenterIntent;
+    return;
+  }
+  powerOnRequested_.store(false, std::memory_order_release);
+  state_ = State::Idle;
+  powerOnReady_.store(true, std::memory_order_release);
 }
 
 void LeafLogSync::finishToMassStorage() {
@@ -205,11 +282,15 @@ void LeafLogSync::finishToMassStorage() {
   if (scanDirectory_) scanDirectory_.close();
   leaf_wifi::disconnectFromNetwork();
   cancelRequested_.store(false, std::memory_order_release);
-  if (resumedAfterEject_)
+  powerOnRequested_.store(false, std::memory_order_release);
+  centerIntentStartedMs_ = 0;
+  if (resumedAfterEject_) {
     sdcard.keepMassStorageEjected();
-  else
-    sdcard.presentMassStorage();
-  state_ = State::HostOwned;
+    resumedAfterEject_ = false;
+    state_ = State::Ejected;
+  } else {
+    state_ = sdcard.presentMassStorage() ? State::HostOwned : State::MassStorageUnavailable;
+  }
 }
 
 void LeafLogSync::handleTransientFailure(const char* reason, int httpStatus, uint32_t elapsedMs,
@@ -240,13 +321,29 @@ void LeafLogSync::handleTransientFailure(const char* reason, int httpStatus, uin
 
 void LeafLogSync::requestCancel() { cancelRequested_.store(true, std::memory_order_release); }
 
+void LeafLogSync::requestPowerOn() {
+  powerOnRequested_.store(true, std::memory_order_release);
+  cancelRequested_.store(true, std::memory_order_release);
+  if (state_ == State::Idle || state_ == State::HostOwned || state_ == State::Ejected) {
+    state_ = State::AwaitingCenterIntent;
+    stateStartedMs_ = millis();
+  }
+}
+
+bool LeafLogSync::takePowerOnReady() {
+  return powerOnReady_.exchange(false, std::memory_order_acq_rel);
+}
+
 bool LeafLogSync::interceptsChargingButtons() const {
   return state_ == State::CheckingEligibility || state_ == State::ConnectingWifi ||
-         state_ == State::WaitingForTime || state_ == State::Uploading || state_ == State::Backoff;
+         state_ == State::WaitingForTime || state_ == State::Uploading ||
+         state_ == State::AwaitingCenterIntent || state_ == State::MassStorageUnavailable ||
+         state_ == State::Backoff;
 }
 
 bool LeafLogSync::canSleepWhileCharging() const {
-  return state_ == State::Idle || state_ == State::HostOwned;
+  return state_ == State::Idle || state_ == State::HostOwned || state_ == State::Ejected ||
+         state_ == State::MassStorageUnavailable;
 }
 
 bool LeafLogSync::screenActive() const { return interceptsChargingButtons(); }
@@ -261,8 +358,13 @@ const char* LeafLogSync::statusLine() const {
       return "Setting network time...";
     case State::Uploading:
       return "Uploading to Leaf Log";
+    case State::AwaitingCenterIntent:
+      return powerOnRequested_.load(std::memory_order_acquire) ? "Closing USB..."
+                                                               : "Hold center to turn on";
     case State::Backoff:
       return "Retry pending...";
+    case State::MassStorageUnavailable:
+      return "USB drive unavailable";
     default:
       return "";
   }

--- a/src/vario/comms/leaf_log_sync.h
+++ b/src/vario/comms/leaf_log_sync.h
@@ -14,17 +14,26 @@ class LeafLogSync {
     ConnectingWifi,
     WaitingForTime,
     Uploading,
+    AwaitingCenterIntent,
     Finishing,
     HostOwned,
+    Ejected,
+    MassStorageUnavailable,
     Backoff,
   };
 
   void update();
+  void prepareForCharging();
+  void prepareForOperating();
   void requestCancel();
+  void requestPowerOn();
+  bool takePowerOnReady();
   bool interceptsChargingButtons() const;
   bool canSleepWhileCharging() const;
   bool screenActive() const;
   bool retryPending() const { return state_ == State::Backoff; }
+  bool massStorageUnavailable() const { return state_ == State::MassStorageUnavailable; }
+  bool powerOnPending() const { return powerOnRequested_.load(std::memory_order_acquire); }
   bool progressKnown() const { return sessionTotalKnown_; }
   const char* statusLine() const;
   uint16_t currentCount() const {
@@ -35,6 +44,8 @@ class LeafLogSync {
  private:
   void beginSession(bool fromEject);
   void beginEligibilityScan();
+  void finishRequestedExit();
+  void finishForPowerOn();
   void finishToMassStorage();
   void handleTransientFailure(const char* reason, int httpStatus = 0, uint32_t elapsedMs = 0,
                               size_t fileSize = 0, size_t responseSize = 0);
@@ -43,6 +54,8 @@ class LeafLogSync {
   File scanDirectory_;
   LeafLogCandidate current_;
   std::atomic<bool> cancelRequested_{false};
+  std::atomic<bool> powerOnRequested_{false};
+  std::atomic<bool> powerOnReady_{false};
   bool wifiAttemptStarted_ = false;
   bool timeStarted_ = false;
   bool resumedAfterEject_ = false;
@@ -51,6 +64,7 @@ class LeafLogSync {
   uint16_t sessionTotalCount_ = 0;
   uint16_t pendingCount_ = 0;
   uint32_t stateStartedMs_ = 0;
+  uint32_t centerIntentStartedMs_ = 0;
   uint32_t retryAtMs_ = 0;
   uint8_t retryIndex_ = 0;
 };

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -3363,7 +3363,10 @@ void webserver_setup() {
   });
 
   user_server.on("/api/debug/mass-storage", HTTP_GET, []() {
-    // Serial.end();
+    if (power.info().onState != PowerState::OffUSB) {
+      user_server.send(409, "text/plain", "SD mass storage is available only in charging mode");
+      return;
+    }
     sdcard.setupMassStorage();
     user_server.send(200, "text/html", "OK!");
   });

--- a/src/vario/diagnostics/diagnostic_logs.cpp
+++ b/src/vario/diagnostics/diagnostic_logs.cpp
@@ -2,6 +2,7 @@
 
 #include <SD_MMC.h>
 
+#include "storage/sd_card.h"
 #include "ui/settings/settings.h"
 
 namespace diagnostic_logs {
@@ -25,6 +26,7 @@ namespace diagnostic_logs {
   }
 
   bool ensureDirectory() {
+    if (!sdcard.firmwareCanAccessFilesystem()) return false;
     if (SD_MMC.exists(DIAGNOSTICS_DIR)) return true;
     return SD_MMC.mkdir(DIAGNOSTICS_DIR);
   }

--- a/src/vario/diagnostics/fatal_error.cpp
+++ b/src/vario/diagnostics/fatal_error.cpp
@@ -9,6 +9,7 @@
 #include <stdarg.h>
 
 #include "hardware/buttons.h"
+#include "storage/sd_card.h"
 #include "system/version_info.h"
 #include "ui/audio/sound_effects.h"
 #include "ui/audio/speaker.h"
@@ -41,6 +42,7 @@ bool useFile() {
   if (fatal_error_file) {
     return true;
   }
+  if (!sdcard.firmwareCanAccessFilesystem()) return false;
 
   unsigned int i = 1;
   char fileName[32];

--- a/src/vario/hardware/buttons.cpp
+++ b/src/vario/hardware/buttons.cpp
@@ -66,10 +66,8 @@ Button Buttons::init() {
   pinMode(BUTTON_PIN_RIGHT, INPUT_PULLDOWN);
   pinMode(BUTTON_PIN_CENTER, INPUT_PULLDOWN);
 
-  attachInterruptArg(BUTTON_PIN_UP, onPressInterrupt, this, RISING);
-  attachInterruptArg(BUTTON_PIN_DOWN, onPressInterrupt, this, RISING);
-  attachInterruptArg(BUTTON_PIN_LEFT, onPressInterrupt, this, RISING);
-  attachInterruptArg(BUTTON_PIN_RIGHT, onPressInterrupt, this, RISING);
+  // Only center controls the charging-mode Leaf Log handoff. The directional buttons remain
+  // available for their normal charging-screen behavior and cannot accidentally cancel uploads.
   attachInterruptArg(BUTTON_PIN_CENTER, onPressInterrupt, this, RISING);
 
   return inspectPins();

--- a/src/vario/hardware/buttons.h
+++ b/src/vario/hardware/buttons.h
@@ -23,7 +23,7 @@ class Buttons : IMessageSource {
   // check the instantaneous state of the button hardware pins
   Button inspectPins();
 
-  // Capture any physical button edge independently of the polling state machine. This is used by
+  // Capture the center-button edge independently of the polling state machine. This is used by
   // blocking operations that must remain cancellable even when update() cannot run.
   void armUrgentPressCapture();
   void disarmUrgentPressCapture();

--- a/src/vario/logging/buslog.cpp
+++ b/src/vario/logging/buslog.cpp
@@ -28,8 +28,8 @@ String BusLogger::desiredFileName() const {
 }
 
 bool BusLogger::startLog() {
-  if (!sdcard.isMounted()) {
-    Serial.println("BusLogger::startLog failed: sdcard not mounted");
+  if (!sdcard.firmwareCanAccessFilesystem()) {
+    Serial.println("BusLogger::startLog failed: sdcard unavailable to firmware");
     return false;
   }
   if (!bus_) {

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -1,7 +1,7 @@
 // Includes
 #include "power.h"
 
-#include "comms/leaf_log_credentials.h"
+#include "comms/leaf_log_sync.h"
 #include "diagnostics/diagnostic_network/diagnostic_network.h"
 #include "diagnostics/heap_monitor.h"
 #include "hardware/Leaf_I2C.h"
@@ -20,6 +20,7 @@
 #include "logging/log.h"
 #include "power.h"
 #include "storage/sd_card.h"
+#include "system/usb_state.h"
 #include "ui/audio/sound_effects.h"
 #include "ui/audio/speaker.h"
 #include "ui/display/display.h"
@@ -159,9 +160,10 @@ void Power::initPeripherals() {
   }
 
   // then initialize the rest of the devices
-  const bool reserveForLeafLog = info_.onState == PowerState::OffUSB && settings.labs_leafLog &&
-                                 leaf_log_credentials::load().linked();
-  sdcard.init(reserveForLeafLog);
+  // The SD LUN starts absent in every power state. Charging mode runs Leaf Log first and explicitly
+  // presents the card; operating mode retains exclusive firmware ownership.
+  sdcard.init(true);
+  if (info_.onState == PowerState::On) leaf_usb::disconnect();
   heap_monitor::checkpoint("periph-sd");
   Serial.println(" - Finished SDcard");
   lc86g.init();
@@ -208,8 +210,6 @@ void Power::sleepPeripherals() {
 void Power::wakePeripherals() {
   heap_monitor::checkpoint("wake-periph-start");
   Serial.println("wake_peripherals: ");
-  sdcard.mount();  // re-initialize SD card in case card state was changed while in charging/USB
-                   // mode
   heap_monitor::checkpoint("wake-periph-sd");
   Serial.println(" - waking GPS");
   lc86g.wake();
@@ -224,7 +224,12 @@ void Power::wakePeripherals() {
   Serial.println(" - DONE");
 }
 
-void Power::switchToOnState() {
+bool Power::switchToOnState() {
+  if (!sdcard.acquireForFirmwareUse(2000, true)) {
+    Serial.println("switch_to_on_state: SD ownership transition failed");
+    return false;
+  }
+  leafLogSync.prepareForOperating();
   latchOn();
   Serial.println("switch_to_on_state");
   info_.onState = PowerState::On;
@@ -233,6 +238,7 @@ void Power::switchToOnState() {
     diagnostic_network.reset("switch_to_on_state");
   }
   maybeStartBusLog();
+  return true;
 }
 
 void Power::maybeStartBusLog() {
@@ -268,6 +274,7 @@ void Power::shutdown(bool deadBattery) {
   if (flightTimer_isRunning()) {
     flightTimer_stop(false);
   }
+  busLog.endLog();
 
   // Show user we're shutting down
   display.clearPage();
@@ -305,6 +312,11 @@ void Power::shutdown(bool deadBattery) {
   // plugged into USB, then we can show necessary charging updates etc
   info_.onState = PowerState::OffUSB;
   display.setPage(MainPage::Charging);
+  if (sdcard.acquireForFirmwareUse()) {
+    leafLogSync.prepareForCharging();
+  } else {
+    Serial.println("power_shutdown: SD unavailable for charging transition");
+  }
 }
 
 void Power::latchOn() { digitalWrite(POWER_LATCH, HIGH); }

--- a/src/vario/power.h
+++ b/src/vario/power.h
@@ -52,7 +52,7 @@ class Power {
   void shutdown();
   void shutdown(bool deadBattery);
 
-  void switchToOnState();
+  bool switchToOnState();
 
   void update();
 

--- a/src/vario/storage/sd_card.cpp
+++ b/src/vario/storage/sd_card.cpp
@@ -4,6 +4,7 @@
 #include <FS.h>
 #include <SD_MMC.h>
 #include <driver/sdmmc_host.h>
+#include <esp_heap_caps.h>
 #include <esp_vfs_fat.h>
 #include <ff.h>
 #include <sdmmc_cmd.h>
@@ -49,6 +50,8 @@ namespace {
 
 void SDCard::init(bool reserveMassStorage) {
   reserveMassStorageOnMount_ = reserveMassStorage;
+  ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
+  heap_monitor::setSdLoggingEnabled(false);
   // Shouldn't need to call set pins since we're using the default pins
   // TODO: try removing this setPins call
   if (!SD_MMC.setPins(SDIO_CLK, SDIO_CMD, SDIO_D0, SDIO_D1, SDIO_D2, SDIO_D3)) {
@@ -76,6 +79,16 @@ void SDCard::init(bool reserveMassStorage) {
 
 void SDCard::update() {
   bool cardPresentNow = isCardPresent();
+  const SDCardOwnership current = ownership_.load(std::memory_order_acquire);
+  if (current == SDCardOwnership::HostOwned) {
+    if (!cardPresentNow) acquireForFirmwareUse();
+    return;
+  }
+  if (current == SDCardOwnership::TransitioningToHost ||
+      current == SDCardOwnership::TransitioningToFirmware) {
+    return;
+  }
+
   // if we have a card when we didn't before...
   if (cardPresentNow && !mounted_) {
     // then mount it!
@@ -95,6 +108,8 @@ void SDCard::update() {
 namespace {
   constexpr const char* STANDARD_DIRECTORIES[] = {"/waypoints", "/routes", "/logbook", "/tracks",
                                                   "/firmware"};
+  constexpr uint32_t SD_SECTOR_SIZE = 512;
+  constexpr uint32_t MSC_BUFFER_SIZE = 4096;
 
   bool ensureDirectory(const char* path) {
     if (SD_MMC.exists(path)) return true;
@@ -111,39 +126,21 @@ namespace {
   }
 
   int32_t onRead(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
-    if (!sdcard.hostOwnsMassStorage()) return -1;
-    // Check bufSize is a multiple of block size
-    if (bufsize % 512) {
-      return -1;
-    }
+    if (!sdcard.beginHostIo()) return -1;
+    struct HostIoGuard {
+      ~HostIoGuard() { sdcard.endHostIo(); }
+    } guard;
 
-    auto bufferOffset = 0;
-    for (int sector = lba; sector < lba + bufsize / 512; sector++) {
-      if (!SD_MMC.readRAW((uint8_t*)buffer + bufferOffset, sector)) {
-        return -1;
-      }
-      bufferOffset += 512;
-    }
-
-    return bufsize;
+    return sdcard.readHostSectors(lba, offset, buffer, bufsize);
   }
 
   int32_t onWrite(uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
-    if (!sdcard.hostOwnsMassStorage()) return -1;
-    // Check bufSize is a multiple of block size
-    if (bufsize % 512) {
-      return -1;
-    }
+    if (!sdcard.beginHostIo()) return -1;
+    struct HostIoGuard {
+      ~HostIoGuard() { sdcard.endHostIo(); }
+    } guard;
 
-    auto bufferOffset = 0;
-    for (int sector = lba; sector < lba + bufsize / 512; sector++) {
-      if (!SD_MMC.writeRAW(buffer + bufferOffset, sector)) {
-        return -1;
-      }
-      bufferOffset += 512;
-    }
-
-    return bufsize;
+    return sdcard.writeHostSectors(lba, offset, buffer, bufsize);
   }
 
   bool onStartStop(uint8_t, bool start, bool loadEject) {
@@ -174,21 +171,31 @@ bool SDCard::setupMassStorage(bool mediaPresent) {
   msc_->onWrite(onWrite);
   msc_->onStartStop(onStartStop);
   msc_->isWritable(true);
-  ownership_.store(mediaPresent ? SDCardOwnership::HostOwned : SDCardOwnership::FirmwareReserved,
-                   std::memory_order_release);
-  msc_->mediaPresent(mediaPresent);
-  msc_->begin(sectorCount, 512);
+  mscSectorCount_ = static_cast<uint32_t>(sectorCount);
+  msc_->mediaPresent(false);
+  if (!msc_->begin(mscSectorCount_, SD_SECTOR_SIZE)) {
+    if (DEBUG_SDCARD) Serial.println("Mass Storage Failed: could not start USB MSC LUN");
+    return false;
+  }
+  mscStarted_ = true;
   if (settings.dev_mode) {
     if (!firmwareMSC_) firmwareMSC_ = new (std::nothrow) FirmwareMSC();
     if (firmwareMSC_) firmwareMSC_->begin();
   }
-  return leaf_usb::begin();
+  if (!leaf_usb::begin()) return false;
+  if (mediaPresent) return presentMassStorage();
+
+  heap_monitor::setSdLoggingEnabled(mounted_);
+  ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
+  return true;
 }
 
 bool SDCard::mount() {
+  if (mounted_) return true;
+
   bool success = false;
 
-  if (!SD_MMC.begin(SD_CARD_MOUNT_POINT, false, false)) {
+  if (!SD_MMC.begin(SD_CARD_MOUNT_POINT, false, false, SDMMC_FREQ_DEFAULT)) {
     if (DEBUG_SDCARD) Serial.println("SDcard Mount Failed");
     success = false;
   } else {
@@ -221,16 +228,142 @@ bool SDCard::reserveForFirmwareUpload() {
                                             std::memory_order_acq_rel);
 }
 
-void SDCard::presentMassStorage() {
-  if (!msc_) return;
-  ownership_.store(SDCardOwnership::HostOwned, std::memory_order_release);
-  msc_->mediaPresent(true);
+bool SDCard::startRawHost() {
+  sdmmc_host_t host = SDMMC_HOST_DEFAULT();
+  host.slot = SDMMC_HOST_SLOT_1;
+  host.flags = SDMMC_HOST_FLAG_4BIT;
+  host.max_freq_khz = SDMMC_FREQ_DEFAULT;
+
+  sdmmc_slot_config_t slot = SDMMC_SLOT_CONFIG_DEFAULT();
+  slot.clk = static_cast<gpio_num_t>(SDIO_CLK);
+  slot.cmd = static_cast<gpio_num_t>(SDIO_CMD);
+  slot.d0 = static_cast<gpio_num_t>(SDIO_D0);
+  slot.d1 = static_cast<gpio_num_t>(SDIO_D1);
+  slot.d2 = static_cast<gpio_num_t>(SDIO_D2);
+  slot.d3 = static_cast<gpio_num_t>(SDIO_D3);
+  slot.width = 4;
+  slot.flags |= SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
+
+  esp_err_t result = sdmmc_host_init();
+  if (result == ESP_OK) result = sdmmc_host_init_slot(host.slot, &slot);
+  if (result == ESP_OK) result = sdmmc_card_init(&host, &rawHostCard_);
+  if (result != ESP_OK) {
+    if (DEBUG_SDCARD) Serial.printf("Mass Storage Failed: raw SD init returned 0x%x\n", result);
+    sdmmc_host_deinit();
+    rawHostCard_ = {};
+    return false;
+  }
+
+  rawHostInitialized_ = true;
+  return true;
 }
 
-void SDCard::keepMassStorageEjected() {
-  ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
-  if (msc_) msc_->mediaPresent(false);
+void SDCard::stopRawHost() {
+  if (rawHostInitialized_) {
+    sdmmc_host_deinit();
+    rawHostInitialized_ = false;
+    rawHostCard_ = {};
+  }
+  if (mscBuffer_) {
+    heap_caps_free(mscBuffer_);
+    mscBuffer_ = nullptr;
+  }
 }
+
+bool SDCard::presentMassStorage() {
+  if (!msc_ || !mscStarted_ || !mounted_) return false;
+
+  ownership_.store(SDCardOwnership::TransitioningToHost, std::memory_order_release);
+  heap_monitor::setSdLoggingEnabled(false);
+
+  mscBuffer_ = static_cast<uint8_t*>(
+      heap_caps_malloc(MSC_BUFFER_SIZE, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+  if (!mscBuffer_) {
+    if (DEBUG_SDCARD) Serial.println("Mass Storage Failed: could not allocate DMA buffer");
+    ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
+    heap_monitor::setSdLoggingEnabled(true);
+    return false;
+  }
+
+  SD_MMC.end();
+  mounted_ = false;
+  if (!startRawHost() || rawHostCard_.csd.sector_size != SD_SECTOR_SIZE ||
+      rawHostCard_.csd.capacity == 0) {
+    stopRawHost();
+    ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
+    if (isCardPresent()) {
+      SD_MMC.setPins(SDIO_CLK, SDIO_CMD, SDIO_D0, SDIO_D1, SDIO_D2, SDIO_D3);
+      mount();
+    }
+    return false;
+  }
+
+  mscSectorCount_ = rawHostCard_.csd.capacity;
+  if (!msc_->begin(mscSectorCount_, SD_SECTOR_SIZE)) {
+    stopRawHost();
+    ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
+    if (isCardPresent()) {
+      SD_MMC.setPins(SDIO_CLK, SDIO_CMD, SDIO_D0, SDIO_D1, SDIO_D2, SDIO_D3);
+      mount();
+    }
+    return false;
+  }
+
+  ownership_.store(SDCardOwnership::HostOwned, std::memory_order_release);
+  msc_->mediaPresent(true);
+  if (leaf_usb::connect()) return true;
+
+  msc_->mediaPresent(false);
+  ownership_.store(SDCardOwnership::TransitioningToFirmware, std::memory_order_release);
+  stopRawHost();
+  ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
+  if (isCardPresent()) {
+    SD_MMC.setPins(SDIO_CLK, SDIO_CMD, SDIO_D0, SDIO_D1, SDIO_D2, SDIO_D3);
+    mount();
+  }
+  return false;
+}
+
+bool SDCard::acquireForFirmwareUse(uint32_t timeoutMs, bool disconnectUsb) {
+  SDCardOwnership current = ownership_.load(std::memory_order_acquire);
+  if (current == SDCardOwnership::FirmwareReserved ||
+      current == SDCardOwnership::FirmwareUploading) {
+    if (disconnectUsb && !leaf_usb::disconnect()) return false;
+    if (mounted_) heap_monitor::setSdLoggingEnabled(true);
+    return true;
+  }
+
+  if (current == SDCardOwnership::TransitioningToHost) return false;
+
+  ownership_.store(SDCardOwnership::TransitioningToFirmware, std::memory_order_release);
+  if (msc_) msc_->mediaPresent(false);
+  if (disconnectUsb && !leaf_usb::disconnect()) return false;
+
+  const uint32_t startedMs = millis();
+  while (activeHostIo_.load(std::memory_order_acquire) != 0) {
+    if (timeoutMs == 0) return false;
+    if (millis() - startedMs >= timeoutMs) {
+      Serial.printf("SD ownership transition timed out with %u host operations active\n",
+                    activeHostIo_.load(std::memory_order_acquire));
+      return false;
+    }
+    delay(1);
+  }
+
+  stopRawHost();
+  ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
+  if (isCardPresent()) {
+    SD_MMC.setPins(SDIO_CLK, SDIO_CMD, SDIO_D0, SDIO_D1, SDIO_D2, SDIO_D3);
+    if (!mount()) {
+      Serial.println("SD ownership transition failed to remount the card");
+      return false;
+    }
+  }
+  if (mounted_) heap_monitor::setSdLoggingEnabled(true);
+  return true;
+}
+
+void SDCard::keepMassStorageEjected() { acquireForFirmwareUse(); }
 
 void SDCard::notifyExplicitEject() {
   if (ownership_.load(std::memory_order_acquire) != SDCardOwnership::HostOwned) return;
@@ -240,22 +373,76 @@ void SDCard::notifyExplicitEject() {
 void SDCard::updateUsbOwnership() {
   if (ownership_.load(std::memory_order_acquire) == SDCardOwnership::HostOwned &&
       !leaf_usb::hostMounted()) {
-    ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
-    if (msc_) msc_->mediaPresent(false);
+    acquireForFirmwareUse();
   }
 }
 
 bool SDCard::takeExplicitEject() {
-  if (!explicitEject_.exchange(false, std::memory_order_acq_rel)) return false;
-  keepMassStorageEjected();
+  if (!explicitEject_.load(std::memory_order_acquire)) return false;
+  if (!acquireForFirmwareUse(0)) return false;
+  explicitEject_.store(false, std::memory_order_release);
   return true;
 }
 
 void SDCard::unmount() {
+  if (!acquireForFirmwareUse()) return;
   heap_monitor::checkpoint("sd-unmount");
   heap_monitor::setSdLoggingEnabled(false);
   SD_MMC.end();
   mounted_ = false;
+}
+
+bool SDCard::beginHostIo() {
+  if (ownership_.load(std::memory_order_acquire) != SDCardOwnership::HostOwned) return false;
+
+  activeHostIo_.fetch_add(1, std::memory_order_acq_rel);
+  if (ownership_.load(std::memory_order_acquire) == SDCardOwnership::HostOwned) return true;
+
+  activeHostIo_.fetch_sub(1, std::memory_order_acq_rel);
+  return false;
+}
+
+void SDCard::endHostIo() { activeHostIo_.fetch_sub(1, std::memory_order_acq_rel); }
+
+int32_t SDCard::readHostSectors(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
+  if (!rawHostInitialized_ || !mscBuffer_ || offset % SD_SECTOR_SIZE != 0 || bufsize == 0 ||
+      bufsize % SD_SECTOR_SIZE != 0 || bufsize > MSC_BUFFER_SIZE) {
+    return -1;
+  }
+
+  const uint64_t firstSector = static_cast<uint64_t>(lba) + offset / SD_SECTOR_SIZE;
+  const size_t sectorCount = bufsize / SD_SECTOR_SIZE;
+  if (firstSector + sectorCount > rawHostCard_.csd.capacity) return -1;
+
+  const esp_err_t result = sdmmc_read_sectors(&rawHostCard_, mscBuffer_, firstSector, sectorCount);
+  if (result != ESP_OK) {
+    Serial.printf("Mass Storage Read Failed: lba=%llu sectors=%u error=0x%x\n", firstSector,
+                  static_cast<unsigned>(sectorCount), result);
+    return -1;
+  }
+  memcpy(buffer, mscBuffer_, bufsize);
+  return static_cast<int32_t>(bufsize);
+}
+
+int32_t SDCard::writeHostSectors(uint32_t lba, uint32_t offset, const uint8_t* buffer,
+                                 uint32_t bufsize) {
+  if (!rawHostInitialized_ || !mscBuffer_ || offset % SD_SECTOR_SIZE != 0 || bufsize == 0 ||
+      bufsize % SD_SECTOR_SIZE != 0 || bufsize > MSC_BUFFER_SIZE) {
+    return -1;
+  }
+
+  const uint64_t firstSector = static_cast<uint64_t>(lba) + offset / SD_SECTOR_SIZE;
+  const size_t sectorCount = bufsize / SD_SECTOR_SIZE;
+  if (firstSector + sectorCount > rawHostCard_.csd.capacity) return -1;
+
+  memcpy(mscBuffer_, buffer, bufsize);
+  const esp_err_t result = sdmmc_write_sectors(&rawHostCard_, mscBuffer_, firstSector, sectorCount);
+  if (result != ESP_OK) {
+    Serial.printf("Mass Storage Write Failed: lba=%llu sectors=%u error=0x%x\n", firstSector,
+                  static_cast<unsigned>(sectorCount), result);
+    return -1;
+  }
+  return static_cast<int32_t>(bufsize);
 }
 
 bool SDCard::format() {
@@ -269,6 +456,12 @@ SDCard::FormatResult SDCard::formatDetailed() {
     if (DEBUG_SDCARD) Serial.println("SDcard Format Failed: no card present");
     result.stage = "card_detection";
     result.error = ESP_ERR_NOT_FOUND;
+    return result;
+  }
+
+  if (!acquireForFirmwareUse()) {
+    result.stage = "ownership_transition";
+    result.error = ESP_ERR_TIMEOUT;
     return result;
   }
 

--- a/src/vario/storage/sd_card.h
+++ b/src/vario/storage/sd_card.h
@@ -4,8 +4,15 @@
 #include "FirmwareMSC.h"
 #include "USBMSC.h"
 #include "esp_err.h"
+#include "sdmmc_cmd.h"
 
-enum class SDCardOwnership : uint8_t { FirmwareReserved, FirmwareUploading, HostOwned };
+enum class SDCardOwnership : uint8_t {
+  FirmwareReserved,
+  FirmwareUploading,
+  TransitioningToHost,
+  HostOwned,
+  TransitioningToFirmware,
+};
 
 class SDCard {
  public:
@@ -30,13 +37,26 @@ class SDCard {
 
   bool setupMassStorage(bool mediaPresent = true);
   bool reserveForFirmwareUpload();
-  void presentMassStorage();
+  bool presentMassStorage();
+  bool acquireForFirmwareUse(uint32_t timeoutMs = 2000, bool disconnectUsb = false);
   void keepMassStorageEjected();
   void notifyExplicitEject();
   bool takeExplicitEject();
   void updateUsbOwnership();
   SDCardOwnership ownership() const { return ownership_.load(std::memory_order_acquire); }
   bool hostOwnsMassStorage() const { return ownership() == SDCardOwnership::HostOwned; }
+  bool firmwareOwnsMassStorage() const {
+    const SDCardOwnership current = ownership();
+    return current == SDCardOwnership::FirmwareReserved ||
+           current == SDCardOwnership::FirmwareUploading;
+  }
+  bool firmwareCanAccessFilesystem() const { return mounted_ && firmwareOwnsMassStorage(); }
+
+  // Used only by the USB MSC callbacks to keep a host request alive across an ownership change.
+  bool beginHostIo();
+  void endHostIo();
+  int32_t readHostSectors(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize);
+  int32_t writeHostSectors(uint32_t lba, uint32_t offset, const uint8_t* buffer, uint32_t bufsize);
   static bool isCardPresent();
 
  private:
@@ -47,9 +67,17 @@ class SDCard {
   FirmwareMSC* firmwareMSC_ = nullptr;
   USBMSC* msc_ = nullptr;
   std::atomic<SDCardOwnership> ownership_{SDCardOwnership::FirmwareReserved};
+  std::atomic<uint16_t> activeHostIo_{0};
   std::atomic<bool> explicitEject_{false};
   bool reserveMassStorageOnMount_ = false;
+  bool mscStarted_ = false;
+  bool rawHostInitialized_ = false;
+  uint32_t mscSectorCount_ = 0;
+  sdmmc_card_t rawHostCard_ = {};
+  uint8_t* mscBuffer_ = nullptr;
 
+  bool startRawHost();
+  void stopRawHost();
   bool formatUnmounted(esp_err_t& error, const char*& stage);
   bool mountWithRetries(uint8_t& attempts);
 };

--- a/src/vario/system/usb_state.cpp
+++ b/src/vario/system/usb_state.cpp
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include <USB.h>
+#include <tusb.h>
 
 #include "system/usb_serial.h"
 
@@ -19,6 +20,7 @@ namespace leaf_usb {
 
     bool initialized = false;
     bool usb_started = false;
+    bool usb_connected = false;
     bool host_mounted = false;
     bool host_suspended = false;
     uint32_t usb_started_ms = 0;
@@ -26,10 +28,12 @@ namespace leaf_usb {
     void onUsbEvent(void*, esp_event_base_t, int32_t event_id, void*) {
       switch (event_id) {
         case ARDUINO_USB_STARTED_EVENT:
+          usb_connected = true;
           host_mounted = true;
           host_suspended = false;
           break;
         case ARDUINO_USB_STOPPED_EVENT:
+          usb_connected = false;
           host_mounted = false;
           host_suspended = false;
           break;
@@ -84,7 +88,32 @@ namespace leaf_usb {
     const bool success = USB.begin();
     if (success && !usb_started) {
       usb_started = true;
+      usb_connected = true;
       usb_started_ms = millis();
+    }
+    return success;
+  }
+
+  bool connect() {
+    if (!usb_started) return begin();
+    if (usb_connected) return true;
+
+    const bool success = tud_connect();
+    if (success) {
+      usb_connected = true;
+      usb_started_ms = millis();
+    }
+    return success;
+  }
+
+  bool disconnect() {
+    if (!usb_started || !usb_connected) return true;
+
+    const bool success = tud_disconnect();
+    if (success) {
+      usb_connected = false;
+      host_mounted = false;
+      host_suspended = false;
     }
     return success;
   }

--- a/src/vario/system/usb_state.h
+++ b/src/vario/system/usb_state.h
@@ -3,6 +3,8 @@
 namespace leaf_usb {
   void init();
   bool begin();
+  bool connect();
+  bool disconnect();
 
   bool started();
   bool hostMounted();

--- a/src/vario/taskman.cpp
+++ b/src/vario/taskman.cpp
@@ -173,7 +173,8 @@ void TaskManager::update() {
   // when re-entering PowerState::On, be sure to start from tasks #1, so baro ADC can be re-prepped
   // before reading
 
-  if (WiFi.status() == WL_CONNECTED || webserver_user_app_active()) {
+  if (sdcard.firmwareOwnsMassStorage() &&
+      (WiFi.status() == WL_CONNECTED || webserver_user_app_active())) {
     webserver_setup();
     webserver_loop();
     factoryDiscovery.update();
@@ -197,6 +198,17 @@ void TaskManager::update() {
 void TaskManager::updateWhileCharging() {
   if (nextChargeTimerBlock.exchange(false, std::memory_order_acq_rel)) {
     leafLogSync.update();
+    if (leafLogSync.takePowerOnReady()) {
+      display.clear();
+      display.showOnSplash();
+      display.setPage((MainPage)settings.startPage);
+      speaker.playSound(fx::enter);
+      if (!power.switchToOnState()) {
+        display.setPage(MainPage::Charging);
+        display.update();
+      }
+      return;
+    }
     // Display Charging Page
     display.setPage(MainPage::Charging);
     display.update();  // update display based on battery charge state etc

--- a/src/vario/ui/display/pages/primary/page_charging.cpp
+++ b/src/vario/ui/display/pages/primary/page_charging.cpp
@@ -86,7 +86,7 @@ void chargingPage_draw() {
     // SD Card Mounted
     u8g2.setCursor(12, 191);
     u8g2.setFont(leaf_icons);
-    if (!sdcard.isMounted()) {
+    if (!sdcard.isCardPresent()) {
       u8g2.print((char)61);
       u8g2.setFont(leaf_6x12);
       u8g2.print(" NO SD!");
@@ -106,7 +106,7 @@ void chargingPage_draw() {
 
       u8g2.setFont(leaf_5x8);
       char status[32];
-      if (leafLogSync.retryPending()) {
+      if (leafLogSync.retryPending() || leafLogSync.powerOnPending()) {
         snprintf(status, sizeof(status), "%s", leafLogSync.statusLine());
       } else if (leafLogSync.progressKnown() && leafLogSync.totalCount() > 0) {
         snprintf(status, sizeof(status), "Uploading %u of %u", leafLogSync.currentCount(),
@@ -115,9 +115,16 @@ void chargingPage_draw() {
         snprintf(status, sizeof(status), "%s", leafLogSync.statusLine());
       }
       printCentered(status, 124);
-      printCentered("Press any button", 138);
-      printCentered("to cancel and", 148);
-      printCentered("enable USB drive", 158);
+      if (leafLogSync.powerOnPending()) {
+        printCentered("Please wait...", 148);
+      } else if (leafLogSync.massStorageUnavailable()) {
+        printCentered("Press to retry.", 143);
+        printCentered("Hold to turn on.", 155);
+      } else {
+        printCentered("Press to cancel", 138);
+        printCentered("and open USB drive.", 148);
+        printCentered("Hold to turn on.", 158);
+      }
       u8g2.setDrawColor(1);
     }
 
@@ -125,23 +132,20 @@ void chargingPage_draw() {
 }
 
 void chargingPage_button(Button button, ButtonEvent state, uint8_t count) {
-  if (button != Button::NONE && state == ButtonEvent::PRESSED &&
+  if (button == Button::CENTER && state == ButtonEvent::PRESSED &&
       leafLogSync.interceptsChargingButtons()) {
     leafLogSync.requestCancel();
+    display.update();
+    return;
+  }
+  if (button == Button::CENTER && state == ButtonEvent::HELD) {
+    leafLogSync.requestPowerOn();
     buttons.consumeButton();
     display.update();
     return;
   }
   switch (button) {
     case Button::CENTER:
-      if (state == ButtonEvent::INCREMENTED && count == 1) {
-        buttons.consumeButton();
-        display.clear();
-        display.showOnSplash();
-        display.setPage((MainPage)settings.startPage);
-        speaker.playSound(fx::enter);
-        power.switchToOnState();
-      }
       break;
     case Button::UP:
       switch (state) {

--- a/tools and analysis/utils/SD_Card_Testing/MSC_Reference_Test/README.md
+++ b/tools and analysis/utils/SD_Card_Testing/MSC_Reference_Test/README.md
@@ -1,0 +1,39 @@
+# ESP32-S3 SDMMC USB MSC reference test
+
+This isolated firmware tests the SD-to-USB data path without mounting FAT in firmware and without
+running the Leaf application, Leaf Log, diagnostics, Wi-Fi, or the SD ownership state machine.
+
+Configuration:
+
+- Leaf hardware v3.2.6/v3.2.7 SDMMC pins
+- Native ESP32-S3 USB device peripheral
+- USB MSC only
+- 4-bit SDMMC at 20 MHz
+- 4 KiB DMA-capable staging buffer
+- One multi-sector `sdmmc_read_sectors()` or `sdmmc_write_sectors()` operation per USB callback
+
+The green status LED is steady when initialization succeeds. It blinks rapidly after the first
+SDMMC read or write failure.
+
+Build from this directory with:
+
+```powershell
+C:\Users\oxoth\.platformio\penv\Scripts\pio.exe run -e leaf_3_2_6_msc_reference
+```
+
+Test with the same card, cable, computer, and large source file used for the Leaf firmware tests.
+Record elapsed time, Windows' displayed rate, whether the LUN disappears, and the final file hash.
+Eject the volume before removing power whenever possible.
+
+## Comparison results
+
+Using the same approximately 45 MB file, SD card, Leaf, cable, and Windows computer:
+
+- 4 KiB multi-sector transactions completed a write in approximately 90 seconds, about 500 KB/s
+  actual throughput, without disconnects.
+- 512-byte single-sector transactions completed the same write in approximately 7.5 minutes,
+  about 100 KB/s actual throughput, without disconnects.
+- Raising the 4 KiB test from 20 MHz to 40 MHz did not improve end-to-end throughput.
+
+These results show that multi-sector batching accounts for most of the performance improvement,
+while 20 MHz already exceeds the throughput required by the USB MSC path.

--- a/tools and analysis/utils/SD_Card_Testing/MSC_Reference_Test/platformio.ini
+++ b/tools and analysis/utils/SD_Card_Testing/MSC_Reference_Test/platformio.ini
@@ -1,0 +1,20 @@
+[platformio]
+src_dir = src
+
+[env:leaf_3_2_6_msc_reference]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.10/platform-espressif32.zip
+board = esp32-s3-devkitc-1
+framework = arduino
+
+board_build.flash_mode = qio
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
+
+build_unflags = -D ARDUINO_USB_MODE
+build_flags =
+    -D ARDUINO_USB_MODE=0
+    -D ARDUINO_USB_CDC_ON_BOOT=0
+    -D ARDUINO_USB_MSC_ON_BOOT=0
+    -D ARDUINO_USB_DFU_ON_BOOT=0
+
+monitor_speed = 115200

--- a/tools and analysis/utils/SD_Card_Testing/MSC_Reference_Test/src/main.cpp
+++ b/tools and analysis/utils/SD_Card_Testing/MSC_Reference_Test/src/main.cpp
@@ -1,0 +1,184 @@
+#include <Arduino.h>
+#include <USB.h>
+#include <USBMSC.h>
+#include <driver/sdmmc_host.h>
+#include <esp_err.h>
+#include <sdmmc_cmd.h>
+
+#if CONFIG_IDF_TARGET_ESP32S3
+#include <soc/rtc_cntl_reg.h>
+#include <soc/soc.h>
+#include <soc/usb_pins.h>
+#include <soc/usb_serial_jtag_reg.h>
+#endif
+
+namespace {
+  constexpr gpio_num_t SD_CLK = GPIO_NUM_36;
+  constexpr gpio_num_t SD_CMD = GPIO_NUM_35;
+  constexpr gpio_num_t SD_D0 = GPIO_NUM_37;
+  constexpr gpio_num_t SD_D1 = GPIO_NUM_38;
+  constexpr gpio_num_t SD_D2 = GPIO_NUM_33;
+  constexpr gpio_num_t SD_D3 = GPIO_NUM_34;
+  constexpr uint32_t SD_SECTOR_SIZE = 512;
+  constexpr uint32_t MSC_BUFFER_SIZE = 4096;
+  constexpr uint8_t STATUS_LED_PIN = 47;
+  constexpr uint16_t REFERENCE_TEST_PID = 0x4002;
+
+  static_assert(MSC_BUFFER_SIZE % SD_SECTOR_SIZE == 0);
+
+  USBMSC msc;
+  sdmmc_card_t card = {};
+  bool ready = false;
+  bool failed = false;
+
+  // Match the production MSC path: one DMA-capable staging buffer and one multi-sector SDMMC
+  // transaction for each complete USB MSC request, capped at 4 KiB.
+  DMA_ATTR uint8_t mscBuffer[MSC_BUFFER_SIZE] __attribute__((aligned(4)));
+
+  void indicateFailure() {
+    failed = true;
+    ready = false;
+    digitalWrite(STATUS_LED_PIN, LOW);
+  }
+
+  bool requestIsValid(uint32_t lba, uint32_t offset, uint32_t bufsize) {
+    if (offset % SD_SECTOR_SIZE != 0 || bufsize == 0 || bufsize % SD_SECTOR_SIZE != 0 ||
+        bufsize > MSC_BUFFER_SIZE) {
+      return false;
+    }
+
+    const uint64_t firstSector = static_cast<uint64_t>(lba) + offset / SD_SECTOR_SIZE;
+    const uint64_t sectorCount = bufsize / SD_SECTOR_SIZE;
+    return firstSector + sectorCount <= card.csd.capacity;
+  }
+
+  int32_t onRead(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
+    if (!ready || !requestIsValid(lba, offset, bufsize)) return -1;
+
+    const uint32_t firstSector = lba + offset / SD_SECTOR_SIZE;
+    const size_t sectorCount = bufsize / SD_SECTOR_SIZE;
+    const esp_err_t result = sdmmc_read_sectors(&card, mscBuffer, firstSector, sectorCount);
+    if (result != ESP_OK) {
+      indicateFailure();
+      return -1;
+    }
+
+    memcpy(buffer, mscBuffer, bufsize);
+    return static_cast<int32_t>(bufsize);
+  }
+
+  int32_t onWrite(uint32_t lba, uint32_t offset, uint8_t* buffer, uint32_t bufsize) {
+    if (!ready || !requestIsValid(lba, offset, bufsize)) return -1;
+
+    memcpy(mscBuffer, buffer, bufsize);
+    const uint32_t firstSector = lba + offset / SD_SECTOR_SIZE;
+    const size_t sectorCount = bufsize / SD_SECTOR_SIZE;
+    const esp_err_t result = sdmmc_write_sectors(&card, mscBuffer, firstSector, sectorCount);
+    if (result != ESP_OK) {
+      indicateFailure();
+      return -1;
+    }
+
+    return static_cast<int32_t>(bufsize);
+  }
+
+  bool onStartStop(uint8_t, bool, bool) { return true; }
+
+  void prepareNativeUsbTakeover() {
+#if CONFIG_IDF_TARGET_ESP32S3
+    CLEAR_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_USB_PAD_ENABLE);
+    CLEAR_PERI_REG_MASK(USB_SERIAL_JTAG_CONF0_REG, USB_SERIAL_JTAG_PHY_SEL);
+    SET_PERI_REG_MASK(RTC_CNTL_USB_CONF_REG, RTC_CNTL_SW_HW_USB_PHY_SEL | RTC_CNTL_SW_USB_PHY_SEL |
+                                                 RTC_CNTL_USB_PAD_ENABLE);
+
+    pinMode(USBPHY_DM_NUM, OUTPUT_OPEN_DRAIN);
+    pinMode(USBPHY_DP_NUM, OUTPUT_OPEN_DRAIN);
+    digitalWrite(USBPHY_DM_NUM, LOW);
+    digitalWrite(USBPHY_DP_NUM, LOW);
+    delay(25);
+#endif
+  }
+
+  esp_err_t initializeSdCard() {
+    sdmmc_host_t host = SDMMC_HOST_DEFAULT();
+    host.slot = SDMMC_HOST_SLOT_1;
+    host.flags = SDMMC_HOST_FLAG_4BIT;
+    host.max_freq_khz = SDMMC_FREQ_DEFAULT;
+
+    sdmmc_slot_config_t slot = SDMMC_SLOT_CONFIG_DEFAULT();
+    slot.clk = SD_CLK;
+    slot.cmd = SD_CMD;
+    slot.d0 = SD_D0;
+    slot.d1 = SD_D1;
+    slot.d2 = SD_D2;
+    slot.d3 = SD_D3;
+    slot.width = 4;
+    // Leaf has external pull-ups. Enabling the internal pull-ups as well matches Espressif's
+    // reference example and is harmless for this isolated test.
+    slot.flags |= SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
+
+    esp_err_t result = sdmmc_host_init();
+    if (result != ESP_OK) return result;
+
+    result = sdmmc_host_init_slot(host.slot, &slot);
+    if (result != ESP_OK) {
+      sdmmc_host_deinit();
+      return result;
+    }
+
+    result = sdmmc_card_init(&host, &card);
+    if (result != ESP_OK) {
+      sdmmc_host_deinit();
+      return result;
+    }
+
+    return ESP_OK;
+  }
+}  // namespace
+
+void setup() {
+  pinMode(STATUS_LED_PIN, OUTPUT);
+  digitalWrite(STATUS_LED_PIN, LOW);
+
+  if (initializeSdCard() != ESP_OK || card.csd.sector_size != SD_SECTOR_SIZE ||
+      card.csd.capacity == 0) {
+    indicateFailure();
+    return;
+  }
+
+  msc.vendorID("Leaf");
+  msc.productID("MSC_Reference");
+  msc.productRevision("1.0");
+  msc.onRead(onRead);
+  msc.onWrite(onWrite);
+  msc.onStartStop(onStartStop);
+  msc.isWritable(true);
+  msc.mediaPresent(true);
+  if (!msc.begin(card.csd.capacity, card.csd.sector_size)) {
+    indicateFailure();
+    return;
+  }
+
+  USB.manufacturerName("Leaf");
+  USB.productName("Leaf MSC Reference");
+  USB.PID(REFERENCE_TEST_PID);
+  prepareNativeUsbTakeover();
+  ready = true;
+  if (!USB.begin()) {
+    ready = false;
+    indicateFailure();
+    return;
+  }
+
+  digitalWrite(STATUS_LED_PIN, HIGH);
+}
+
+void loop() {
+  if (!failed) {
+    delay(1000);
+    return;
+  }
+
+  digitalWrite(STATUS_LED_PIN, !digitalRead(STATUS_LED_PIN));
+  delay(250);
+}


### PR DESCRIPTION
## Summary

- enforce exclusive SD-card ownership between Leaf firmware and the USB mass-storage host
- make a short Center press cancel Leaf Log activity into USB storage, while a Center hold closes USB and powers on safely
- quiesce mass-storage traffic before reclaiming the SD card and handle host eject, USB reconnect, SD insertion, and charge-mode transitions deterministically
- suspend diagnostics and other firmware SD writes while the host owns the card
- use a temporary, recoverable 4 KiB mass-storage transfer buffer for substantially faster transfers without reserving that RAM in normal operation
- harden Leaf Log cancellation, retry, and failure cleanup around ownership transitions
- include the isolated ESP32-S3 mass-storage reference firmware used to validate the transfer path

## Verification

- formatted with `src\scripts\format_all_files.ps1`
- built `leaf_3_2_6_release` successfully after rebasing onto `main`
- exercised on Leaf 3.2.6 hardware with development diagnostics both enabled and disabled
- verified a roughly 45 MB host-to-Leaf write in about 90 seconds and a Leaf-to-host read in about 55 seconds; copied files matched
- verified clean Windows eject, repeated mass-storage sessions, and healthy volume checks after proper eject
- verified diagnostics remain static while USB owns the SD and resume between mass-storage sessions
- verified short versus long Center presses, power-on during an active host write, no-SD startup and insertion, and unplug/replug upload resume
- verified Leaf reaches normal operating mode after deliberate USB revocation; Windows reports the expected interrupted-transfer error when power-on is requested mid-write

## Notes

A Center hold during an active host write deliberately revokes the USB device so Leaf can power on. The interrupted host write is inherently not guaranteed to be filesystem-safe; normal eject remains the recommended path when preserving an in-progress write matters.