### PR TITLE
Remove seeded ThermalTrack test data

### DIFF
--- a/src/vario/logging/log.cpp
+++ b/src/vario/logging/log.cpp
@@ -117,7 +117,6 @@ void log_update() {
 
         // get first set of log values
         log_captureValues();
-        if (settings.labs_thermalTrack) thermalTracker.seedTestThermalsForFlight();
 
         // initial min/max values
         logbook.alt_max = logbook.alt_start;
@@ -279,6 +278,8 @@ void flightTimer_start() {
     return;
   }
 
+  flightTimer_resetAutoStop();
+
   // start timer
   speaker.playSound(fx::enter);
   settings.resetShortcutVolume();
@@ -301,6 +302,7 @@ void flightTimer_stop(bool showSummary) {
   windEstimator.clearWindEstimate();  // clear the wind estimate when we stop a flight
   power.resetAutoOffCounter();  // reset the auto-off counter when we stop a flight (it could have
                                 // counted up to nearly the limit prior to auto-starting a log)
+  flightTimer_resetAutoStop();
   // Short Circuit, no need to do anything if there's no flight recording.
   if (flight == NULL) {
     return;

--- a/src/vario/navigation/thermal_tracker.cpp
+++ b/src/vario/navigation/thermal_tracker.cpp
@@ -55,7 +55,6 @@ namespace {
 
 void ThermalTracker::reset() {
   originValid_ = false;
-  seededThisFlight_ = false;
   lastDetectorSecond_ = 0;
   lastLatE7_ = 0;
   lastLonE7_ = 0;
@@ -97,29 +96,6 @@ bool ThermalTracker::readCurrentFix(Sample& sample) {
   currentAltM_ = sample.altM;
   currentTrackDeg_ = sample.courseDeg;
   return true;
-}
-
-void ThermalTracker::readSeedReference(Sample& sample) {
-  GPSPositionSnapshot fix;
-  const bool hasFix = gps.lastValidFix(fix);
-  const double latitude = hasFix ? fix.latitude : 0.0;
-  const double longitude = hasFix ? fix.longitude : 0.0;
-  if (!originValid_) establishOrigin(latitude, longitude);
-
-  sample.valid = true;
-  sample.xM = clampInt16((longitude - originLon_) * metersPerDegLon_);
-  sample.yM = clampInt16((latitude - originLat_) * METERS_PER_DEG_LAT);
-  sample.altM = static_cast<int16_t>(baro.altAdjusted() / 100);
-  sample.courseDeg = hasFix ? static_cast<int16_t>(roundf(fix.courseDeg)) : 0;
-  sample.climb1SecCms = static_cast<int16_t>(constrain(
-      baro.climbRate1SecAverageValid() ? baro.climbRate1SecAverage() : baro.climbRateFiltered(),
-      -32768L, 32767L));
-  sample.timeS = millis() / 1000;
-
-  currentXM_ = sample.xM;
-  currentYM_ = sample.yM;
-  currentAltM_ = sample.altM;
-  currentTrackDeg_ = sample.courseDeg;
 }
 
 void ThermalTracker::updateDetector() {
@@ -595,14 +571,12 @@ void ThermalTracker::mergeThermal(uint8_t target, const ThermalNode* nodes, uint
   thermal.avgClimbCms =
       (thermal.avgClimbCms * oldDuration + avgClimbCms * newDuration) / totalDuration;
   thermal.lastSeenS = millis() / 1000;
-  thermal.seeded = false;
 }
 
 void ThermalTracker::storeThermal(const ThermalNode* nodes, uint8_t nodeCount, int16_t gainM,
                                   int16_t avgClimbCms, uint16_t durationS) {
   SavedThermal& thermal = thermals_[replacementIndex()];
   thermal.valid = true;
-  thermal.seeded = false;
   thermal.nodeCount = min<uint8_t>(nodeCount, MAX_THERMAL_NODES);
   for (uint8_t i = 0; i < thermal.nodeCount; ++i) thermal.nodes[i] = nodes[i];
   thermal.gainM = gainM;
@@ -621,7 +595,6 @@ uint8_t ThermalTracker::replacementIndex() const {
   for (uint8_t i = 0; i < MAX_SAVED_THERMALS; ++i) {
     const SavedThermal& thermal = thermals_[i];
     int32_t score = thermal.gainM + thermal.avgClimbCms + thermal.durationS / 2;
-    if (thermal.seeded) score -= 10000;
     if (score < weakestScore) {
       weakestScore = score;
       weakest = i;
@@ -757,41 +730,4 @@ uint8_t ThermalTracker::savedThermalCount() const {
     if (thermal.valid) count++;
   }
   return count;
-}
-
-void ThermalTracker::seedTestThermalsForFlight() {
-  if (seededThisFlight_) return;
-
-  Sample current;
-  readSeedReference(current);
-  memset(thermals_, 0, sizeof(thermals_));
-
-  const int16_t bearingsDeg[MAX_SAVED_THERMALS] = {-6,  18,   -38, 55,  -72, 96,  -118, 145,
-                                                   178, -165, 28,  -24, 72,  -88, 122};
-  const uint16_t distancesM[MAX_SAVED_THERMALS] = {420,  780,  1100, 1450, 1800, 2300, 2700, 3200,
-                                                   3800, 4400, 5200, 5600, 6100, 6600, 7000};
-  const uint8_t targetQualities[MAX_SAVED_THERMALS] = {1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5};
-
-  for (uint8_t i = 0; i < MAX_SAVED_THERMALS; ++i) {
-    SavedThermal& thermal = thermals_[i];
-    thermal.valid = true;
-    thermal.seeded = true;
-    thermal.nodeCount = MAX_THERMAL_NODES;
-    thermal.avgClimbCms = targetQualities[i] >= 4 ? 260 : targetQualities[i] == 3 ? 125 : 80;
-    thermal.gainM = targetQualities[i] == 5 ? 315 : 90;
-    thermal.durationS = 60 + (i % 5) * 50;
-    thermal.lastSeenS = millis() / 1000;
-
-    const float absoluteBearing = currentTrackDeg_ + bearingsDeg[i];
-    const int16_t baseX = currentXM_ + sin(absoluteBearing * DEG_TO_RAD) * distancesM[i];
-    const int16_t baseY = currentYM_ + cos(absoluteBearing * DEG_TO_RAD) * distancesM[i];
-    const int16_t baseAltitudeOffsetM = targetQualities[i] == 1 ? 600 : -180 + (i % 4) * 80;
-    for (uint8_t n = 0; n < MAX_THERMAL_NODES; ++n) {
-      thermal.nodes[n].xM = baseX + (static_cast<int8_t>(n) - 1) * (8 + i % 4);
-      thermal.nodes[n].yM = baseY + n * (10 + i % 5);
-      thermal.nodes[n].altM = currentAltM_ + baseAltitudeOffsetM + n * 120;
-    }
-  }
-  seededThisFlight_ = true;
-  rebuildDisplayItems();
 }

--- a/src/vario/navigation/thermal_tracker.h
+++ b/src/vario/navigation/thermal_tracker.h
@@ -14,7 +14,6 @@ struct ThermalNode {
 
 struct SavedThermal {
   bool valid = false;
-  bool seeded = false;
   uint8_t nodeCount = 0;
   ThermalNode nodes[MAX_THERMAL_NODES];
   int16_t avgClimbCms = 0;
@@ -54,7 +53,6 @@ class ThermalTracker {
   void reset();
   void updateDetector();
   void updateNavigation();
-  void seedTestThermalsForFlight();
   uint8_t recentCoreSamples(CoreSample* out, uint8_t maxCount) const;
 
   const ThermalDisplayItem* displayItems() const { return displayItems_; }
@@ -122,7 +120,6 @@ class ThermalTracker {
   static constexpr double METERS_PER_DEG_LAT = 111320.0;
 
   bool readCurrentFix(Sample& sample);
-  void readSeedReference(Sample& sample);
   void establishOrigin(double latitude, double longitude);
   void addSample(Sample sample);
   void evaluateDetector();
@@ -168,8 +165,6 @@ class ThermalTracker {
   uint32_t lastDetectorSecond_ = 0;
   int32_t lastLatE7_ = 0;
   int32_t lastLonE7_ = 0;
-  bool seededThisFlight_ = false;
-
   Sample samples_[MAX_DETECTOR_SAMPLES];
   uint8_t nextSample_ = 0;
   uint8_t sampleCount_ = 0;


### PR DESCRIPTION
## Summary

- remove the fake ThermalTrack thermals seeded when flight logging begins
- remove the test-only seeded thermal state and replacement handling
- minor bug fix: reset the auto-stop countdown whenever a flight starts or stops

## Verification

- ran the firmware formatter
- built `leaf_3_2_6_release` successfully
- flashed both OTA application slots and verified both image hashes
- starting a flight now does not pre-populate the ThermalTrack page with fake thermals
- manually confirmed repeated flight starts receive a fresh 20-second auto-stop countdown
