### PR TITLE
Ignore hidden SD firmware files

### DIFF
--- a/src/vario/comms/sd_firmware_update.cpp
+++ b/src/vario/comms/sd_firmware_update.cpp
@@ -111,6 +111,11 @@ namespace {
     return lower.endsWith(".bin");
   }
 
+  bool isHiddenFile(const String& name) {
+    const int basenameStart = name.lastIndexOf('/') + 1;
+    return basenameStart < static_cast<int>(name.length()) && name[basenameStart] == '.';
+  }
+
   bool filenameContainsDifferentLeafHardware(const String& name) {
     return name.indexOf("leaf_") >= 0 || name.indexOf("Leaf_") >= 0 || name.indexOf("LEAF_") >= 0;
   }
@@ -220,7 +225,8 @@ namespace {
     String found;
     File entry = dir.openNextFile();
     while (entry) {
-      if (!entry.isDirectory() && hasFirmwareExtension(entry.name())) {
+      const String name = entry.name();
+      if (!entry.isDirectory() && !isHiddenFile(name) && hasFirmwareExtension(name)) {
         if (found.length()) {
           result = Result::FailedMultipleFiles;
           entry.close();


### PR DESCRIPTION
## Summary

- Ignore dot-prefixed hidden files when scanning `/firmware`.
- Prevent macOS `._*.bin` metadata files from triggering the “multiple firmware files” error.
- Preserve the existing exactly-one-visible-`.bin` safety check.

## Testing

- Formatting passed.
- `leaf_3_2_6_release` build passed.