### PR TITLE
Add configurable climb/glide averaging and fix BLE queue corruption

### DIFF
--- a/src/vario/comms/ble.cpp
+++ b/src/vario/comms/ble.cpp
@@ -3,12 +3,14 @@
 #include <Arduino.h>
 #include <algorithm>
 #include <atomic>
+#include <type_traits>
 
 #include <NimBLEDevice.h>
 #include "TinyGPSPlus.h"
 #include "comms/fanet_radio.h"
 #include "comms/webserver.h"
 #include "diagnostics/diagnostic_logs.h"
+#include "diagnostics/fatal_error.h"
 #include "diagnostics/heap_monitor.h"
 #include "esp_heap_caps.h"
 #include "etl/string.h"
@@ -50,17 +52,6 @@ namespace {
     pendingBleDiagnosticEvents.fetch_or(static_cast<uint32_t>(event), std::memory_order_relaxed);
   }
 }  // namespace
-
-/// @brief Internal struct to be passed in the message queues to wakup the BLE task
-struct WakeupMessage {
-  enum Reason { PERIODIC, FANET_RX, GPS_GPGGA, GPS_GPRMC } reason;
-  using MessageVariant = etl::variant<NMEAString, FanetPacket>;
-  MessageVariant message;
-
-  WakeupMessage(Reason reason, MessageVariant message) : reason(reason), message(message) {}
-  WakeupMessage(Reason reason) : reason(reason) {}
-  WakeupMessage() { reason = Reason::PERIODIC; }
-};
 
 class ServerCallbacks : public NimBLEServerCallbacks {
   // Not sure we need this.  Taken from the demo
@@ -126,11 +117,22 @@ void BLE::setup() {
    */
   pAdvertising->enableScanResponse(true);
 
-  // Setup the FreeRTOS Tasks and Timers associated with this module
-  // Create a queue the size of a couple of WakeupMessage length.
-  // If say a GPS and periodic send request comes in too close together
-  // one of them may be dropped for this cycle.
-  xQueue = xQueueCreate(4, sizeof(WakeupMessage));
+  // FreeRTOS queues byte-copy their items, so queue pointers to preconstructed C++ objects rather
+  // than WakeupMessage itself. In particular, etl::string contains a pointer to its inline buffer.
+  static_assert(std::is_trivially_copyable_v<WakeupMessage*>);
+  xQueue = xQueueCreate(QUEUE_CAPACITY, sizeof(WakeupMessage*));
+  xFreeQueue = xQueueCreate(QUEUE_CAPACITY, sizeof(WakeupMessage*));
+  if (xQueue == nullptr || xFreeQueue == nullptr) {
+    fatalError("Failed to create BLE message queues");
+    return;
+  }
+  for (WakeupMessage& slot : messagePool_) {
+    WakeupMessage* slotPointer = &slot;
+    if (xQueueSend(xFreeQueue, &slotPointer, 0) != pdTRUE) {
+      fatalError("Failed to initialize BLE message pool");
+      return;
+    }
+  }
   heap_monitor::checkpoint("ble-queue");
 
   // Create the freeRTOS Task for handling Bluetooth low energy IO
@@ -170,7 +172,9 @@ void BLE::stop() {
 }
 
 void BLE::end() {
-  if (pServer == nullptr && xTimer == nullptr && xTask == nullptr && xQueue == nullptr) return;
+  if (pServer == nullptr && xTimer == nullptr && xTask == nullptr && xQueue == nullptr &&
+      xFreeQueue == nullptr)
+    return;
 
   heap_monitor::checkpoint("ble-end-before");
   if (pAdvertising != nullptr && started) {
@@ -191,6 +195,10 @@ void BLE::end() {
   if (xQueue != nullptr) {
     vQueueDelete(xQueue);
     xQueue = nullptr;
+  }
+  if (xFreeQueue != nullptr) {
+    vQueueDelete(xFreeQueue);
+    xFreeQueue = nullptr;
   }
   heap_monitor::registerTask("ble", nullptr);
 
@@ -215,13 +223,11 @@ void BLE::on_receive(const GpsMessage& msg) {
   // If the GPS message is a GPGGA or GPRMC, we store it in the buffers
   // for the next periodic send.
   if (msg.nmea.substr(0, 6) == "$GPGGA" || msg.nmea.substr(0, 6) == "$GNGGA") {
-    WakeupMessage message(WakeupMessage::Reason::GPS_GPGGA, msg.nmea);
-    if (xQueueSend(BLE::get().xQueue, &message, 0) != pdTRUE) {
+    if (!enqueue(WakeupReason::GPS_GPGGA, msg.nmea)) {
       markBleDiagnosticEvent(BLE_DIAG_GPS_QUEUE_FULL);
     }
   } else if (msg.nmea.substr(0, 6) == "$GPRMC" || msg.nmea.substr(0, 6) == "$GNRMC") {
-    WakeupMessage message(WakeupMessage::Reason::GPS_GPRMC, msg.nmea);
-    if (xQueueSend(BLE::get().xQueue, &message, 0) != pdTRUE) {
+    if (!enqueue(WakeupReason::GPS_GPRMC, msg.nmea)) {
       markBleDiagnosticEvent(BLE_DIAG_GPS_QUEUE_FULL);
     }
   }
@@ -231,8 +237,7 @@ void BLE::on_receive(const FanetPacket& msg) {
   // Short circuit if not initialized
   if (pServer == nullptr) return;
 
-  WakeupMessage message(WakeupMessage::Reason::FANET_RX, msg);
-  if (xQueueSend(BLE::get().xQueue, &message, 0) != pdTRUE) {
+  if (!enqueue(WakeupReason::FANET_RX, msg)) {
     markBleDiagnosticEvent(BLE_DIAG_FANET_QUEUE_FULL);
   }
 }
@@ -240,37 +245,47 @@ void BLE::on_receive(const FanetPacket& msg) {
 // FreeRTOS Task
 void BLE::bleTask(void* args) {
   BLE* ble = (BLE*)args;  // Bluetooth instance that started this task
-  WakeupMessage message;  // Reason for waking up, message to send out
   while (true) {
     // Sleep until there's some message to send out.
-    xQueueReceive(ble->xQueue, &message, portMAX_DELAY);
+    WakeupMessage* message = nullptr;
+    if (xQueueReceive(ble->xQueue, &message, portMAX_DELAY) != pdTRUE || message == nullptr) {
+      continue;
+    }
     ble->processDiagnostics();
-    switch (message.reason) {
-      case WakeupMessage::Reason::PERIODIC:
+    switch (message->reason) {
+      case WakeupReason::PERIODIC:
         // Periodic wakeup to send out the last known Vario & Baro data.
         ble->sendVarioUpdate();
         break;
-      case WakeupMessage::Reason::FANET_RX:
-        ble->sendFanetUpdate(etl::get<FanetPacket>(message.message));
+      case WakeupReason::FANET_RX:
+        ble->sendFanetUpdate(etl::get<FanetPacket>(message->message));
         break;
-      case WakeupMessage::Reason::GPS_GPGGA: {
+      case WakeupReason::GPS_GPGGA: {
         if (millis() - ble->lastGpsGgaMs < 500) {
           // If we received a GPGGA too soon, skip it
-          continue;
+          break;
         }
-        auto& gpsGpggaBuffer = etl::get<NMEAString>(message.message);
+        auto& gpsGpggaBuffer = etl::get<NMEAString>(message->message);
+        if (!ownsInlineBuffer(gpsGpggaBuffer)) {
+          fatalError("BLE GGA queue item does not own its string buffer");
+          break;
+        }
         ble->addChecksumToNMEA(gpsGpggaBuffer);
         ble->pCharacteristic->setValue((const uint8_t*)gpsGpggaBuffer.c_str(),
                                        gpsGpggaBuffer.size());
         ble->recordNusNotifyResult(ble->pCharacteristic->notify());
         ble->lastGpsGgaMs = millis();
       } break;
-      case WakeupMessage::Reason::GPS_GPRMC: {
+      case WakeupReason::GPS_GPRMC: {
         if (millis() - ble->lastGpsGprmcMs < 500) {
           // If we received a GPRMC too soon, skip it
-          continue;
+          break;
         }
-        auto& gpsGprmcBuffer = etl::get<NMEAString>(message.message);
+        auto& gpsGprmcBuffer = etl::get<NMEAString>(message->message);
+        if (!ownsInlineBuffer(gpsGprmcBuffer)) {
+          fatalError("BLE RMC queue item does not own its string buffer");
+          break;
+        }
         ble->addChecksumToNMEA(gpsGprmcBuffer);
         ble->pCharacteristic->setValue((const uint8_t*)gpsGprmcBuffer.c_str(),
                                        gpsGprmcBuffer.size());
@@ -280,17 +295,62 @@ void BLE::bleTask(void* args) {
         break;
       }
     }
+    ble->release(message);
   }
 }
 
 void BLE::timerCallback(TimerHandle_t timer) {
   // Send a message on the queue that it's time to do a periodic task send
   // (wake up the BLE task)
-  if (BLE::get().xQueue == nullptr) return;
-  WakeupMessage message(WakeupMessage::Reason::PERIODIC);
-  if (xQueueSend(BLE::get().xQueue, &message, 0) != pdTRUE) {
+  if (!BLE::get().enqueue(WakeupReason::PERIODIC)) {
     markBleDiagnosticEvent(BLE_DIAG_PERIODIC_QUEUE_FULL);
   }
+}
+
+bool BLE::enqueue(WakeupReason reason) {
+  if (xQueue == nullptr || xFreeQueue == nullptr) return false;
+  WakeupMessage* message = nullptr;
+  if (xQueueReceive(xFreeQueue, &message, 0) != pdTRUE || message == nullptr) return false;
+  message->reason = reason;
+  if (xQueueSend(xQueue, &message, 0) == pdTRUE) return true;
+  release(message);
+  return false;
+}
+
+bool BLE::enqueue(WakeupReason reason, const NMEAString& nmea) {
+  if (xQueue == nullptr || xFreeQueue == nullptr) return false;
+  WakeupMessage* message = nullptr;
+  if (xQueueReceive(xFreeQueue, &message, 0) != pdTRUE || message == nullptr) return false;
+  message->reason = reason;
+  message->message = nmea;
+  if (xQueueSend(xQueue, &message, 0) == pdTRUE) return true;
+  release(message);
+  return false;
+}
+
+bool BLE::enqueue(WakeupReason reason, const FanetPacket& packet) {
+  if (xQueue == nullptr || xFreeQueue == nullptr) return false;
+  WakeupMessage* message = nullptr;
+  if (xQueueReceive(xFreeQueue, &message, 0) != pdTRUE || message == nullptr) return false;
+  message->reason = reason;
+  message->message = packet;
+  if (xQueueSend(xQueue, &message, 0) == pdTRUE) return true;
+  release(message);
+  return false;
+}
+
+void BLE::release(WakeupMessage* message) {
+  if (message == nullptr || xFreeQueue == nullptr) return;
+  if (xQueueSend(xFreeQueue, &message, 0) != pdTRUE) {
+    fatalError("Failed to return BLE message to pool");
+  }
+}
+
+bool BLE::ownsInlineBuffer(const NMEAString& nmea) {
+  const uintptr_t objectStart = reinterpret_cast<uintptr_t>(&nmea);
+  const uintptr_t objectEnd = objectStart + sizeof(nmea);
+  const uintptr_t buffer = reinterpret_cast<uintptr_t>(nmea.data());
+  return buffer >= objectStart && buffer < objectEnd;
 }
 
 void BLE::sendVarioUpdate() {

--- a/src/vario/comms/ble.h
+++ b/src/vario/comms/ble.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <array>
+
 #include <NimBLEDevice.h>
 #include "TinyGPSPlus.h"
+#include "etl/variant.h"
 
 #include "dispatch/message_sink.h"
 #include "dispatch/message_types.h"
@@ -35,6 +38,15 @@ class BLE : public MessageSink<BLE, GpsMessage, FanetPacket> {
   void on_receive_unknown(const etl::imessage& msg) {}
 
  private:
+  enum class WakeupReason : uint8_t { PERIODIC, FANET_RX, GPS_GPGGA, GPS_GPRMC };
+
+  struct WakeupMessage {
+    WakeupReason reason = WakeupReason::PERIODIC;
+    etl::variant<NMEAString, FanetPacket> message;
+  };
+
+  static constexpr size_t QUEUE_CAPACITY = 4;
+
   BLE()
       : pServer(nullptr),
         pService(nullptr),
@@ -42,6 +54,7 @@ class BLE : public MessageSink<BLE, GpsMessage, FanetPacket> {
         pCharacteristic(nullptr),
         pAdvertising(nullptr),
         xQueue(nullptr),
+        xFreeQueue(nullptr),
         xTimer(nullptr),
         xTask(nullptr),
         started(false) {}
@@ -56,8 +69,11 @@ class BLE : public MessageSink<BLE, GpsMessage, FanetPacket> {
   NimBLECharacteristic* pCharacteristic;
   NimBLEAdvertising* pAdvertising;
 
-  // Queue for handling messages into this task from either buffer or periodic wakeup events.
+  // The work queue carries pointers because WakeupMessage contains self-referential ETL objects
+  // that cannot safely be byte-copied by a FreeRTOS queue. The free queue owns the available slots.
   QueueHandle_t xQueue;
+  QueueHandle_t xFreeQueue;
+  std::array<WakeupMessage, QUEUE_CAPACITY> messagePool_;
   // Timer for periodically requesting an update be sent for our Baro updates
   TimerHandle_t xTimer;
   // Task to handle Bluetooth IO
@@ -66,6 +82,12 @@ class BLE : public MessageSink<BLE, GpsMessage, FanetPacket> {
   // FreeRTOS Task handler callbacks
   static void bleTask(void*);
   static void timerCallback(TimerHandle_t timer);
+
+  bool enqueue(WakeupReason reason);
+  bool enqueue(WakeupReason reason, const NMEAString& nmea);
+  bool enqueue(WakeupReason reason, const FanetPacket& packet);
+  void release(WakeupMessage* message);
+  static bool ownsInlineBuffer(const NMEAString& nmea);
 
   void sendVarioUpdate();
   // NimBLE reports whether an update was submitted, not final over-the-air delivery.

--- a/src/vario/instruments/baro.cpp
+++ b/src/vario/instruments/baro.cpp
@@ -21,9 +21,7 @@
 #include "utils/flags_enum.h"
 #include "utils/magic_enum.h"
 
-// number of seconds for average climb rate (this is used for smoother data in places like
-// glide ratio, where rapidly fluctuating glide numbers aren't as useful as a several-second
-// average)
+// Number of seconds for the legacy long-term diagnostic climb average.
 constexpr uint32_t CLIMB_AVERAGE_S = 4;
 
 // number of seconds to average the climb rate before declaring that the averaged value is valid
@@ -128,6 +126,11 @@ void Barometer::init(void) {
   validClimbRate1SecAverage_ = false;
   climbFilter.reset();
   climb1SecFilter.reset();
+  climbDisplayHistory_.fill(0);
+  climbDisplayHistoryCount_ = 0;
+  climbDisplayHistoryIndex_ = 0;
+  climbDisplayBlockSum_ = 0;
+  climbDisplayBlockCount_ = 0;
   climbRateAverage_ = 0;
   nInitSamplesRemaining_ = CLIMB_AVERAGE_INIT_S * BARO_SAMPLES_PER_SECOND;
   startupDiscardSamplesRemaining_ = BARO_STARTUP_DISCARD_SAMPLES;
@@ -275,6 +278,29 @@ bool Barometer::climbRateFilteredValid() {
   return true;
 }
 
+int32_t Barometer::climbRateForDisplay() {
+  const int32_t current = climbRateFiltered();
+  if (climbDisplayAverageSeconds_ == 0 || climbDisplayHistoryCount_ == 0) return current;
+
+  const size_t requestedSamples = climbDisplayAverageSeconds_ * CLIMB_DISPLAY_SAMPLES_PER_SECOND;
+  const size_t validHistoryCount =
+      min<size_t>(climbDisplayHistoryCount_, CLIMB_DISPLAY_HISTORY_SIZE);
+  const size_t historyWriteIndex = climbDisplayHistoryIndex_ % CLIMB_DISPLAY_HISTORY_SIZE;
+  const size_t samplesToAverage = min(requestedSamples, validHistoryCount);
+  int32_t sum = 0;
+  for (size_t i = 0; i < samplesToAverage; ++i) {
+    const size_t historyIndex =
+        (historyWriteIndex + CLIMB_DISPLAY_HISTORY_SIZE - 1 - i) % CLIMB_DISPLAY_HISTORY_SIZE;
+    sum += climbDisplayHistory_[historyIndex];
+  }
+  return sum / static_cast<int32_t>(samplesToAverage);
+}
+
+void Barometer::setClimbDisplayAverageSeconds(uint8_t seconds) {
+  climbDisplayAverageSeconds_ =
+      seconds > CLIMB_DISPLAY_AVERAGE_MAX_SECONDS ? CLIMB_DISPLAY_AVERAGE_MAX_SECONDS : seconds;
+}
+
 int32_t Barometer::climbRate1SecAverage() {
   assertState("Barometer::climbRate1SecAverage", State::Ready);
   if (!validClimbRate1SecAverage_) {
@@ -355,6 +381,7 @@ void Barometer::filterClimb() {
   }
   climbRateFiltered_ = (int32_t)(climbFilterAvg * 100);
   validClimbRateFiltered_ = true;
+  updateClimbDisplayHistory();
 
   climb1SecFilter.update(climbRateRaw_);
   const float climb1SecAvg = climb1SecFilter.getAverage();
@@ -375,7 +402,7 @@ void Barometer::filterClimb() {
     nInitSamplesRemaining_ = 0;
   } else {
     // now calculate the longer-running average climb value
-    // (this is a smoother, slower-changing value for things like glide ratio, etc)
+    // (this is a smoother, slower-changing diagnostic value)
     uint32_t total_samples = CLIMB_AVERAGE_S * BARO_SAMPLES_PER_SECOND;
 
     climbRateAverage_ =
@@ -417,6 +444,25 @@ void Barometer::filterClimb() {
       file.close();
     }
   }
+}
+
+void Barometer::updateClimbDisplayHistory() {
+  constexpr uint8_t BARO_SAMPLES_PER_DISPLAY_SAMPLE =
+      BARO_SAMPLES_PER_SECOND / CLIMB_DISPLAY_SAMPLES_PER_SECOND;
+
+  climbDisplayBlockSum_ += climbRateFiltered_;
+  climbDisplayBlockCount_++;
+  if (climbDisplayBlockCount_ < BARO_SAMPLES_PER_DISPLAY_SAMPLE) return;
+
+  const int32_t blockAverage = climbDisplayBlockSum_ / climbDisplayBlockCount_;
+  // Normalize before dereferencing so even a corrupted retained index cannot become a wild write.
+  if (climbDisplayHistoryIndex_ >= CLIMB_DISPLAY_HISTORY_SIZE) climbDisplayHistoryIndex_ = 0;
+  climbDisplayHistory_[climbDisplayHistoryIndex_] =
+      static_cast<int16_t>(constrain(blockAverage, -32768L, 32767L));
+  climbDisplayHistoryIndex_ = (climbDisplayHistoryIndex_ + 1) % CLIMB_DISPLAY_HISTORY_SIZE;
+  if (climbDisplayHistoryCount_ < CLIMB_DISPLAY_HISTORY_SIZE) climbDisplayHistoryCount_++;
+  climbDisplayBlockSum_ = 0;
+  climbDisplayBlockCount_ = 0;
 }
 
 // ^^^ Device reading & data processing ^^^

--- a/src/vario/instruments/baro.h
+++ b/src/vario/instruments/baro.h
@@ -19,6 +19,8 @@
 #define FILTER_VALS_MAX 20  // total array size max;
 #define DEFAULT_SAMPLES_TO_AVERAGE 3
 #define BARO_SAMPLES_PER_SECOND 20
+#define CLIMB_DISPLAY_SAMPLES_PER_SECOND 5
+#define CLIMB_DISPLAY_AVERAGE_MAX_SECONDS 5
 
 // Barometer reporting altitude, adjusted altitude, climb rate, and other information.
 // Requires a pressure source.
@@ -62,13 +64,19 @@ class Barometer : public MessageSink<Barometer, PressureUpdate>,
 
   bool climbRateFilteredValid();
 
+  // Climb value for numerical display only (cm/s). This optionally applies the user's additional
+  // display averaging without changing the vario bar, speaker, or other climb consumers.
+  int32_t climbRateForDisplay();
+
+  void setClimbDisplayAverageSeconds(uint8_t seconds);
+
   // fixed 1-second averaged climb rate, independent of user vario sensitivity (cm/s)
   int32_t climbRate1SecAverage();
 
   bool climbRate1SecAverageValid();
 
-  // long-term (several seconds) averaged climb rate for smoothing out glide ratio and other
-  // calculations (cm/s)
+  // Legacy long-term (several seconds) averaged climb rate retained for diagnostics and other
+  // non-display consumers (cm/s)
   float climbRateAverage();
 
   bool climbRateAverageValid();
@@ -122,6 +130,16 @@ class Barometer : public MessageSink<Barometer, PressureUpdate>,
   int32_t climbRateFiltered_;
   bool validClimbRateFiltered_ = false;
 
+  static constexpr size_t CLIMB_DISPLAY_HISTORY_SIZE =
+      CLIMB_DISPLAY_SAMPLES_PER_SECOND * CLIMB_DISPLAY_AVERAGE_MAX_SECONDS;
+  static_assert(CLIMB_DISPLAY_HISTORY_SIZE == 25);
+  std::array<int16_t, CLIMB_DISPLAY_HISTORY_SIZE> climbDisplayHistory_{};
+  uint8_t climbDisplayHistoryCount_ = 0;
+  uint8_t climbDisplayHistoryIndex_ = 0;
+  int32_t climbDisplayBlockSum_ = 0;
+  uint8_t climbDisplayBlockCount_ = 0;
+  uint8_t climbDisplayAverageSeconds_ = 0;
+
   int32_t climbRate1SecAverage_;
   bool validClimbRate1SecAverage_ = false;
 
@@ -162,6 +180,7 @@ class Barometer : public MessageSink<Barometer, PressureUpdate>,
   // == Device reading & data processing ==
   void setPressureAlt(int32_t newPressure);
   void filterClimb(void);
+  void updateClimbDisplayHistory();
   void calculateAlts(void);
 };
 extern Barometer baro;

--- a/src/vario/instruments/gps.cpp
+++ b/src/vario/instruments/gps.cpp
@@ -145,22 +145,70 @@ void LeafGPS::init(void) {
 }  // gps_init
 
 void LeafGPS::calculateGlideRatio() {
-  if (!baro.climbRateAverageValid()) {
+  if (!hasFreshGroundSpeed() || !baro.climbRateFilteredValid()) {
+    resetGlideHistory();
     glideRatio = 0;
     return;
   }
-  float climb = baro.climbRateAverage();
-  float speed = gps.speed.kmph();
 
-  if (climb == 0 || speed == 0) {
-    glideRatio = 0;
-  } else {
-    //             km per hour       / cm per sec * sec per hour / cm per km
-    glideRatio = navigator.averageSpeed /
-                 (-1 * climb * 3600 /
-                  100000);  // add -1 to invert climbrate because 'negative' is down (in climb), but
-                            // we want a standard glide ratio (ie 'gliding down') to be positive
+  const uint32_t speedCommitMs = millis() - gps.speed.age();
+  if (speedCommitMs != lastGroundSpeedCommitMs_ && baro.climbRate1SecAverageValid()) {
+    lastGroundSpeedCommitMs_ = speedCommitMs;
+    recordGlideSample();
   }
+
+  if (glideAverageSeconds_ == 0) {
+    const int32_t climbCms = baro.climbRateFiltered();
+    const float groundSpeedCms = gps.speed.mps() * 100.0f;
+    glideRatio = climbCms < 0 && groundSpeedCms > 0 ? groundSpeedCms / -climbCms : 0;
+    return;
+  }
+
+  const size_t validHistoryCount = min<size_t>(glideHistoryCount_, GLIDE_HISTORY_SIZE);
+  const size_t historyWriteIndex = glideHistoryIndex_ % GLIDE_HISTORY_SIZE;
+  const size_t samplesToAverage = min<size_t>(validHistoryCount, glideAverageSeconds_);
+  if (samplesToAverage == 0) {
+    glideRatio = 0;
+    return;
+  }
+
+  uint32_t speedSum = 0;
+  int32_t climbSum = 0;
+  for (size_t i = 0; i < samplesToAverage; ++i) {
+    const size_t historyIndex =
+        (historyWriteIndex + GLIDE_HISTORY_SIZE - 1 - i) % GLIDE_HISTORY_SIZE;
+    speedSum += glideHistory_[historyIndex].groundSpeedCms;
+    climbSum += glideHistory_[historyIndex].climbCms;
+  }
+  glideRatio = climbSum < 0 && speedSum > 0 ? static_cast<float>(speedSum) / -climbSum : 0;
+}
+
+void LeafGPS::recordGlideSample() {
+  int32_t groundSpeedCms = static_cast<int32_t>(gps.speed.mps() * 100.0f);
+  if (groundSpeedCms < 0) groundSpeedCms = 0;
+  if (groundSpeedCms > UINT16_MAX) groundSpeedCms = UINT16_MAX;
+
+  int32_t climbCms = baro.climbRate1SecAverage();
+  if (climbCms < INT16_MIN) climbCms = INT16_MIN;
+  if (climbCms > INT16_MAX) climbCms = INT16_MAX;
+
+  // Normalize before dereferencing so even a corrupted retained index cannot become a wild write.
+  if (glideHistoryIndex_ >= GLIDE_HISTORY_SIZE) glideHistoryIndex_ = 0;
+  glideHistory_[glideHistoryIndex_] = {static_cast<uint16_t>(groundSpeedCms),
+                                       static_cast<int16_t>(climbCms)};
+  glideHistoryIndex_ = (glideHistoryIndex_ + 1) % GLIDE_HISTORY_SIZE;
+  if (glideHistoryCount_ < GLIDE_HISTORY_SIZE) glideHistoryCount_++;
+}
+
+void LeafGPS::resetGlideHistory() {
+  glideHistoryCount_ = 0;
+  glideHistoryIndex_ = 0;
+  lastGroundSpeedCommitMs_ = 0;
+}
+
+void LeafGPS::setGlideAverageSeconds(uint8_t seconds) {
+  if (seconds > GLIDE_HISTORY_SIZE) seconds = GLIDE_HISTORY_SIZE;
+  glideAverageSeconds_ = seconds - seconds % 2;
 }
 
 void LeafGPS::updateFixInfo() {
@@ -199,7 +247,7 @@ void LeafGPS::on_receive(const GpsMessage& msg) {
   if (DEBUG_GPS) {
     Serial.printf("LeafGPS::on_receive %d %s\n", msg.nmea.length(), msg.nmea.c_str());
   }
-  bool newSentence;
+  bool newSentence = false;
   {
     GpsLockGuard mutex;  // Ensure we have a lock on write
     for (size_t i = 0; i < msg.nmea.length(); i++) {

--- a/src/vario/instruments/gps.h
+++ b/src/vario/instruments/gps.h
@@ -17,6 +17,8 @@
 #ifndef gps_h
 #define gps_h
 
+#include <array>
+
 #include <TinyGPSPlus.h>
 #include "dispatch/message_sink.h"
 #include "dispatch/message_source.h"
@@ -98,6 +100,7 @@ class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, 
   bool lastValidFix(GPSPositionSnapshot& snapshot) const;
 
   float getGlideRatio(void) { return glideRatio; }
+  void setGlideAverageSeconds(uint8_t seconds);
 
   // Cached version of the sat info for showing on display (this will be re-written each time a
   // total set of new sat info is available)
@@ -112,6 +115,8 @@ class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, 
   void syncSystemClockIfNeeded();
 
   void calculateGlideRatio();
+  void recordGlideSample();
+  void resetGlideHistory();
 
   void testSats();
 
@@ -143,7 +148,18 @@ class LeafGPS : public TinyGPSPlus, IMessageSource, public MessageSink<LeafGPS, 
   // available
   etl::imessage_bus* bus_ = nullptr;
 
-  float glideRatio;
+  struct GlideSample {
+    uint16_t groundSpeedCms = 0;
+    int16_t climbCms = 0;
+  };
+  static_assert(sizeof(GlideSample) == 4);
+  static constexpr size_t GLIDE_HISTORY_SIZE = 20;
+  std::array<GlideSample, GLIDE_HISTORY_SIZE> glideHistory_{};
+  uint8_t glideHistoryCount_ = 0;
+  uint8_t glideHistoryIndex_ = 0;
+  uint32_t lastGroundSpeedCommitMs_ = 0;
+  uint8_t glideAverageSeconds_ = 10;
+  float glideRatio = 0;
 
   NMEAString nmeaBuffer = {'\0'};  // buffer for reading NMEA sentences
   int nmeaBufferIndex = 0;         // index into the buffer currently writing to

--- a/src/vario/navigation/gpx.cpp
+++ b/src/vario/navigation/gpx.cpp
@@ -353,7 +353,6 @@ void Navigator::clear() {
   activeRoutePointIndex = RouteIndex::None;
   activeRouteIndex = RouteID::None;
   altAboveWaypoint = 0;
-  averageSpeed = 0;
   glideToActive = 0;
   segmentDistance = 0;
   pointDistanceRemaining = 0;
@@ -499,13 +498,6 @@ void Navigator::update() {
       altAboveGoal_ = 100 * (gps.altitude.meters() - goalPoint_.ele);
     else
       altAboveGoal_ = altAboveWaypoint;
-  }
-
-  // update additional values that are required regardless of if we're navigating to a point
-  // average speed
-  if (gps.hasFreshGroundSpeed()) {
-    averageSpeed =
-        (averageSpeed * (AVERAGE_SPEED_SAMPLES - 1) + gps.speed.kmph()) / AVERAGE_SPEED_SAMPLES;
   }
 }
 

--- a/src/vario/navigation/gpx.h
+++ b/src/vario/navigation/gpx.h
@@ -6,8 +6,6 @@
 
 #include "navigation/nav_ids.h"
 
-#define AVERAGE_SPEED_SAMPLES 5
-
 // Waypoint definition and memory allocation
 #define defaultWaypointRadius 150  // meters radius to count as "reaching/crossing" a waypoint
 #define maxRoutes 10
@@ -185,9 +183,6 @@ class Navigator {
 
   // (gps measured) Altitude in cm above current waypoint
   int32_t altAboveWaypoint = 0;
-
-  // keep a running average speed, to smooth out glide ratio and time-remaning calculations.
-  float averageSpeed = 0;
 
   // glide ratio from current position to active waypoint
   float glideToActive = 0;

--- a/src/vario/ui/display/pages/menu/page_menu_vario.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.cpp
@@ -16,16 +16,17 @@
 enum vario_menu_items {
   cursor_vario_back,
   cursor_vario_volume,
+  cursor_vario_volumeShortcut,
   // cursor_vario_tones,
   cursor_vario_quietmode,
 
   cursor_vario_sensitive,
-  // cursor_vario_climbavg,
+  cursor_vario_climbavg,
+  cursor_vario_glideavg,
 
   cursor_vario_climbstart,
   // cursor_vario_liftyair,
   cursor_vario_sinkalarm,
-  cursor_vario_volumeShortcut,
 };
 
 void VarioMenuPage::draw() {
@@ -37,7 +38,7 @@ void VarioMenuPage::draw() {
     // Menu Items
     uint8_t setting_name_x = 2;
     uint8_t setting_choice_x = 68;
-    uint8_t menu_items_y[] = {190, 40, 55, 70, 85, 100, 128 /*, 135, 150, 165*/};
+    uint8_t menu_items_y[] = {190, 40, 55, 70, 85, 100, 115, 130, 145};
 
     for (int i = 0; i <= cursor_max; i++) {
       const bool selected = i == cursor_position;
@@ -50,6 +51,10 @@ void VarioMenuPage::draw() {
           u8g2.setFont(leaf_icons);
           u8g2.print(char('I' + settings.vario_volume));
           u8g2.setFont(leaf_6x12);
+          break;
+        case cursor_vario_volumeShortcut:
+          u8g2.setCursor(80, menu_items_y[i]);
+          menu_ui::printGlyph(settings.volumeShortcut ? menu_ui::ICON_ON : menu_ui::ICON_OFF);
           break;
         /*
         case cursor_vario_tones:
@@ -72,12 +77,24 @@ void VarioMenuPage::draw() {
           u8g2.print(' ');
           u8g2.print(settings.vario_sensitivity);
           break;
-        /*
         case cursor_vario_climbavg:
           u8g2.print(' ');
-          u8g2.print(settings.vario_climbAvg);
+          if (settings.vario_climbDisplayAverage == 0)
+            u8g2.print("OFF");
+          else {
+            u8g2.print(settings.vario_climbDisplayAverage);
+            u8g2.print('s');
+          }
           break;
-        */
+        case cursor_vario_glideavg:
+          u8g2.print(' ');
+          if (settings.glideAverageSeconds == 0)
+            u8g2.print("OFF");
+          else {
+            u8g2.print(settings.glideAverageSeconds);
+            u8g2.print('s');
+          }
+          break;
         case cursor_vario_climbstart:
           if (settings.units_climb) {
             u8g2.print(' ');
@@ -138,11 +155,6 @@ void VarioMenuPage::draw() {
           u8g2.setFont(leaf_6x12);
           break;
 
-        case cursor_vario_volumeShortcut:
-          u8g2.setCursor(80, menu_items_y[i]);
-          menu_ui::printGlyph(settings.volumeShortcut ? menu_ui::ICON_ON : menu_ui::ICON_OFF);
-          break;
-
         case cursor_vario_back:
           menu_ui::drawBackIcon(setting_choice_x, menu_items_y[i]);
           break;
@@ -168,6 +180,10 @@ void VarioMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count)
       if (state != ButtonEvent::CLICKED) return;
       settings.adjustVolumeVario(dir);
       break;
+    case cursor_vario_volumeShortcut:
+      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
+        settings.toggleBoolOnOff(&settings.volumeShortcut);
+      break;
     case cursor_vario_quietmode:
       if (state == ButtonEvent::CLICKED) settings.toggleBoolOnOff(&settings.vario_quietMode);
       break;
@@ -182,20 +198,17 @@ void VarioMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count)
       if (state == ButtonEvent::CLICKED) settings.adjustLiftyAir(dir);
       break;
       */
-    /*
     case cursor_vario_climbavg:
-      if (state == ButtonEvent::CLICKED) settings.adjustClimbAverage(dir);
+      if (state == ButtonEvent::CLICKED) settings.adjustClimbDisplayAverage(dir);
       break;
-    */
+    case cursor_vario_glideavg:
+      if (state == ButtonEvent::CLICKED) settings.adjustGlideAverage(dir);
+      break;
     case cursor_vario_climbstart:
       if (state == ButtonEvent::CLICKED) settings.adjustClimbStart(dir);
       break;
     case cursor_vario_sinkalarm:
       if (state == ButtonEvent::CLICKED) settings.adjustSinkAlarm(dir);
-      break;
-    case cursor_vario_volumeShortcut:
-      if (state == ButtonEvent::CLICKED && (dir == Button::CENTER || dir == Button::RIGHT))
-        settings.toggleBoolOnOff(&settings.volumeShortcut);
       break;
     case cursor_vario_back:
       if (state == ButtonEvent::CLICKED) {
@@ -213,5 +226,6 @@ void VarioMenuPage::setting_change(Button dir, ButtonEvent state, uint8_t count)
 
 bool VarioMenuPage::cursorUsesLeftButton() const {
   return cursor_position == cursor_vario_volume || cursor_position == cursor_vario_sensitive ||
+         cursor_position == cursor_vario_climbavg || cursor_position == cursor_vario_glideavg ||
          cursor_position == cursor_vario_climbstart || cursor_position == cursor_vario_sinkalarm;
 }

--- a/src/vario/ui/display/pages/menu/page_menu_vario.cpp
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.cpp
@@ -21,12 +21,11 @@ enum vario_menu_items {
   cursor_vario_quietmode,
 
   cursor_vario_sensitive,
-  cursor_vario_climbavg,
-  cursor_vario_glideavg,
-
   cursor_vario_climbstart,
   // cursor_vario_liftyair,
   cursor_vario_sinkalarm,
+  cursor_vario_climbavg,
+  cursor_vario_glideavg,
 };
 
 void VarioMenuPage::draw() {
@@ -38,7 +37,7 @@ void VarioMenuPage::draw() {
     // Menu Items
     uint8_t setting_name_x = 2;
     uint8_t setting_choice_x = 68;
-    uint8_t menu_items_y[] = {190, 40, 55, 70, 85, 100, 115, 130, 145};
+    uint8_t menu_items_y[] = {190, 40, 55, 70, 85, 100, 115, 145, 160};
 
     for (int i = 0; i <= cursor_max; i++) {
       const bool selected = i == cursor_position;
@@ -47,7 +46,7 @@ void VarioMenuPage::draw() {
       u8g2.setCursor(setting_choice_x, menu_items_y[i]);
       switch (i) {
         case cursor_vario_volume:
-          u8g2.print(' ');
+          u8g2.setCursor(80, menu_items_y[i]);
           u8g2.setFont(leaf_icons);
           u8g2.print(char('I' + settings.vario_volume));
           u8g2.setFont(leaf_6x12);
@@ -66,7 +65,7 @@ void VarioMenuPage::draw() {
           break;
           */
         case cursor_vario_quietmode:
-          u8g2.print(' ');
+          u8g2.setCursor(80, menu_items_y[i]);
           if (settings.vario_quietMode)
             menu_ui::printGlyph(menu_ui::ICON_ON);
           else
@@ -78,19 +77,21 @@ void VarioMenuPage::draw() {
           u8g2.print(settings.vario_sensitivity);
           break;
         case cursor_vario_climbavg:
-          u8g2.print(' ');
-          if (settings.vario_climbDisplayAverage == 0)
+          if (settings.vario_climbDisplayAverage == 0) {
+            u8g2.setCursor(setting_choice_x + 3, menu_items_y[i]);
             u8g2.print("OFF");
-          else {
+          } else {
+            u8g2.print(' ');
             u8g2.print(settings.vario_climbDisplayAverage);
             u8g2.print('s');
           }
           break;
         case cursor_vario_glideavg:
-          u8g2.print(' ');
-          if (settings.glideAverageSeconds == 0)
+          if (settings.glideAverageSeconds == 0) {
+            u8g2.setCursor(setting_choice_x + 3, menu_items_y[i]);
             u8g2.print("OFF");
-          else {
+          } else {
+            u8g2.print(' ');
             u8g2.print(settings.glideAverageSeconds);
             u8g2.print('s');
           }

--- a/src/vario/ui/display/pages/menu/page_menu_vario.h
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.h
@@ -21,16 +21,16 @@ class VarioMenuPage : public SettingsMenuPage {
  private:
   static constexpr char* labels[9] = {
       "Back",
-      "Beep Vol",
+      "Beep Volume",
       "Vol Shortcut",
       /*"Tones",*/
-      "QuietMode",
+      "Quiet Mode",
       "Sensitivity",
-      "Climb Avg",
-      "Glide Avg",
       "ClimbStart",
       /*"LiftyAir",*/
       "SinkAlarm",
+      "Climb Avg",
+      "Glide Avg",
   };
 };
 

--- a/src/vario/ui/display/pages/menu/page_menu_vario.h
+++ b/src/vario/ui/display/pages/menu/page_menu_vario.h
@@ -10,7 +10,7 @@ class VarioMenuPage : public SettingsMenuPage {
  public:
   VarioMenuPage() {
     cursor_position = 0;
-    cursor_max = 6;
+    cursor_max = 8;
   }
   void draw();
 
@@ -19,17 +19,18 @@ class VarioMenuPage : public SettingsMenuPage {
   bool cursorUsesLeftButton() const override;
 
  private:
-  static constexpr char* labels[7] = {
+  static constexpr char* labels[9] = {
       "Back",
       "Beep Vol",
+      "Vol Shortcut",
       /*"Tones",*/
       "QuietMode",
       "Sensitivity",
-      /*"ClimbAvg",*/
+      "Climb Avg",
+      "Glide Avg",
       "ClimbStart",
       /*"LiftyAir",*/
       "SinkAlarm",
-      "Vol Shortcut",
   };
 };
 

--- a/src/vario/ui/display/pages/primary/page_navigate.cpp
+++ b/src/vario/ui/display/pages/primary/page_navigate.cpp
@@ -262,6 +262,7 @@ void navigatePage_draw() {
     // Vario Bar
     // TODO: display lack of climb rate differently than 0
     int32_t climbRate = baro.climbRateFilteredValid() ? baro.climbRateFiltered() : 0;
+    const int32_t displayClimbRate = baro.climbRateFilteredValid() ? baro.climbRateForDisplay() : 0;
     display_varioBar(topOfFrame, varioBarTopHeight, varioBarBottomHeight, varioBarWidth, climbRate);
 
     // Climb
@@ -321,7 +322,7 @@ void navigatePage_draw() {
       u8g2.print("-");
 
     // climb value
-    display_unsignedClimbRate_short(varioBarWidth + 1, varioBarMidpoint + 20, climbRate);
+    display_unsignedClimbRate_short(varioBarWidth + 1, varioBarMidpoint + 20, displayClimbRate);
 
     // alt
     display_alt_type(49, 109, leaf_8x14, settings.disp_navPageAltType);

--- a/src/vario/ui/display/pages/primary/page_simple.cpp
+++ b/src/vario/ui/display/pages/primary/page_simple.cpp
@@ -93,6 +93,7 @@ void simplePage_draw() {
 
     // TODO: display lack of climb rate differently than 0
     int32_t climbRate = baro.climbRateFilteredValid() ? baro.climbRateFiltered() : 0;
+    const int32_t displayClimbRate = baro.climbRateFilteredValid() ? baro.climbRateForDisplay() : 0;
     display_varioBar(topOfFrame, varioBarClimbHeight, varioBarSinkHeight, varioBarWidth, climbRate);
 
     // Climb
@@ -100,7 +101,7 @@ void simplePage_draw() {
     uint8_t climbBoxY = topOfFrame + varioBarClimbHeight - climbBoxHeight / 2;
     display_climbRatePointerBox(varioBarWidth + 9, climbBoxY, 75, climbBoxHeight,
                                 16);  // x, y, w, h, triangle size
-    display_climbRate(11, climbBoxY + 31, leaf_28h, climbRate);
+    display_climbRate(11, climbBoxY + 31, leaf_28h, displayClimbRate);
     u8g2.setDrawColor(0);
     u8g2.drawPixel(varioBarWidth + 9,
                    climbBoxY);  // one pixel corner needs trimmed due to interaction with triangle

--- a/src/vario/ui/display/pages/primary/page_thermal.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal.cpp
@@ -70,6 +70,7 @@ void thermalPage_draw() {
 
     // TODO: display lack of climb rate differently than 0
     int32_t climbRate = baro.climbRateFilteredValid() ? baro.climbRateFiltered() : 0;
+    const int32_t displayClimbRate = baro.climbRateFilteredValid() ? baro.climbRateForDisplay() : 0;
     display_varioBar(topOfFrame, varioBarClimbHeight, varioBarSinkHeight, varioBarWidth, climbRate);
 
     // Altitude
@@ -97,7 +98,7 @@ void thermalPage_draw() {
     uint8_t climbBoxY = topOfFrame + varioBarClimbHeight - climbBoxHeight / 2;
     display_climbRatePointerBox(varioBarWidth, climbBoxY, 76, climbBoxHeight,
                                 13);  // x, y, w, h, triangle size
-    display_climbRate(20, climbBoxY + 24, leaf_21h, climbRate);
+    display_climbRate(20, climbBoxY + 24, leaf_21h, displayClimbRate);
     u8g2.setDrawColor(0);
     u8g2.setFont(leaf_5h);
     u8g2.print(" ");  // put a space, but using a small font so the space isn't too wide

--- a/src/vario/ui/display/pages/primary/page_thermal_core.cpp
+++ b/src/vario/ui/display/pages/primary/page_thermal_core.cpp
@@ -276,6 +276,7 @@ namespace {
 
   void drawThermalCoreContent() {
     const int32_t climbRate = baro.climbRateFilteredValid() ? baro.climbRateFiltered() : 0;
+    const int32_t displayClimbRate = baro.climbRateFilteredValid() ? baro.climbRateForDisplay() : 0;
     const ThermalCoreEstimate& estimate = thermalCore.estimate();
     const int8_t direction = estimate.direction;
     const int8_t turnSide = direction < 0 ? -1 : direction > 0 ? 1 : 0;
@@ -291,7 +292,7 @@ namespace {
     display_varioBar(VARIO_BAR_TOP, VARIO_BAR_HALF_HEIGHT, VARIO_BAR_HALF_HEIGHT, VARIO_BAR_WIDTH,
                      climbRate);
     drawAltitudeField();
-    drawClimbRateField(climbRate);
+    drawClimbRateField(displayClimbRate);
 
     if (hasGuidance) {
       drawArc(targetCx, AIRCRAFT_Y, dynamicRadius, turnSide);

--- a/src/vario/ui/settings/settings.cpp
+++ b/src/vario/ui/settings/settings.cpp
@@ -49,7 +49,6 @@ bool Settings::init() {
     }
     baro.setFilterSamples(nSamples);
   });
-
   loadDefaults();  // load defaults regardless, but we'll overwrite
                    // these with saved user settings (if available)
 
@@ -80,6 +79,8 @@ bool Settings::init() {
     retrieve();
     boot_firstTime = false;
   }
+  baro.setClimbDisplayAverageSeconds(vario_climbDisplayAverage);
+  gps.setGlideAverageSeconds(glideAverageSeconds);
   return boot_firstTime;
 }
 
@@ -161,7 +162,8 @@ void Settings::loadDefaults() {
   vario_sinkAlarm = DEF_SINK_ALARM;
   vario_sinkAlarm_units = DEF_SINK_ALARM_UNITS;
   vario_sensitivity.loadDefault();
-  vario_climbAvg = DEF_CLIMB_AVERAGE;
+  vario_climbDisplayAverage = DEF_CLIMB_DISPLAY_AVERAGE;
+  glideAverageSeconds = DEF_GLIDE_AVERAGE;
   vario_climbStart = DEF_CLIMB_START;
   vario_volume = DEF_VOLUME_VARIO;
   volumeShortcut = DEF_VOLUME_SHORTCUT;
@@ -244,7 +246,12 @@ void Settings::retrieve() {
   vario_sinkAlarm = leafPrefs.getFloat("SINK_ALARM_VAL", DEF_SINK_ALARM);
   vario_sinkAlarm_units = leafPrefs.getBool("SINK_ALARM_UNIT", DEF_SINK_ALARM_UNITS);
   vario_sensitivity.readFrom(leafPrefs);
-  vario_climbAvg = leafPrefs.getChar("CLIMB_AVERAGE");
+  vario_climbDisplayAverage = leafPrefs.getChar("climbDispAvg", DEF_CLIMB_DISPLAY_AVERAGE);
+  if (vario_climbDisplayAverage < 0 || vario_climbDisplayAverage > 5)
+    vario_climbDisplayAverage = DEF_CLIMB_DISPLAY_AVERAGE;
+  glideAverageSeconds = leafPrefs.getChar("glideAvgSec", DEF_GLIDE_AVERAGE);
+  if (glideAverageSeconds < 0 || glideAverageSeconds > 20) glideAverageSeconds = DEF_GLIDE_AVERAGE;
+  glideAverageSeconds -= glideAverageSeconds % 2;
   vario_climbStart = leafPrefs.getChar("CLIMB_START");
   vario_volume = leafPrefs.getChar("VOLUME_VARIO");
   volumeShortcut = leafPrefs.getBool("VOL_SHORTCUT", DEF_VOLUME_SHORTCUT);
@@ -344,7 +351,8 @@ void Settings::save() {
   leafPrefs.putFloat("SINK_ALARM_VAL", vario_sinkAlarm);
   leafPrefs.putBool("SINK_ALARM_UNIT", vario_sinkAlarm_units);
   vario_sensitivity.putInto(leafPrefs);
-  leafPrefs.putChar("CLIMB_AVERAGE", vario_climbAvg);
+  leafPrefs.putChar("climbDispAvg", vario_climbDisplayAverage);
+  leafPrefs.putChar("glideAvgSec", glideAverageSeconds);
   leafPrefs.putChar("CLIMB_START", vario_climbStart);
   leafPrefs.putChar("VOLUME_VARIO", vario_volume);
   leafPrefs.putBool("VOL_SHORTCUT", volumeShortcut);
@@ -540,23 +548,44 @@ void Settings::adjustVarioAverage(Button dir) {
   speaker.playSound(sound);
 }
 
-// climb average goes between 0 and CLIMB_AVERAGE_MAX
-void Settings::adjustClimbAverage(Button dir) {
+void Settings::adjustClimbDisplayAverage(Button dir) {
   sound_t sound = fx::neutral;
 
   if (dir == Button::RIGHT) {
     sound = fx::increase;
-    if (++vario_climbAvg >= CLIMB_AVERAGE_MAX) {
-      vario_climbAvg = CLIMB_AVERAGE_MAX;
+    if (vario_climbDisplayAverage < 5)
+      vario_climbDisplayAverage++;
+    else
       sound = fx::doubleClick;
-    }
   } else {
     sound = fx::decrease;
-    if (--vario_climbAvg <= 0) {
-      vario_climbAvg = 0;
+    if (vario_climbDisplayAverage > 0)
+      vario_climbDisplayAverage--;
+    else
       sound = fx::doubleClick;
-    }
   }
+  baro.setClimbDisplayAverageSeconds(vario_climbDisplayAverage);
+  speaker.playSound(sound);
+}
+
+void Settings::adjustGlideAverage(Button dir) {
+  const int8_t before = glideAverageSeconds;
+  int8_t after = before;
+  sound_t sound = fx::neutral;
+
+  if (dir == Button::RIGHT) {
+    sound = fx::increase;
+    after = before + 2;
+    if (after > 20) after = 20;
+  } else {
+    sound = fx::decrease;
+    after = before - 2;
+    if (after < 0) after = 0;
+  }
+
+  glideAverageSeconds = after;
+  if (before == glideAverageSeconds) sound = fx::doubleClick;
+  gps.setGlideAverageSeconds(glideAverageSeconds);
   speaker.playSound(sound);
 }
 

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -14,8 +14,7 @@
 // Lifty Air Thermal Sniffer
 #define LIFTY_AIR_MAX -8  // 0.1 m/s - sinking less than this will trigger
 // Climb settings
-#define CLIMB_AVERAGE_MAX 3  // units of 10 seconds, so max 30 sec averaging
-#define CLIMB_START_MAX 20   // cm/s when climb note begins
+#define CLIMB_START_MAX 20  // cm/s when climb note begins
 
 // System
 // Display Contrast
@@ -32,11 +31,12 @@
 #define DEF_SINK_ALARM -2.5f    // m/s sink
 #define DEF_SINK_ALARM_UNITS 0  // 0 = m/s, 1 = fpm
 #define DEF_VARIO_SENSE 3       // 3 = avg of 6 samples (6/20 of a second)
-#define DEF_CLIMB_AVERAGE 1     // in units of 5-seconds.  (def = 1 = 5sec)
-#define DEF_CLIMB_START 5       // cm/s when climb note begins
-#define DEF_VOLUME_VARIO 2      // 0=off, 1=low, 2=med, 3=high
-#define DEF_QUIET_MODE 0        // 0 = off, 1 = on (ON means no beeping until flight recording)
-#define DEF_VOLUME_SHORTCUT 0   // 0 = disabled, 1 = enabled
+#define DEF_CLIMB_DISPLAY_AVERAGE 0
+#define DEF_GLIDE_AVERAGE 10
+#define DEF_CLIMB_START 5      // cm/s when climb note begins
+#define DEF_VOLUME_VARIO 2     // 0=off, 1=low, 2=med, 3=high
+#define DEF_QUIET_MODE 0       // 0 = off, 1 = on (ON means no beeping until flight recording)
+#define DEF_VOLUME_SHORTCUT 0  // 0 = disabled, 1 = enabled
 // 0 == linear pitch interpolation; 1 == major C-scale for climb, minor scale for descent
 #define DEF_VARIO_TONES 0
 // In units of 10 cm/s (a sink rate of only 30cm/s means the air itself is going up).  '0' is off.
@@ -125,7 +125,10 @@ class Settings {
   // Vario Settings
   float vario_sinkAlarm;
   bool vario_sinkAlarm_units;
-  int8_t vario_climbAvg;
+  // Additional averaging applied only to the numerical climb display, in seconds.
+  int8_t vario_climbDisplayAverage;
+  // Common averaging window for the ground-speed and sink components of displayed glide ratio.
+  int8_t glideAverageSeconds;
   int8_t vario_climbStart;
   int8_t vario_volume;
   bool volumeShortcut;
@@ -237,7 +240,8 @@ setting | samples | time avg
   void adjustSinkAlarm(Button dir);
   void adjustSinkAlarmUnits(bool units);
   void adjustVarioAverage(Button dir);
-  void adjustClimbAverage(Button dir);
+  void adjustClimbDisplayAverage(Button dir);
+  void adjustGlideAverage(Button dir);
   void adjustClimbStart(Button dir);
   void adjustLiftyAir(Button dir);
   void adjustVolumeVario(Button dir);


### PR DESCRIPTION
## Summary

This PR adds configurable averaging for the displayed climb rate and glide ratio, refines the Vario settings menu, and fixes a pre-existing BLE queue ownership bug uncovered during hardware testing.

## Display averaging

### Climb rate

Adds a `Climb Avg` setting with values from `OFF` through `5s`, defaulting to `OFF`.

- Averaging affects only the numerical climb-rate display.
- The vario bar, speaker tones, flight logic, and other climb-rate consumers remain unchanged.
- The existing 20 Hz filtered climb data is reduced to 5 Hz before being stored.
- A fixed 25-entry `int16_t` ring buffer provides up to five seconds of history with minimal memory use.
- While the history is filling, the average uses the available samples rather than waiting for a complete window.

### Glide ratio

Adds a `Glide Avg` setting from `OFF` through `20s` in two-second increments, defaulting to `10s`.

- Each fresh GPS ground-speed update records a compact sample containing:
  - ground speed in cm/s
  - the corresponding one-second climb-rate average in cm/s
- Up to 20 samples are stored in a fixed-size history.
- Ground speed and vertical speed are averaged separately before calculating the ratio. This is more meaningful than averaging already-calculated glide-ratio values.
- `OFF` uses the current fresh ground speed and filtered climb rate.
- Glide history is cleared when valid/fresh input data is unavailable.
- The previous independent exponential `Navigator::averageSpeed` smoothing was removed.

The climb history consumes 50 bytes for samples, and the glide history consumes 80 bytes for samples.

## Vario menu changes

The Vario menu now contains:

1. Beep Volume
2. Vol Shortcut
3. Quiet Mode
4. Sensitivity
5. ClimbStart
6. SinkAlarm
7. Climb Avg
8. Glide Avg

Additional layout refinements:

- The speaker icon and both checkboxes share the same control column.
- `Vol Shortcut` displays its explanatory note whenever the row is selected.
- A blank row after `SinkAlarm` leaves room for its `fpm` or `m/s` units.
- The `OFF` labels for the averaging settings are shifted slightly left to fit the display.
- The average values include an `s` suffix.

## BLE queue corruption fix

### Root cause

Hardware testing initially produced repeatable panic resets after roughly 30–80 seconds with BLE enabled.

The BLE work queue previously stored `WakeupMessage` objects directly:

```cpp
xQueueCreate(4, sizeof(WakeupMessage))
```

`WakeupMessage` contains an `etl::variant<NMEAString, FanetPacket>`, and `NMEAString` is an `etl::string` with an internal pointer to its inline character buffer.

FreeRTOS queues do not invoke C++ copy constructors. They copy queue items as raw bytes. Consequently, copying a `WakeupMessage` into and out of the queue also copied the string's internal buffer pointer without rebinding it to the copied object's inline storage.

The BLE task therefore received an apparently valid string object whose internal pointer still referenced the producer's former stack object on `loopTask`. When BLE appended the NMEA checksum and line ending, it wrote through that stale pointer and corrupted the loop task's stack.

Core-dump inspection confirmed the complete failure chain:

- A queued `$GNGGA` sentence still pointed into the loop task stack.
- BLE appended `*50\r\n` through that dangling pointer.
- The checksum bytes overwrote part of a saved return address.
- A valid code address beginning with `0x4005...` became the invalid PC `0x352a59e0`, with `0x35 0x2a` corresponding to the `"5*"` checksum bytes.
- The resulting panic reset was reported as reset reason 4.

This was a latent queue-ownership problem exposed consistently by the stack-layout changes in this branch; the averaging arrays themselves were not corrupting memory.

### Fix

BLE now uses a fixed pool of four fully constructed `WakeupMessage` objects:

- The work queue carries only `WakeupMessage*`.
- A second queue tracks available pool entries.
- Producers acquire an entry, assign the NMEA or FANET payload using normal C++ assignment, and enqueue its pointer.
- The BLE task processes the entry and returns it to the free queue.
- The queue remains bounded at four messages and performs no per-message heap allocation.
- Both GPS/NMEA and FANET payload variants retain correct C++ object ownership.
- BLE setup and teardown create and delete both queues.
- Dropped/too-frequent GPS messages now return their pool entries correctly.
- Runtime ownership checks verify that queued NMEA strings point into their own inline storage and raise a diagnostic fatal error if this invariant is ever broken.

## Additional safety changes

- Ring-buffer indices are normalized before array access.
- The GPS NMEA parser's `newSentence` flag is explicitly initialized.
- Invalid persisted averaging values are replaced with defaults, and glide averaging values are normalized to even-numbered seconds.

## Verification

- Ran the repository formatter.
- Successfully built `leaf_3_2_6_release`.
  - RAM: 103,708 bytes / 327,680 bytes (31.6%)
  - Flash: 2,237,840 bytes / 3,342,336 bytes (67.0%)
- Flashed the firmware to both OTA application slots on a Leaf 3.2.6 device.
- Visually verified the updated Vario menu on the device.
- Exercised a complete flight-log cycle while:
  - changing climb and glide averaging settings
  - disabling Bluetooth
  - re-enabling Bluetooth
- The stress-test session ran for approximately 485 seconds with continuous main-loop heartbeats.
- BLE teardown and recreation completed successfully.
- Heap and task stack measurements remained stable after BLE recreation.
- No new panic, watchdog, assertion, queue failure, or ownership-guard event was recorded.
- The later `poweron` reset in the diagnostic log was the expected transition into USB mass-storage/charge mode.
