### PR TITLE
Fix the emulator against main + review follow-ups

### DIFF
--- a/sim/README.md
+++ b/sim/README.md
@@ -165,8 +165,14 @@ POST /api/clock              {"speed":10} {"paused":true} {"stepMs":500}
 POST /api/scenario           {"load":"flight.igc"} {"play":true} {"seek":42.0}
 POST /api/inject             {"line":"P1234,92310"}
 POST /api/board              {"batteryPercent":42,"charging":true,"cardPresent":false}
-POST /api/restart            reboot the emulated device
+POST /api/restart            reboot the emulated device (a real process restart)
 ```
+
+`seek` moves the recording's cursor and nothing else. The firmware keeps the state it had already
+reached -- barometer filters, GPS fix, navigation, the flight timer, the open log -- so seeking
+back replays earlier data into later state, and seeking forward skips everything in between. To
+land the device in the state a given moment of a flight would really have produced, restart and
+replay to that time at `--speed 0`.
 
 ## What is real and what is not
 

--- a/sim/device/comms.cpp
+++ b/sim/device/comms.cpp
@@ -11,6 +11,7 @@
 
 #include "comms/ble.h"
 #include "comms/factory_discovery.h"
+#include "comms/leaf_log_client.h"
 #include "comms/ota.h"
 #include "comms/sd_firmware_update.h"
 #include "comms/webserver.h"
@@ -99,6 +100,17 @@ String webserver_user_app_url() { return String(); }
 String webserver_leaf_ap_ssid() { return String(); }
 String webserver_leaf_ap_password() { return String(); }
 String webserver_leaf_ap_wifi_qr() { return String(); }
+
+// ---------------------------------------------------------------- Leaf Log
+//
+// leaf_log_client.cpp and leaf_log_sync.cpp are real firmware, compiled for the emulator like
+// everything above storage/network hardware -- but these two accessors live inside webserver.cpp
+// upstream, which is excluded here (see FW_EXCLUDE), so they need a stand-in too. HTTPClient::begin
+// always fails in the emulator (no network path out), so neither value is ever actually used for a
+// request; the CA cert is left empty rather than duplicating the real PEM for no reason.
+
+const char* leafLogBaseUrl() { return "https://leaflog.norcalflight.com"; }
+const char* leafLogCaCertificate() { return ""; }
 
 // ---------------------------------------------------------------- OTA and SD firmware update
 

--- a/sim/device/sd_card.cpp
+++ b/sim/device/sd_card.cpp
@@ -84,7 +84,7 @@ bool SDCard::presentMassStorage() { return false; }
 bool SDCard::reserveForFirmwareUpload() {
   SDCardOwnership expected = SDCardOwnership::FirmwareReserved;
   return ownership_.compare_exchange_strong(expected, SDCardOwnership::FirmwareUploading,
-                                             std::memory_order_acq_rel);
+                                            std::memory_order_acq_rel);
 }
 
 bool SDCard::acquireForFirmwareUse(uint32_t timeoutMs, bool disconnectUsb) {
@@ -115,7 +115,7 @@ int32_t SDCard::readHostSectors(uint32_t lba, uint32_t offset, void* buffer, uin
 }
 
 int32_t SDCard::writeHostSectors(uint32_t lba, uint32_t offset, const uint8_t* buffer,
-                                  uint32_t bufsize) {
+                                 uint32_t bufsize) {
   (void)lba;
   (void)offset;
   (void)buffer;

--- a/sim/device/sd_card.cpp
+++ b/sim/device/sd_card.cpp
@@ -1,9 +1,13 @@
 // The emulated SD card, replacing storage/sd_card.cpp.
 //
-// The real one drives an SDIO host, an ESP-IDF FAT mount and a USB mass-storage endpoint, none of
-// which exist here.  What matters to the rest of the firmware is preserved: a card that can be
-// present or absent, mounted or unmounted, with insertion and removal noticed by the periodic
-// update() -- backed by a host directory instead of a FAT volume.
+// The real one drives an SDIO host, an ESP-IDF FAT mount and a USB mass-storage endpoint that can
+// hand the card to a connected computer. None of that exists here, and there is no host to hand
+// the card to, so the emulated card never leaves firmware ownership -- what matters to the rest of
+// the firmware is preserved: a card that can be present or absent, mounted or unmounted, with
+// insertion and removal noticed by the periodic update(), backed by a host directory instead of a
+// FAT volume. Mass-storage and ownership-handoff calls keep the real contract's shapes so callers
+// do not need to special-case the emulator, but they decline rather than pretend to hand the card
+// to a host that is not there.
 
 #include <Arduino.h>
 #include <SD_MMC.h>
@@ -17,7 +21,8 @@ SDCard sdcard;
 
 bool SDCard::isCardPresent() { return SD_MMC.simPresent(); }
 
-void SDCard::init(void) {
+void SDCard::init(bool reserveMassStorage) {
+  reserveMassStorageOnMount_ = reserveMassStorage;
   Serial.println("SD card: emulated (backed by a host directory)");
   mount();
 }
@@ -52,7 +57,7 @@ void SDCard::update() {
 bool SDCard::format() { return formatDetailed().formatted; }
 
 SDCard::FormatResult SDCard::formatDetailed() {
-  // Formatting would mean deleting the user's folder of test data.  The emulator declines, and
+  // Formatting would mean deleting the user's folder of test data. The emulator declines, and
   // says so, rather than quietly reporting success it did not achieve.
   FormatResult result;
   result.stage = "not_supported_in_emulator";
@@ -65,7 +70,58 @@ SDCard::FormatResult SDCard::formatDetailed() {
 SDCard::FormatResult SDCard::remountAfterFormat() { return formatDetailed(); }
 
 bool SDCard::setLabel() { return true; }
-bool SDCard::setupMassStorage() { return false; }
+
+// There is no USB host in the emulator, so the card is never actually handed off: these keep the
+// real contract's return values and ownership bookkeeping, but ownership never leaves the
+// firmware.
+bool SDCard::setupMassStorage(bool mediaPresent) {
+  (void)mediaPresent;
+  return false;
+}
+
+bool SDCard::presentMassStorage() { return false; }
+
+bool SDCard::reserveForFirmwareUpload() {
+  SDCardOwnership expected = SDCardOwnership::FirmwareReserved;
+  return ownership_.compare_exchange_strong(expected, SDCardOwnership::FirmwareUploading,
+                                             std::memory_order_acq_rel);
+}
+
+bool SDCard::acquireForFirmwareUse(uint32_t timeoutMs, bool disconnectUsb) {
+  (void)timeoutMs;
+  (void)disconnectUsb;
+  ownership_.store(SDCardOwnership::FirmwareReserved, std::memory_order_release);
+  return true;
+}
+
+void SDCard::keepMassStorageEjected() {}
+
+void SDCard::notifyExplicitEject() {}
+
+bool SDCard::takeExplicitEject() { return false; }
+
+void SDCard::updateUsbOwnership() {}
+
+bool SDCard::beginHostIo() { return false; }
+
+void SDCard::endHostIo() {}
+
+int32_t SDCard::readHostSectors(uint32_t lba, uint32_t offset, void* buffer, uint32_t bufsize) {
+  (void)lba;
+  (void)offset;
+  (void)buffer;
+  (void)bufsize;
+  return -1;
+}
+
+int32_t SDCard::writeHostSectors(uint32_t lba, uint32_t offset, const uint8_t* buffer,
+                                  uint32_t bufsize) {
+  (void)lba;
+  (void)offset;
+  (void)buffer;
+  (void)bufsize;
+  return -1;
+}
 
 bool SDCard::formatUnmounted(esp_err_t& error, const char*& stage) {
   error = ESP_ERR_NOT_SUPPORTED;

--- a/sim/device/usb.cpp
+++ b/sim/device/usb.cpp
@@ -11,6 +11,8 @@ namespace leaf_usb {
 
   void init() {}
   bool begin() { return true; }
+  bool connect() { return true; }
+  bool disconnect() { return true; }
   bool started() { return true; }
   bool hostMounted() { return false; }
   bool hostSuspended() { return false; }

--- a/sim/emulator/http_server.cpp
+++ b/sim/emulator/http_server.cpp
@@ -3,6 +3,7 @@
 #include <ArduinoJson.h>
 #include <SD_MMC.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netinet/in.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -183,7 +184,9 @@ namespace sim {
   HttpServer::~HttpServer() { stop(); }
 
   bool HttpServer::start(uint16_t port) {
-    listenSocket_ = ::socket(AF_INET, SOCK_STREAM, 0);
+    // Close-on-exec throughout: a device restart replaces the process image, and a listening
+    // socket inherited into the new one would still hold the port when it tries to bind.
+    listenSocket_ = ::socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (listenSocket_ < 0) return false;
 
     int reuse = 1;
@@ -222,7 +225,7 @@ namespace sim {
 
   void HttpServer::acceptLoop() {
     while (running_) {
-      const int client = ::accept(listenSocket_, nullptr, nullptr);
+      const int client = ::accept4(listenSocket_, nullptr, nullptr, SOCK_CLOEXEC);
       if (client < 0) continue;
       std::thread([this, client] {
         handleConnection(client);
@@ -337,6 +340,12 @@ namespace sim {
       if (!sendString(client, header)) return;
 
       uint64_t lastFrame = UINT64_MAX;
+      // Cursors of this connection's own, so several open tabs each see the whole stream
+      // instead of dividing it between them, and a script's expect-serial keeps its lines.
+      // The console starts at zero -- a tab opened late still gets the boot log -- while tones
+      // start at the present, because replaying an hour of beeps at someone is not useful.
+      uint64_t serialCursor = 0;
+      uint64_t toneCursor = board().toneEventCount();
       while (running_) {
         const uint64_t sequence = device.frameSequence();
         if (sequence != lastFrame) {
@@ -351,12 +360,14 @@ namespace sim {
           return;
         }
 
-        const auto lines = device.drainSerial();
+        std::vector<std::string> lines;
+        serialCursor = device.serialSince(serialCursor, lines);
         for (const std::string& line : lines) {
           if (!sendString(client, "event: serial\ndata: \"" + jsonEscape(line) + "\"\n\n")) return;
         }
 
-        const auto tones = board().drainToneEvents();
+        std::vector<ToneEvent> tones;
+        toneCursor = board().toneEventsSince(toneCursor, tones);
         for (const ToneEvent& tone : tones) {
           std::ostringstream out;
           out << "event: tone\ndata: {\"atMs\":" << tone.atMs << ",\"hz\":" << tone.frequencyHz

--- a/sim/emulator/http_server.cpp
+++ b/sim/emulator/http_server.cpp
@@ -207,14 +207,14 @@ namespace sim {
       return false;
     }
 
-    running_ = true;
+    running_->store(true);
     acceptThread_ = std::thread([this] { acceptLoop(); });
     return true;
   }
 
   void HttpServer::stop() {
-    if (!running_) return;
-    running_ = false;
+    if (!running_->load()) return;
+    running_->store(false);
     if (listenSocket_ >= 0) {
       ::shutdown(listenSocket_, SHUT_RDWR);
       ::close(listenSocket_);
@@ -224,17 +224,19 @@ namespace sim {
   }
 
   void HttpServer::acceptLoop() {
-    while (running_) {
+    while (running_->load()) {
       const int client = ::accept4(listenSocket_, nullptr, nullptr, SOCK_CLOEXEC);
       if (client < 0) continue;
-      std::thread([this, client] {
-        handleConnection(client);
+      // The flag goes with the thread rather than being read back off the server, which the
+      // detached thread can outlive.
+      std::thread([client, running = running_] {
+        handleConnection(client, *running);
         ::close(client);
       }).detach();
     }
   }
 
-  void HttpServer::handleConnection(int client) {
+  void HttpServer::handleConnection(int client, std::atomic<bool>& running) {
     // Read the request head, then the body if the headers promised one.
     std::string request;
     char buffer[4096];
@@ -346,7 +348,7 @@ namespace sim {
       // start at the present, because replaying an hour of beeps at someone is not useful.
       uint64_t serialCursor = 0;
       uint64_t toneCursor = board().toneEventCount();
-      while (running_) {
+      while (running.load()) {
         const uint64_t sequence = device.frameSequence();
         if (sequence != lastFrame) {
           lastFrame = sequence;

--- a/sim/emulator/http_server.h
+++ b/sim/emulator/http_server.h
@@ -1,7 +1,8 @@
 // The emulator's control surface: a small HTTP server for the browser panel and for scripts.
 //
-// Every request is handled on its own thread and turned into a command queued for the device
-// thread, so nothing here touches firmware state directly.
+// Every request is handled on its own thread.  Most are queued for the device thread; buttons,
+// board state and the clock are applied directly, on state guarded for it -- see runtime.h for
+// why those three cannot be queued.
 //
 //   GET  /                      the control panel
 //   GET  /api/state             device status as JSON
@@ -21,6 +22,7 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <memory>
 #include <string>
 #include <thread>
 
@@ -35,10 +37,12 @@ namespace sim {
 
    private:
     void acceptLoop();
-    void handleConnection(int client);
+    static void handleConnection(int client, std::atomic<bool>& running);
 
     int listenSocket_ = -1;
-    std::atomic<bool> running_{false};
+    // Shared rather than a member flag: connection threads are detached and an event stream only
+    // notices the shutdown on its next 50ms pass, which is long after the server itself is gone.
+    std::shared_ptr<std::atomic<bool>> running_ = std::make_shared<std::atomic<bool>>(false);
     std::thread acceptThread_;
   };
 

--- a/sim/emulator/main.cpp
+++ b/sim/emulator/main.cpp
@@ -58,6 +58,10 @@ namespace {
 }  // namespace
 
 int main(int argc, char** argv) {
+  // Kept before anything can consume argv: a restart replaces the process with this same command
+  // line, which is the only faithful way to emulate ESP.restart().
+  sim::Runtime::setRelaunchArguments(argc, argv);
+
   sim::Runtime::Options options;
   std::string scenarioPath;
   std::string scriptPath;
@@ -129,8 +133,10 @@ int main(int argc, char** argv) {
 
   options.screenshotOnExit = screenshotPath;
   options.screenshotScale = scale;
-  options.exitOnFatalError =
-      runSeconds > 0;  // headless runs report and stop; interactive ones wait
+  // Headless runs report and stop; interactive ones leave the error on screen.  A script is a
+  // headless run even without --run-seconds: its length comes from its last step below, long
+  // after configure() has to know whether to install the hook.
+  options.exitOnFatalError = runSeconds > 0 || !scriptPath.empty();
 
   sim::Runtime& device = sim::runtime();
   device.configure(options);

--- a/sim/emulator/runtime.cpp
+++ b/sim/emulator/runtime.cpp
@@ -5,7 +5,11 @@
 #include <SD_MMC.h>
 
 #include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include <chrono>
 #include <fstream>
@@ -50,6 +54,14 @@ namespace sim {
     // How long a queued "click" holds the button down: long enough to survive the 5ms debounce,
     // short enough that it never turns into a hold (800ms).
     constexpr uint32_t CLICK_HOLD_MS = 60;
+
+    // The command line to start again on a restart.
+    std::vector<std::string> g_relaunchArgs;
+
+    // A restart replaces the process, so a firmware bug that reboots on boot would otherwise
+    // fork-bomb a CI job with no output.  The count survives execv in the environment.
+    constexpr const char* RESTART_COUNT_ENV = "LEAFSIM_RESTART_COUNT";
+    constexpr long MAX_RESTARTS = 16;
 
     void ensureDirectory(const std::string& path) {
       if (path.empty()) return;
@@ -140,10 +152,43 @@ namespace sim {
     printf("leafsim: wrote %s\n", options_.screenshotOnExit.c_str());
   }
 
+  void Runtime::setRelaunchArguments(int argc, char** argv) {
+    g_relaunchArgs.clear();
+    for (int i = 0; i < argc; i++) g_relaunchArgs.push_back(argv[i]);
+  }
+
+  void Runtime::relaunch() {
+    // Re-running setup() is not a restart.  The firmware's globals are statics that outlive it:
+    // the message bus above all, whose subscriber list is a fixed-capacity vector setup() only
+    // ever appends to, so a second pass overflows it and fatal-errors on the way.  Timers, task
+    // state, the open log and the listening UDP server would all survive too.  Replacing the
+    // process image is the only thing here that is really ESP.restart(); everything that should
+    // outlive a reboot already lives outside the process, in the card and settings directories.
+    Serial.println("--- emulated device restarting ---");
+    Serial.flush();
+    fflush(stderr);
+
+    long restarts = 0;
+    if (const char* seen = getenv(RESTART_COUNT_ENV)) restarts = strtol(seen, nullptr, 10);
+    if (restarts >= MAX_RESTARTS) {
+      fprintf(stderr, "leafsim: %ld restarts, giving up rather than looping\n", restarts);
+      exit(4);
+    }
+    setenv(RESTART_COUNT_ENV, std::to_string(restarts + 1).c_str(), 1);
+
+    std::vector<char*> argv;
+    for (std::string& argument : g_relaunchArgs) argv.push_back(&argument[0]);
+    argv.push_back(nullptr);
+    execvp(argv[0], argv.data());
+
+    fprintf(stderr, "leafsim: could not restart: %s\n", strerror(errno));
+    exit(4);
+  }
+
   void Runtime::boot() {
-    // A reboot re-runs setup(), which installs the task timers again.  The old ones have to go
-    // first, or the device would run its task schedule twice over.  (Firmware statics do not
-    // reset, so this is a warm restart, not a power cycle.)
+    // Timers are installed by setup(); the emulated device only ever boots once per process (a
+    // restart is a new process, see relaunch()), but clearing them keeps boot() honest about
+    // what it assumes.
     clock().clearTimers();
 
     Board& b = board();
@@ -191,11 +236,7 @@ namespace sim {
       updateStatus();
     }
 
-    if (g_restartRequested) {
-      g_restartRequested = false;
-      Serial.println("--- emulated device restarting ---");
-      booted_ = false;
-    }
+    if (g_restartRequested) relaunch();
   }
 
   void Runtime::run() {
@@ -314,7 +355,9 @@ namespace sim {
     clock().setPaused(false);
   }
 
-  void Runtime::restart() { g_restartRequested = true; }
+  void Runtime::restart() {
+    g_restartRequested = true;
+  }  // acted on by step(), on the device thread
 
   // ---------------------------------------------------------------- observation
 
@@ -323,7 +366,9 @@ namespace sim {
     std::lock_guard<std::mutex> lock(stateMutex_);
     if (!(captured == frame_)) {
       frame_ = std::move(captured);
-      frameSequence_++;
+      // Released after the frame is in place, so a reader that sees the new sequence number and
+      // then takes the lock cannot come away with the previous frame.
+      frameSequence_.fetch_add(1, std::memory_order_release);
     }
   }
 
@@ -392,7 +437,11 @@ namespace sim {
     return status_;
   }
 
-  std::vector<std::string> Runtime::drainSerial() { return HostConsole::drainLines(); }
+  uint64_t Runtime::serialSince(uint64_t cursor, std::vector<std::string>& into) {
+    return HostConsole::linesSince(cursor, into);
+  }
+
+  uint64_t Runtime::serialCursor() { return HostConsole::lineCount(); }
 
   std::string Runtime::screenshotPng(int scale) { return encodePng(frame(), scale); }
 

--- a/sim/emulator/runtime.h
+++ b/sim/emulator/runtime.h
@@ -1,9 +1,16 @@
 // The emulated device: the firmware's setup()/loop() driven by the virtual clock.
 //
 // Everything the firmware does happens on one thread (the "device thread"), exactly as it does on
-// the ESP32's Arduino loop task.  The HTTP server runs on other threads and never touches
-// firmware state directly; it queues commands that the device thread applies between passes
-// through loop(), which keeps the emulator free of races the real device cannot have.
+// the ESP32's Arduino loop task.  The HTTP server runs on other threads and never calls into
+// firmware; it queues commands that the device thread applies between passes through loop(),
+// which keeps the emulator free of races the real device cannot have.
+//
+// Three things deliberately do not go through that queue, because queueing them would not work:
+// button presses and board state are pin writes rather than firmware calls, and a device halted
+// in the fatal-error handler is still reading pins while draining no queue; and the clock is
+// driven straight from the asking thread, because a paused clock blocks the device thread inside
+// advanceUs(), so the thread that unpauses cannot be the one waiting to drain the queue.  The
+// state all three touch is guarded by its own mutex or atomics -- see Board and Clock.
 #pragma once
 
 #include <stdint.h>
@@ -118,13 +125,28 @@ namespace sim {
     void setSpeed(double speed);
     void setPaused(bool paused);
     void stepMilliseconds(uint32_t ms);
+
+    // Reboots the device, which means replacing this process: see relaunch() in runtime.cpp for
+    // why re-running setup() is not a restart.  Also reached from the firmware's own
+    // ESP.restart(), so a settings reset or the fatal-error handler's reboot behaves the same.
     void restart();
+
+    // The command line this process was started with, kept so a restart can start it again.
+    static void setRelaunchArguments(int argc, char** argv);
 
     // ---------------------------------------------------------------- observation (any thread)
     Frame frame();
-    uint64_t frameSequence() const { return frameSequence_; }
+    // Bumped by the device thread whenever the screen changes; the event stream polls it from its
+    // own thread to decide whether a new frame is worth sending, so it is atomic rather than
+    // guarded by stateMutex_ -- the poll must not queue behind a frame copy.
+    uint64_t frameSequence() const { return frameSequence_.load(std::memory_order_acquire); }
     Status status();
-    std::vector<std::string> drainSerial();
+    // Console lines after `cursor`, appended to `into`; returns the cursor to pass next time.
+    // Every consumer keeps its own, so a browser watching the console cannot swallow a line the
+    // script's expect-serial was waiting for.  serialCursor() is the "only what happens next"
+    // starting point.
+    uint64_t serialSince(uint64_t cursor, std::vector<std::string>& into);
+    uint64_t serialCursor();
     std::string screenshotPng(int scale);
 
     // Writes the exit screenshot, if one was requested.
@@ -137,6 +159,7 @@ namespace sim {
     void captureDisplay();
     void updateStatus();
     static void onClockAdvance();
+    [[noreturn]] void relaunch();
 
     Options options_;
     bool booted_ = false;
@@ -163,7 +186,7 @@ namespace sim {
 
     std::mutex stateMutex_;
     Frame frame_;
-    uint64_t frameSequence_ = 0;
+    std::atomic<uint64_t> frameSequence_{0};
     Status status_;
     uint32_t lastCaptureMs_ = 0;
   };

--- a/sim/emulator/scenario.cpp
+++ b/sim/emulator/scenario.cpp
@@ -293,7 +293,11 @@ namespace sim {
     int firstSecondOfDay = 0;
     double previousLat = 0;
     double previousLon = 0;
-    int previousSecond = 0;
+    int previousSecondOfDay = 0;
+    int previousElapsedS = 0;
+    // B records carry a time of day, not a date, so an evening flight that runs past midnight
+    // sees the clock wrap back to zero.  Each wrap adds a day here.
+    int dayOffsetS = 0;
 
     while (std::getline(in, line)) {
       // B HHMMSS DDMMmmm N DDDMMmmm E A PPPPP GGGGG
@@ -320,14 +324,18 @@ namespace sim {
         firstSecondOfDay = secondOfDay;
         previousLat = latitude;
         previousLon = longitude;
-        previousSecond = secondOfDay;
+        previousSecondOfDay = secondOfDay;
       }
 
-      const uint32_t atMs = (uint32_t)((secondOfDay - firstSecondOfDay) * 1000);
+      // A jump backwards of more than half a day is midnight, not a fix arriving out of order.
+      if (secondOfDay < previousSecondOfDay - 43200) dayOffsetS += 86400;
+
+      const int elapsedS = secondOfDay + dayOffsetS - firstSecondOfDay;
+      const uint32_t atMs = (uint32_t)(elapsedS * 1000);
 
       // IGC has no speed or heading, so derive them from consecutive fixes: that is what the
       // receiver reports on a real flight, and the firmware's wind and navigation code needs it.
-      const int dt = secondOfDay - previousSecond;
+      const int dt = elapsedS - previousElapsedS;
       double speedKnots = 0;
       double courseDeg = 0;
       if (dt > 0) {
@@ -376,7 +384,8 @@ namespace sim {
 
       previousLat = latitude;
       previousLon = longitude;
-      previousSecond = secondOfDay;
+      previousSecondOfDay = secondOfDay;
+      previousElapsedS = elapsedS;
     }
 
     if (!haveFirst) {
@@ -529,6 +538,8 @@ namespace sim {
   }
 
   void Scenario::seek(double seconds) {
+    // Only the input cursor moves; see the note in scenario.h on why this is a jump rather than
+    // a scrub.
     std::lock_guard<std::mutex> lock(mutex_);
     if (seconds < 0) seconds = 0;
     positionMs_ = (uint32_t)(seconds * 1000);

--- a/sim/emulator/scenario.h
+++ b/sim/emulator/scenario.h
@@ -48,6 +48,12 @@ namespace sim {
 
     void play();
     void pause();
+
+    // Moves the *input* cursor, and nothing else.  The firmware keeps whatever state it had
+    // reached: barometer filters, GPS fix, navigation, the flight timer and the log all stay
+    // where they were, so seeking backwards replays earlier inputs into later state and seeking
+    // forwards skips everything in between.  It is a jump in the recording, not a scrub of the
+    // device -- a faithful scrub would mean rebooting and replaying to the requested time.
     void seek(double seconds);
 
     // Called from the device loop: publishes everything due at the current device time.

--- a/sim/emulator/script.cpp
+++ b/sim/emulator/script.cpp
@@ -13,8 +13,9 @@
 namespace sim {
 
   namespace {
-    // Console output the script can assert on.  Kept here rather than in the runtime because only
-    // expect-serial needs a full transcript; the UI drains its own copy.
+    // Everything the console has said so far, flattened for expect-serial to search.  The lines
+    // themselves come from the runtime's shared transcript through this script's own cursor, so
+    // a browser watching the same console does not consume them first.
     std::string g_transcript;
   }  // namespace
 
@@ -64,10 +65,12 @@ namespace sim {
   }
 
   void Script::update(uint32_t nowMs) {
-    // Keep the transcript current for expect-serial.  Draining here means the UI and the script
-    // do not compete for the same lines.
-    for (const std::string& line : runtime().drainSerial()) {
-      printf("%s\n", line.c_str());
+    // Keep the transcript current for expect-serial.  The lines are not echoed here: HostConsole
+    // already writes them to stdout as the firmware prints them, so printing again would double
+    // every line of a scripted run's log.
+    std::vector<std::string> lines;
+    serialCursor_ = runtime().serialSince(serialCursor_, lines);
+    for (const std::string& line : lines) {
       g_transcript += line;
       g_transcript += "\n";
     }

--- a/sim/emulator/script.h
+++ b/sim/emulator/script.h
@@ -45,6 +45,7 @@ namespace sim {
 
     std::vector<Step> steps_;
     size_t nextIndex_ = 0;
+    uint64_t serialCursor_ = 0;  // this script's place in the console transcript
     int failures_ = 0;
     bool quitRequested_ = false;
   };

--- a/sim/hal/include/Arduino.h
+++ b/sim/hal/include/Arduino.h
@@ -105,6 +105,10 @@ uint64_t esp_timer_get_time(void);
 void delay(uint32_t ms);
 void delayMicroseconds(uint32_t us);
 void yield(void);
+// NTP sync has nowhere to reach in the emulator, so this is a no-op: whatever already seeds the
+// system clock (see sim/hal/src/system_clock.cpp) is what code guarded on a valid time will see.
+void configTime(long gmtOffsetSec, int daylightOffsetSec, const char* server1,
+                const char* server2 = nullptr, const char* server3 = nullptr);
 
 // ---------------------------------------------------------------- pins
 void pinMode(uint8_t pin, uint8_t mode);
@@ -114,6 +118,7 @@ uint16_t analogRead(uint8_t pin);
 uint32_t analogReadMilliVolts(uint8_t pin);
 void analogWrite(uint8_t pin, int value);
 void attachInterrupt(uint8_t pin, void (*handler)(void), int mode);
+void attachInterruptArg(uint8_t pin, void (*handler)(void*), void* arg, int mode);
 void detachInterrupt(uint8_t pin);
 uint8_t digitalPinToInterrupt(uint8_t pin);
 

--- a/sim/hal/include/HTTPClient.h
+++ b/sim/hal/include/HTTPClient.h
@@ -1,0 +1,26 @@
+// HTTP client stand-in.
+//
+// The emulator has no real network path out, so begin() always fails -- the same "report
+// yourself unavailable" contract WiFi.h and the other network stand-ins use, rather than
+// pretending a request could ever succeed.
+#pragma once
+
+#include <stddef.h>
+
+#include "Stream.h"
+#include "WString.h"
+
+class WiFiClientSecure;
+
+class HTTPClient {
+ public:
+  bool begin(WiFiClientSecure&, const String&) { return false; }
+  bool begin(const String&) { return false; }
+  void setConnectTimeout(int) {}
+  void setTimeout(int) {}
+  void addHeader(const String&, const String&) {}
+  int sendRequest(const char*, Stream* = nullptr, size_t = 0) { return -1; }
+  int GET() { return -1; }
+  String getString() { return String(); }
+  void end() {}
+};

--- a/sim/hal/include/HardwareSerial.h
+++ b/sim/hal/include/HardwareSerial.h
@@ -41,8 +41,15 @@ class HostConsole : public HardwareSerial {
   int peek() override { return -1; }
   void flush() override;
 
-  // Lines the emulator UI shows, drained rather than accumulated forever.
-  static std::vector<std::string> drainLines();
+  // The console is an append-only transcript, not a queue: the script's expect-serial assertions
+  // and every connected browser read it through a cursor of their own, so no consumer can take a
+  // line out from under another.  Appends the lines after `cursor` to `into` and returns the
+  // cursor to pass next time.  A consumer that falls more than the retained history behind
+  // silently resumes at the oldest line still held.
+  static uint64_t linesSince(uint64_t cursor, std::vector<std::string>& into);
+
+  // Sequence number one past the newest line, for a consumer that only wants what happens next.
+  static uint64_t lineCount();
 };
 
 class HostGpsSerial : public HardwareSerial {

--- a/sim/hal/include/WiFiClientSecure.h
+++ b/sim/hal/include/WiFiClientSecure.h
@@ -1,0 +1,10 @@
+// TLS client stand-in.
+//
+// The emulator has no network path out (see HTTPClient.h), so this only needs to exist as a type
+// HTTPClient::begin can accept.
+#pragma once
+
+class WiFiClientSecure {
+ public:
+  void setCACert(const char*) {}
+};

--- a/sim/hal/include/esp_attr.h
+++ b/sim/hal/include/esp_attr.h
@@ -4,3 +4,4 @@
 #define DRAM_ATTR
 #define RTC_DATA_ATTR
 #define EXT_RAM_ATTR
+#define ARDUINO_ISR_ATTR

--- a/sim/hal/include/esp_sleep.h
+++ b/sim/hal/include/esp_sleep.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// Minimal stand-in for ESP-IDF's sleep API. The emulator's clock is virtual and there is no real
+// low-power hardware to program, so these report success without doing anything real; see
+// esp_light_sleep_start's definition in sim/hal/src/esp.cpp for how it still keeps timing right.
+
+#include <stdint.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  ESP_EXT1_WAKEUP_ALL_LOW,
+  ESP_EXT1_WAKEUP_ANY_HIGH,
+} esp_sleep_ext1_wakeup_mode_t;
+
+esp_err_t esp_sleep_enable_timer_wakeup(uint64_t time_in_us);
+esp_err_t esp_sleep_enable_ext0_wakeup(int gpio_num, int level);
+esp_err_t esp_sleep_enable_ext1_wakeup(uint64_t mask, esp_sleep_ext1_wakeup_mode_t mode);
+esp_err_t esp_light_sleep_start(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sim/hal/include/sdmmc_cmd.h
+++ b/sim/hal/include/sdmmc_cmd.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Minimal stand-in for the ESP-IDF SD/MMC driver header. storage/sd_card.h holds one of these as
+// a member so its layout has to be a complete type, but the only file that does anything real
+// with it -- storage/sd_card.cpp -- talks to a raw SDIO host that has no emulator equivalent and
+// is excluded from the sim build (see FW_EXCLUDE in sim/Makefile). Nothing here needs a body.
+struct sdmmc_card_t {};

--- a/sim/hal/include/sim/board.h
+++ b/sim/hal/include/sim/board.h
@@ -42,8 +42,15 @@ namespace sim {
     uint32_t currentTone() const;
     void setVolumePins(bool a, bool b);
     uint8_t volume() const;
-    // Tone changes since the last drain, for the UI to turn into audible beeps.
-    std::vector<ToneEvent> drainToneEvents();
+    // Tone changes, kept as an append-only stream so several listening browsers each hear the
+    // whole beep rather than dividing the events between them.  Appends everything after
+    // `cursor` to `into` and returns the cursor to pass next time; a listener that falls behind
+    // resumes at the oldest event still held.
+    uint64_t toneEventsSince(uint64_t cursor, std::vector<ToneEvent>& into) const;
+
+    // Sequence number one past the newest tone event.  A browser starts here rather than at zero:
+    // tones are live events, and replaying the whole flight's beeps on connect is not useful.
+    uint64_t toneEventCount() const;
 
     // ------------------------------------------------------------------ GPS UART
     // Bytes the emulator pushes here are read back by the firmware's Serial0, so recorded NMEA
@@ -78,6 +85,7 @@ namespace sim {
     bool volA_ = false;
     bool volB_ = false;
     std::vector<ToneEvent> toneEvents_;
+    uint64_t toneFirstSeq_ = 0;  // sequence number of toneEvents_.front()
 
     std::deque<uint8_t> gpsRx_;
     std::string gpsTx_;

--- a/sim/hal/include/sim/clock.h
+++ b/sim/hal/include/sim/clock.h
@@ -8,6 +8,8 @@
 
 #include <stdint.h>
 
+#include <atomic>
+
 namespace sim {
 
   // Hardware timer interrupts (the 10ms task timer and 500ms charge timer the firmware installs).
@@ -15,11 +17,15 @@ namespace sim {
   // is the same place the device sees them: in the middle of the main loop.
   using TimerCallback = void (*)();
 
+  // Everything the device thread owns is plain; the four fields below are atomic because the
+  // emulator's HTTP threads drive the clock directly rather than through the runtime's command
+  // queue.  They have to: a paused clock blocks the device thread inside advanceUs(), so the
+  // thread that unpauses cannot be the one waiting to drain a queued command.
   class Clock {
    public:
-    uint64_t nowUs() const { return nowUs_; }
-    uint32_t millis() const { return (uint32_t)(nowUs_ / 1000); }
-    uint32_t micros() const { return (uint32_t)nowUs_; }
+    uint64_t nowUs() const { return nowUs_.load(std::memory_order_relaxed); }
+    uint32_t millis() const { return (uint32_t)(nowUs() / 1000); }
+    uint32_t micros() const { return (uint32_t)nowUs(); }
 
     // Moves virtual time forward, firing any timer callbacks due along the way, and blocks in real
     // time if the clock is pacing to a speed multiplier.
@@ -27,11 +33,11 @@ namespace sim {
 
     // Speed multiplier: 1.0 tracks wall clock, 10.0 runs ten times faster, 0 runs flat out.
     void setSpeed(double speed);
-    double speed() const { return speed_; }
+    double speed() const { return speed_.load(std::memory_order_relaxed); }
 
     // Paused clocks refuse to advance, so the firmware sees time standing still.
-    void setPaused(bool paused) { paused_ = paused; }
-    bool paused() const { return paused_; }
+    void setPaused(bool paused) { paused_.store(paused, std::memory_order_relaxed); }
+    bool paused() const { return paused_.load(std::memory_order_relaxed); }
 
     // Runs one timer slot; returns the handle index used by timerBegin()/timerAlarm().
     int addTimer(uint32_t frequencyHz);
@@ -67,15 +73,16 @@ namespace sim {
     static constexpr int MAX_TIMERS = 8;
     Timer timers_[MAX_TIMERS];
 
-    uint64_t nowUs_ = 0;
-    double speed_ = 1.0;
-    bool paused_ = false;
+    std::atomic<uint64_t> nowUs_{0};
+    std::atomic<double> speed_{1.0};
+    std::atomic<bool> paused_{false};
     StallHook stallHook_ = nullptr;
 
     // Wall-clock anchor for pacing; reset whenever speed changes or the clock is unpaused.
+    // Only the device thread reads the anchor itself; setSpeed() invalidates it from any thread.
     uint64_t anchorHostUs_ = 0;
     uint64_t anchorSimUs_ = 0;
-    bool anchored_ = false;
+    std::atomic<bool> anchored_{false};
   };
 
   Clock& clock();

--- a/sim/hal/src/arduino.cpp
+++ b/sim/hal/src/arduino.cpp
@@ -21,6 +21,15 @@ void delayMicroseconds(uint32_t us) { sim::clock().advanceUs(us); }
 void yield(void) { sim::clock().advanceUs(50); }
 extern "C" void vPortYield(void) { yield(); }
 
+void configTime(long gmtOffsetSec, int daylightOffsetSec, const char* server1,
+                const char* server2, const char* server3) {
+  (void)gmtOffsetSec;
+  (void)daylightOffsetSec;
+  (void)server1;
+  (void)server2;
+  (void)server3;
+}
+
 // ---------------------------------------------------------------- pins
 
 void pinMode(uint8_t pin, uint8_t mode) { sim::board().pinMode(pin, mode); }
@@ -43,6 +52,12 @@ void analogWrite(uint8_t pin, int value) {
 void attachInterrupt(uint8_t pin, void (*handler)(void), int mode) {
   (void)pin;
   (void)handler;
+  (void)mode;
+}
+void attachInterruptArg(uint8_t pin, void (*handler)(void*), void* arg, int mode) {
+  (void)pin;
+  (void)handler;
+  (void)arg;
   (void)mode;
 }
 void detachInterrupt(uint8_t pin) { (void)pin; }

--- a/sim/hal/src/arduino.cpp
+++ b/sim/hal/src/arduino.cpp
@@ -21,8 +21,8 @@ void delayMicroseconds(uint32_t us) { sim::clock().advanceUs(us); }
 void yield(void) { sim::clock().advanceUs(50); }
 extern "C" void vPortYield(void) { yield(); }
 
-void configTime(long gmtOffsetSec, int daylightOffsetSec, const char* server1,
-                const char* server2, const char* server3) {
+void configTime(long gmtOffsetSec, int daylightOffsetSec, const char* server1, const char* server2,
+                const char* server3) {
   (void)gmtOffsetSec;
   (void)daylightOffsetSec;
   (void)server1;

--- a/sim/hal/src/board.cpp
+++ b/sim/hal/src/board.cpp
@@ -83,8 +83,11 @@ namespace sim {
     event.frequencyHz = frequencyHz;
     event.volume = (uint8_t)((volA_ ? 1 : 0) + (volB_ ? 2 : 0));
     toneEvents_.push_back(event);
-    // The UI drains these; if nobody is listening, keep the buffer bounded.
-    if (toneEvents_.size() > 512) toneEvents_.erase(toneEvents_.begin(), toneEvents_.begin() + 256);
+    // Nobody may be listening, so keep the retained tail bounded; the sequence numbers carry on.
+    if (toneEvents_.size() > 512) {
+      toneEvents_.erase(toneEvents_.begin(), toneEvents_.begin() + 256);
+      toneFirstSeq_ += 256;
+    }
   }
 
   uint32_t Board::currentTone() const {
@@ -103,11 +106,19 @@ namespace sim {
     return (uint8_t)((volA_ ? 1 : 0) + (volB_ ? 2 : 0));
   }
 
-  std::vector<ToneEvent> Board::drainToneEvents() {
+  uint64_t Board::toneEventsSince(uint64_t cursor, std::vector<ToneEvent>& into) const {
     std::lock_guard<std::mutex> lock(mutex_);
-    std::vector<ToneEvent> out;
-    out.swap(toneEvents_);
-    return out;
+    const uint64_t end = toneFirstSeq_ + toneEvents_.size();
+    if (cursor < toneFirstSeq_) cursor = toneFirstSeq_;
+    for (uint64_t seq = cursor; seq < end; seq++) {
+      into.push_back(toneEvents_[(size_t)(seq - toneFirstSeq_)]);
+    }
+    return end;
+  }
+
+  uint64_t Board::toneEventCount() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return toneFirstSeq_ + toneEvents_.size();
   }
 
   void Board::gpsFeed(const std::string& bytes) {

--- a/sim/hal/src/clock.cpp
+++ b/sim/hal/src/clock.cpp
@@ -21,8 +21,11 @@ namespace sim {
   }
 
   void Clock::setSpeed(double speed) {
-    speed_ = speed < 0 ? 0 : speed;
-    anchored_ = false;
+    // Called from the HTTP threads as well as the device thread, hence the atomics: the store
+    // publishes the new speed, and dropping the anchor tells the device thread to re-anchor its
+    // pacing to it on the next advance.
+    speed_.store(speed < 0 ? 0 : speed, std::memory_order_relaxed);
+    anchored_.store(false, std::memory_order_relaxed);
   }
 
   void Clock::advanceUs(uint64_t us) {
@@ -30,33 +33,34 @@ namespace sim {
 
     // A paused clock blocks the device thread instead of advancing: from the firmware's point of
     // view the world simply stops, which is what makes single-stepping a flight useful.
-    while (paused_) {
+    while (paused_.load(std::memory_order_relaxed)) {
       std::this_thread::sleep_for(std::chrono::microseconds(PAUSE_POLL_US));
-      anchored_ = false;
+      anchored_.store(false, std::memory_order_relaxed);
     }
 
-    const uint64_t target = nowUs_ + us;
+    const uint64_t target = nowUs() + us;
     fireDueTimers(target);
-    nowUs_ = target;
+    nowUs_.store(target, std::memory_order_relaxed);
 
-    if (speed_ <= 0) return;  // free-running: as fast as the host can manage
+    const double speed = speed_.load(std::memory_order_relaxed);
+    if (speed <= 0) return;  // free-running: as fast as the host can manage
 
-    if (!anchored_) {
+    if (!anchored_.load(std::memory_order_relaxed)) {
       anchorHostUs_ = hostUs();
-      anchorSimUs_ = nowUs_;
-      anchored_ = true;
+      anchorSimUs_ = target;
+      anchored_.store(true, std::memory_order_relaxed);
       return;
     }
 
-    const uint64_t simElapsed = nowUs_ - anchorSimUs_;
-    const uint64_t hostTarget = anchorHostUs_ + (uint64_t)(simElapsed / speed_);
+    const uint64_t simElapsed = target - anchorSimUs_;
+    const uint64_t hostTarget = anchorHostUs_ + (uint64_t)(simElapsed / speed);
     const uint64_t hostNow = hostUs();
     if (hostTarget > hostNow) {
       std::this_thread::sleep_for(std::chrono::microseconds(hostTarget - hostNow));
     } else if (hostNow - hostTarget > 250000) {
       // The host fell far behind (a long scenario load, a debugger break).  Re-anchor rather than
       // sprinting to catch up, which would replay a burst of sensor data at the wrong rate.
-      anchored_ = false;
+      anchored_.store(false, std::memory_order_relaxed);
     }
   }
 
@@ -75,7 +79,7 @@ namespace sim {
       if (soonest < 0) return;
 
       Timer& t = timers_[soonest];
-      nowUs_ = soonestAt > nowUs_ ? soonestAt : nowUs_;
+      if (soonestAt > nowUs()) nowUs_.store(soonestAt, std::memory_order_relaxed);
       if (t.autoReload) {
         t.nextUs = soonestAt + t.periodUs;
       } else {

--- a/sim/hal/src/esp.cpp
+++ b/sim/hal/src/esp.cpp
@@ -4,6 +4,7 @@
 #include <esp_debug_helpers.h>
 #include <esp_heap_caps.h>
 #include <esp_mac.h>
+#include <esp_sleep.h>
 #include <esp_system.h>
 #include <esp_wifi.h>
 #include <execinfo.h>
@@ -41,6 +42,11 @@ esp_err_t esp_sleep_enable_timer_wakeup(uint64_t timeInUs) {
 esp_err_t esp_sleep_enable_ext0_wakeup(int gpioNum, int level) {
   (void)gpioNum;
   (void)level;
+  return ESP_OK;
+}
+esp_err_t esp_sleep_enable_ext1_wakeup(uint64_t mask, esp_sleep_ext1_wakeup_mode_t mode) {
+  (void)mask;
+  (void)mode;
   return ESP_OK;
 }
 

--- a/sim/hal/src/serial.cpp
+++ b/sim/hal/src/serial.cpp
@@ -19,7 +19,10 @@ HostConsole Serial2;
 namespace {
   std::mutex g_consoleMutex;
   std::string g_pending;             // partial line not yet terminated
-  std::vector<std::string> g_lines;  // completed lines waiting for the UI
+  std::vector<std::string> g_lines;  // the retained tail of the transcript
+  // Sequence number of g_lines.front(); everything older has been dropped.  Consumers hold a
+  // sequence number rather than an index so that trimming the tail cannot shift them.
+  uint64_t g_firstSeq = 0;
   constexpr size_t MAX_PENDING_LINES = 2000;
 
   void pushChar(char c) {
@@ -31,7 +34,9 @@ namespace {
       g_lines.push_back(g_pending);
       g_pending.clear();
       if (g_lines.size() > MAX_PENDING_LINES) {
-        g_lines.erase(g_lines.begin(), g_lines.begin() + (g_lines.size() - MAX_PENDING_LINES));
+        const size_t dropped = g_lines.size() - MAX_PENDING_LINES;
+        g_lines.erase(g_lines.begin(), g_lines.begin() + dropped);
+        g_firstSeq += dropped;
       }
       return;
     }
@@ -55,11 +60,17 @@ size_t HostConsole::write(const uint8_t* buffer, size_t size) {
 
 void HostConsole::flush() { fflush(stdout); }
 
-std::vector<std::string> HostConsole::drainLines() {
+uint64_t HostConsole::linesSince(uint64_t cursor, std::vector<std::string>& into) {
   std::lock_guard<std::mutex> lock(g_consoleMutex);
-  std::vector<std::string> out;
-  out.swap(g_lines);
-  return out;
+  const uint64_t end = g_firstSeq + g_lines.size();
+  if (cursor < g_firstSeq) cursor = g_firstSeq;  // fell behind; resume at the oldest line held
+  for (uint64_t seq = cursor; seq < end; seq++) into.push_back(g_lines[(size_t)(seq - g_firstSeq)]);
+  return end;
+}
+
+uint64_t HostConsole::lineCount() {
+  std::lock_guard<std::mutex> lock(g_consoleMutex);
+  return g_firstSeq + g_lines.size();
 }
 
 size_t HostGpsSerial::write(uint8_t c) {

--- a/sim/recordings/thermal-core.json
+++ b/sim/recordings/thermal-core.json
@@ -1,0 +1,865 @@
+{
+  "description": "Two thermals on a light-wind summer day, flown the way they are actually flown: entered late and off to one side, read over a lap or two, then walked onto the core by flattening the turn where it points at the lift. The first climb is right-handed and the second left-handed, so the Thermal Core page has to draw both mirror images of its layout. Every climb rate in the file comes from a Gaussian core placed in the air mass, not from a number picked by hand: the glider flies past it, feels what the geometry gives it, and the asymmetry the page has to detect is a real consequence of where the circle sits.",
+  "_authoring_notes": [
+    "Wind is 2 m/s from 250, and the scenario player adds it on top of these AIR headings. It matters more here than it looks: a lap is 18 s, so the air mass - and the thermal in it - moves 36 m a lap, further than the 27 m circle radius. The markers on the page are drawn in the ground frame, so the trail is a drifting spiral rather than a closed circle, and samples older than about 25 s have slid off the upwind edge of the 96x96 map. That is the real behaviour, and it is deliberately not designed away.",
+    "The geometry: 9.5 m/s of airspeed at 20 deg/s is a 27 m radius, an 18 s lap and about 19 degrees of bank, which is a paraglider working a core. Circling legs are cut into 3 s pieces (60 deg of arc), which is as finely as the vario can resolve a change in lift anyway - climb reaches the detector through the Kalman fusion and a 1 s average, so a shorter leg would only be smoothed back out.",
+    "Thermal 1 is entered 27 m off the core: the glider flew within 10 m of the middle, the pilot reacted a second and a half after the surge and took another second and a half to roll in, and that lag alone puts the circle a full radius out. Two laps at 27 m read -0.2 to +4.2 m/s - a Ring9 marker on the strong side and crosses opposite it - and average +1.65. Then two corrections: flatten the turn for 1.25 s where the heading points from the circle centre at the core (12 m of circle), then 1.5 s more (14 m). Flying straight walks the circle centre along the heading, which is what re-centring physically is. Centred to 1 m the lap reads +1.9 to +2.5 all the way round and averages +2.26 - better than the uncentred lap by more than half a metre a second, and steady instead of surging.",
+    "Thermal 2 is the same story mirrored: a softer edge, two and a half seconds of reaction, 31 m off, two laps of -0.1 to +3.6, one 2.5 s flatten worth 24 m, then three steady laps at +2.2. It is turned to the LEFT, so the page has to put the glider on the right of the map and bend its arc the other way. A sign error in the phase mirroring shows here and nowhere else.",
+    "Three things are in the recording on purpose besides the climbs. A dying bubble 24 m off the wing on the first glide lifts the vario to +0.5 for a few seconds without ever justifying a turn - the page must stay in its no-turn layout, glider centred, no arc. The last two laps of thermal 1 are the thermal dying under the glider rather than the glider flying out of it: the whole lap weakens together, +2.3 to +0.2, so the markers shrink evenly instead of going asymmetric. And the glide between the two climbs is 82 s of straight flight, which is long enough for the 40 s sample window to empty of turning (120 deg of accumulated turn is the threshold) and force the page back to its no-turn layout before the second climb rebuilds it.",
+    "Altitudes are honest: launch at 1350 m, the glide costs 60 m, thermal 1 climbs to 1583 m before it dies, the glide to the next trigger costs 82 m, and thermal 2 tops out at 1674 m. The barometer sees exactly this, because the player converts these altitudes to pressure with the inverse of the firmware's own altitude formula."
+  ],
+  "start": {
+    "lat": 47.51,
+    "lon": 11.18,
+    "altitudeM": 1350,
+    "headingDeg": 250.0,
+    "hour": 13
+  },
+  "wind": {
+    "speedMps": 2.0,
+    "fromDeg": 250
+  },
+  "ambient": {
+    "temperatureC": 24.0,
+    "humidity": 35.0
+  },
+  "legs": [
+    {
+      "durationS": 24.0,
+      "airspeedMps": 2.0,
+      "climbMps": 0.0,
+      "headingDeg": 250.0,
+      "comment": "on launch, wing up into the breeze: airspeed cancels the wind, so the fix sits still while the startup checks run"
+    },
+    {
+      "durationS": 4.0,
+      "airspeedMps": 9.0,
+      "climbMps": -1.37,
+      "headingDeg": 250.0,
+      "comment": "launch run, into wind"
+    },
+    {
+      "durationS": 3.5,
+      "airspeedMps": 10.5,
+      "climbMps": -1.62,
+      "turnRateDegPerS": 25.0,
+      "comment": "turn away from the hill onto the glide"
+    },
+    {
+      "durationS": 3.5,
+      "airspeedMps": 10.5,
+      "climbMps": -1.65,
+      "turnRateDegPerS": 25.0
+    },
+    {
+      "durationS": 9.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.54,
+      "headingDeg": 65.0,
+      "comment": "glide out at 11 m/s, sinking through neutral air"
+    },
+    {
+      "durationS": 9.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.43,
+      "headingDeg": 65.0
+    },
+    {
+      "durationS": 6.0,
+      "airspeedMps": 11.0,
+      "climbMps": -0.18,
+      "headingDeg": 65.0,
+      "comment": "the air improves for a few seconds - a dying bubble 24 m off the left wing, not worth a turn"
+    },
+    {
+      "durationS": 6.0,
+      "airspeedMps": 11.0,
+      "climbMps": -0.23,
+      "headingDeg": 65.0
+    },
+    {
+      "durationS": 6.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.4,
+      "headingDeg": 65.0,
+      "comment": "back into sink, then lift builds hard: the edge of the day's thermal, 10 m off the right wing"
+    },
+    {
+      "durationS": 6.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.52,
+      "headingDeg": 65.0
+    },
+    {
+      "durationS": 6.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.54,
+      "headingDeg": 65.0
+    },
+    {
+      "durationS": 6.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.41,
+      "headingDeg": 65.0
+    },
+    {
+      "durationS": 6.0,
+      "airspeedMps": 11.0,
+      "climbMps": 1.61,
+      "headingDeg": 65.0
+    },
+    {
+      "durationS": 1.5,
+      "airspeedMps": 10.0,
+      "climbMps": 3.69,
+      "headingDeg": 65.0,
+      "comment": "a second and a half of reaction"
+    },
+    {
+      "durationS": 1.5,
+      "airspeedMps": 9.8,
+      "climbMps": 2.67,
+      "turnRateDegPerS": 13.0,
+      "comment": "rolling into a right-hand turn"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.96,
+      "turnRateDegPerS": 20.0,
+      "comment": "lap 1, 27 m off the core: one strong surge a lap, and sink opposite it"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": -0.01,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.22,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.68,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 3.83,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 3.12,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.03,
+      "turnRateDegPerS": 20.0,
+      "comment": "lap 2, still uncorrected - a lap or two is what it takes to read the asymmetry"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": -0.01,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.17,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.78,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 3.72,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 3.21,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 2.5,
+      "airspeedMps": 9.5,
+      "climbMps": 1.12,
+      "turnRateDegPerS": 20.0,
+      "comment": "circling on to the correction point"
+    },
+    {
+      "durationS": 2.5,
+      "airspeedMps": 9.5,
+      "climbMps": 0.04,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 2.5,
+      "airspeedMps": 9.5,
+      "climbMps": 0.01,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 2.75,
+      "airspeedMps": 9.5,
+      "climbMps": 0.7,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 1.25,
+      "airspeedMps": 9.5,
+      "climbMps": 1.89,
+      "comment": "flatten heading straight at the core: the re-centring, and worth about 12 m of circle"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.96,
+      "turnRateDegPerS": 20.0,
+      "comment": "lap 3, now 13 m off: the surge is wider and the weak side is no longer sinking"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 3.59,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.59,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.39,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.9,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.62,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.9,
+      "turnRateDegPerS": 20.0,
+      "comment": "lap 4"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 3.6,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.64,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.3,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.01,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.54,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.95,
+      "turnRateDegPerS": 20.0,
+      "comment": "circling on to the second correction point"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 3.61,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.57,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.4,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.9,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.61,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 1.5,
+      "airspeedMps": 9.5,
+      "climbMps": 2.48,
+      "comment": "a second flatten, another 14 m, and this one finishes the job"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.42,
+      "turnRateDegPerS": 20.0,
+      "comment": "lap 5, centred to 1 m: steady lift all the way round, and a better average than the peak of lap 1"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.47,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.37,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.35,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.43,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.31,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.31,
+      "turnRateDegPerS": 20.0,
+      "comment": "lap 6, centred"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.08,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.95,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.84,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.68,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.71,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.51,
+      "turnRateDegPerS": 20.0,
+      "comment": "lap 7, centred - and the thermal is past its best"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.43,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.25,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.07,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.05,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.86,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.84,
+      "turnRateDegPerS": 20.0,
+      "comment": "lap 8: the thermal is dying under the glider, not being flown out of - the whole lap weakens together"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.65,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.5,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.43,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.24,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.25,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.07,
+      "turnRateDegPerS": 20.0,
+      "comment": "lap 9, ragged and barely climbing: time to leave"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": -0.04,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": -0.14,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": -0.33,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": -0.33,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": -0.53,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 3.5,
+      "airspeedMps": 10.0,
+      "climbMps": -0.62,
+      "turnRateDegPerS": 20.0,
+      "comment": "roll out and leave on 075"
+    },
+    {
+      "durationS": 3.75,
+      "airspeedMps": 10.0,
+      "climbMps": -0.84,
+      "turnRateDegPerS": 20.0
+    },
+    {
+      "durationS": 10.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.35,
+      "headingDeg": 74.5,
+      "comment": "on glide: from here the 40 s sample window empties of turning"
+    },
+    {
+      "durationS": 10.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.52,
+      "headingDeg": 74.5
+    },
+    {
+      "durationS": 10.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.54,
+      "headingDeg": 74.5,
+      "comment": "still gliding - 35 s of straight flight is what it takes for the accumulated turn to fall below the 120 deg threshold"
+    },
+    {
+      "durationS": 10.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.52,
+      "headingDeg": 74.5
+    },
+    {
+      "durationS": 10.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.53,
+      "headingDeg": 74.5
+    },
+    {
+      "durationS": 10.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.54,
+      "headingDeg": 74.5
+    },
+    {
+      "durationS": 11.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.51,
+      "headingDeg": 74.5,
+      "comment": "the next thermal is 22 m off the left wing now"
+    },
+    {
+      "durationS": 11.0,
+      "airspeedMps": 11.0,
+      "climbMps": 0.01,
+      "headingDeg": 74.5
+    },
+    {
+      "durationS": 2.5,
+      "airspeedMps": 10.0,
+      "climbMps": 2.41,
+      "headingDeg": 74.5,
+      "comment": "lift again - this one is softer edged and two and a half seconds go by before the turn"
+    },
+    {
+      "durationS": 1.5,
+      "airspeedMps": 9.8,
+      "climbMps": 1.23,
+      "turnRateDegPerS": -13.0,
+      "comment": "rolling into a LEFT-hand turn this time"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.22,
+      "turnRateDegPerS": -20.0,
+      "comment": "left lap 1, 31 m off the core: everything the right-hand climb did, mirrored"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.01,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.69,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.56,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 3.32,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.69,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.31,
+      "turnRateDegPerS": -20.0,
+      "comment": "left lap 2, still off"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": -0.09,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.77,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.53,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 3.29,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.77,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.21,
+      "turnRateDegPerS": -20.0,
+      "comment": "circling on to the correction point"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 0.01,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 2.75,
+      "airspeedMps": 9.5,
+      "climbMps": 0.66,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 2.5,
+      "airspeedMps": 9.5,
+      "climbMps": 2.02,
+      "comment": "one decisive flatten straight at the core, worth 24 m"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.61,
+      "turnRateDegPerS": -20.0,
+      "comment": "left lap 3, centred to 5 m"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.62,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.33,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.85,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.75,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.14,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.51,
+      "turnRateDegPerS": -20.0,
+      "comment": "left lap 4, centred"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.71,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.27,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.86,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.8,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.05,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.61,
+      "turnRateDegPerS": -20.0,
+      "comment": "left lap 5, centred and still climbing"
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.63,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.31,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.88,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 1.74,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.0,
+      "airspeedMps": 9.5,
+      "climbMps": 2.15,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.5,
+      "airspeedMps": 10.5,
+      "climbMps": 2.38,
+      "turnRateDegPerS": -20.0,
+      "comment": "roll out and head home"
+    },
+    {
+      "durationS": 3.5,
+      "airspeedMps": 10.5,
+      "climbMps": 2.23,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.5,
+      "airspeedMps": 10.5,
+      "climbMps": 1.49,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.5,
+      "airspeedMps": 10.5,
+      "climbMps": 1.36,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 3.5,
+      "airspeedMps": 10.5,
+      "climbMps": 1.75,
+      "turnRateDegPerS": -20.0
+    },
+    {
+      "durationS": 12.0,
+      "airspeedMps": 11.0,
+      "climbMps": -0.15,
+      "headingDeg": 250.0,
+      "comment": "straight home, so the recording ends in the no-turn layout"
+    },
+    {
+      "durationS": 12.0,
+      "airspeedMps": 11.0,
+      "climbMps": -1.54,
+      "headingDeg": 250.0
+    }
+  ]
+}

--- a/sim/scripts/thermal-core.txt
+++ b/sim/scripts/thermal-core.txt
@@ -1,0 +1,83 @@
+# Walks the Thermal Core page through sim/recordings/thermal-core.json and screenshots every
+# state it can be in.  Times are device seconds, which track scenario seconds because the
+# recording starts playing at boot.
+#
+#   leafsim --port 0 --speed 0 --accept-warning \
+#           --setting LAB_THERM_CORE=1 --setting SHOW_THERM_CORE=1 \
+#           --setting SHOW_THERM_TRK=0 --setting SHOW_NAV=0 --setting SHOW_LANDING=0 \
+#           --scenario sim/recordings/thermal-core.json --play \
+#           --script sim/scripts/thermal-core.txt
+#
+# With the other flight pages hidden, one RIGHT from the User page lands on Thermal Core.
+#
+# Build with OPT="-O1 -g -DDEBUG_THERMAL_CORE" to get the estimator's own numbers on the serial
+# console alongside these screenshots.
+20   press         RIGHT
+21   expect-page   ThermalCore
+
+# --- gliding, no turn ------------------------------------------------------------------------
+# Straight flight: the glider sits in the middle of the map, the trail runs straight down it at the
+# zoomed-out glide scale, and there is no core marker and no status line, because there is no
+# circle to advise on.  AVG reads the sink of the glide.
+40   status
+42   screenshot    sim/build/tc-01-glide.png
+
+# The dying bubble: the vario lifts to about +0.5 m/s for a few seconds.  Rings appear in the
+# trail, but the layout must not change - lift alone is not a thermal.
+60   status
+61   screenshot    sim/build/tc-02-bubble.png
+
+# --- thermal 1, right hand, entered 27 m off the core ----------------------------------------
+# Circling starts at 98 s.  Four seconds of sustained turn and 200 degrees of sweep are needed
+# before the page commits to a direction, so the turn layout appears around 109 s and not before,
+# and the core marker follows a couple of seconds later once the fit has a lap to work with.
+100  status
+104  screenshot    sim/build/tc-03-rolling-in.png
+
+# Lap 2 of an uncentred circle.  The trail should be a closed circle rather than a downwind
+# spiral - that is the wind correction working - with the fat side of the necklace towards the
+# core, the bullseye sitting on that side about 23 m from the circle centre tick, and OPEN
+# appearing for the few seconds each lap when the nose lines up with the correction.
+130  status
+132  screenshot    sim/build/tc-04-offset-lap.png
+
+# The first correction is flown at 144 s: 1.25 s of straight flight aimed at the core.
+147  screenshot    sim/build/tc-05-correcting.png
+160  status
+162  screenshot    sim/build/tc-06-half-centred.png
+
+# Centred to a metre from 201 s: +1.9 to +2.5 m/s all the way round, so the trail is one uniform
+# ring size, the circle centre tick disappears under the bullseye, and the status line reads
+# CENTRED.  AVG should be reading about +2.2.
+215  status
+217  screenshot    sim/build/tc-07-centred.png
+235  screenshot    sim/build/tc-08-centred-later.png
+
+# The thermal dies under the glider: the whole lap weakens together rather than going lopsided.
+265  status
+285  status
+287  screenshot    sim/build/tc-09-dying.png
+
+# --- the glide between climbs ----------------------------------------------------------------
+# Rolled out at 298 s.  The turn layout must be gone by about 307 s - the turn rate is measured
+# over four seconds and the circling state needs three more of level flight to release - and the
+# page must not keep drawing a circle the pilot is no longer flying just because the buffer
+# still holds one.
+312  screenshot    sim/build/tc-10-just-left.png
+345  status
+347  screenshot    sim/build/tc-11-aged-out.png
+
+# --- thermal 2, left hand, entered 31 m off the core ------------------------------------------
+# Everything mirrored: glider on the right of the map, core marker to the left.  A sign error in
+# the body-frame rotation or in the turn direction shows here and nowhere else.
+390  status
+412  screenshot    sim/build/tc-12-left-offset.png
+430  screenshot    sim/build/tc-13-left-correcting.png
+470  status
+472  screenshot    sim/build/tc-14-left-centred.png
+
+# --- home -------------------------------------------------------------------------------------
+505  status
+520  screenshot    sim/build/tc-15-home.png
+521  expect-page   ThermalCore
+525  quit

--- a/sim/web/index.html
+++ b/sim/web/index.html
@@ -152,6 +152,9 @@
         <input type="range" id="seek" min="0" max="1000" value="0">
       </div>
       <div class="row"><span class="pill" id="scenarioPos">no scenario loaded</span></div>
+      <div class="row"><span class="pill">the slider jumps the recording, it does not rewind the
+        device: seek back and earlier data arrives into the state the firmware has already
+        reached</span></div>
     </section>
 
     <section class="wide">


### PR DESCRIPTION
Fixed the missing include stubs that broke the emulator on the latest commits (#383, #384, #386). The emulator builds the real firmware, so any new include in `src/vario` breaks it. Nothing in CI builds `sim/`, so this will happen again — fine by me, it's a dev tool.

Then went through Codex's review:

- **Fatal errors could hang a headless run.** `--script` without `--run-seconds` never installed the hook. Fixed.
- **`/api/restart` wasn't a restart.** Re-running `setup()` re-subscribes everything and overflows the 11-slot message bus. Now re-execs the process, capped at 16 restarts so a boot loop can't run away.
- **Clock races are real**, but they can't go through the command queue — a paused clock blocks the device thread inside `advanceUs()`, so the thread that unpauses can't be the one draining the queue. Made the shared fields atomic instead.
- **Serial/SSE competing.** Serial and tone output are both append-only with a cursor per consumer now. Also found every serial line was being printed twice in scripted runs.
- **IGC across midnight.** Fixed, a 12s flight was loading as 49 days.
- **Seek** only moves the input cursor, correct. Documented it rather than fixing. Replay is cheap (~700x realtime, so re-running to any point is about a second), so a real scrub is doable later — the annoying part is the re-exec dropping the browser connection, not the CPU.
- **Scenario controls aren't actually racy**, `Scenario` already locks everything.

Also in here: a Thermal Core scenario + script, and a fix for detached HTTP threads reading a destroyed server's flag on shutdown.

Builds clean under gcc 13, both scripts pass.
