### PR TITLE
Improve factory commissioning reliability

### DIFF
--- a/factory_interface/src/factory_interface/app.py
+++ b/factory_interface/src/factory_interface/app.py
@@ -212,7 +212,7 @@ def commissioning_session_summaries() -> list[dict]:
                 "label": session.mac_address,
                 "url": f"/setup/{session.mac_address}",
                 "status": session.status,
-                "details": session.details,
+                "details": session.progress_details(),
                 "created_at": session.created_at.isoformat(),
                 "updated_at": session.updated_at.isoformat(),
             }

--- a/factory_interface/src/factory_interface/commissioning_sessions.py
+++ b/factory_interface/src/factory_interface/commissioning_sessions.py
@@ -99,13 +99,36 @@ class CommissioningSession:
     def touch(self) -> None:
         self.updated_at = datetime.now()
 
+    def progress_details(self) -> str:
+        if self.status != "running":
+            return self.details
+
+        stage_names = {
+            "prepare_sd_card": "Preparing SD card",
+            "firmware_version": "Reading firmware version",
+            "interactive_self_test": "Running self tests",
+            "retrieve_test_details": "Retrieving self-test details",
+            "fanet_id": "Assigning FANET ID",
+            "persist_results": "Writing commissioning log",
+            "clear_self_test_results": "Clearing self-test results",
+            "notify_commissioning_complete": "Finishing commissioning",
+        }
+        for name, stage_name in stage_names.items():
+            task = self.tasks.get(name, {})
+            if task.get("status") != "running":
+                continue
+            if name == "interactive_self_test":
+                return self_test_progress(task.get("result", {}))
+            return stage_name
+        return self.details
+
     def snapshot(self) -> dict:
         return {
             "mac_address": self.mac_address,
             "operator": self.operator,
             "notes": self.notes,
             "status": self.status,
-            "details": self.details,
+            "details": self.progress_details(),
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
             "device": self.device.snapshot(),
@@ -277,6 +300,20 @@ async def prepare_session_sd_card(session: CommissioningSession) -> None:
         raise RuntimeError(
             f"SD card format failed ({details})."
         )
+    if payload.get("restart_required", False):
+        task.update(
+            {
+                "status": "running",
+                "details": "SD card formatted. Waiting for Leaf to restart and verify it...",
+            }
+        )
+        session.touch()
+        await asyncio.sleep(REBOOT_GRACE_SECONDS)
+        await wait_for_session_device(session)
+        await remount_session_sd_card(session)
+        task["details"] = "SD card formatted, Leaf restarted, and the card mounted successfully."
+        session.touch()
+        return
     if not payload.get("mounted", False):
         if payload.get("stage") == "temporary_unmount":
             raise RuntimeError(
@@ -434,6 +471,31 @@ def self_test_status(payload: dict) -> str | None:
     return None
 
 
+def self_test_progress(payload: dict) -> str:
+    results = payload.get("results") if isinstance(payload.get("results"), dict) else {}
+    test_names = {
+        "sd_card": "SD Card",
+        "baro": "Baro",
+        "imu": "IMU",
+        "gps_serial": "GPS Serial",
+        "ambient": "Ambient",
+        "display": "Display",
+        "power": "Power",
+        "vario": "Vario",
+        "buttons": "Buttons",
+        "speaker": "Speaker",
+        "gps_fix": "GPS Fix",
+    }
+    for name, display_name in test_names.items():
+        if str(results.get(name, "unknown")).lower() != "running":
+            continue
+        progress = f"Running self tests: {display_name}: Running"
+        if name == "gps_fix":
+            progress += f": {int(payload.get('gps_satellites', 0))} sats"
+        return progress
+    return "Running self tests"
+
+
 async def retrieve_session_self_test_details(session: CommissioningSession, base_url: str) -> str:
     self_test_details = await asyncio.to_thread(
         fetch_text,
@@ -447,11 +509,18 @@ async def retrieve_session_self_test_details(session: CommissioningSession, base
 
 
 async def notify_session_commissioning_complete(session: CommissioningSession) -> dict:
-    payload = await asyncio.to_thread(
-        fetch_json,
-        f"{device_base_url(session)}/commissioning/complete",
-        method="POST",
-    )
+    try:
+        payload = await asyncio.to_thread(
+            fetch_json,
+            f"{device_base_url(session)}/commissioning/complete",
+            method="POST",
+        )
+    except (OSError, URLError, TimeoutError):
+        # Leaf saves completion before replying. Reconcile that durable state if the reply is lost.
+        payload = await asyncio.to_thread(
+            fetch_json,
+            f"{device_base_url(session)}/commissioning/status",
+        )
     if not payload.get("commissioning_complete", False):
         raise RuntimeError("Device did not acknowledge commissioning completion.")
     return payload
@@ -708,6 +777,10 @@ async def run_commissioning_session(
                             f"Test details could not be retrieved: "
                             f"{type(details_exc).__name__}: {details_exc}"
                         )
+                    self_test_task["details"] += (
+                        "\n\nOne or more tests failed. Use Retry all self tests to run the "
+                        "verification sequence again."
+                    )
                     session.status = "failure"
                     session.details = "Verification tests failed."
                     return

--- a/factory_interface/src/factory_interface/templates/setup_session.html
+++ b/factory_interface/src/factory_interface/templates/setup_session.html
@@ -104,7 +104,7 @@
       <span>Verification tests</span>
       <div class="checklist-details-group" id="self-test-details-group" hidden>
         <div class="checklist-details verification-test-details" id="self-test-details"></div>
-        <button class="task-retry-button" id="retry-self-test" type="button" hidden>Restart self tests</button>
+        <button class="task-retry-button" id="retry-self-test" type="button" hidden>Retry all self tests</button>
       </div>
     </div>
 
@@ -246,7 +246,12 @@
         const item = document.createElement("span");
         const normalizedStatus = String(status || "unknown").toLowerCase();
         item.className = `verification-result verification-result-${normalizedStatus}`;
-        item.textContent = `${formatTestName(name)}: ${normalizedStatus}`;
+        let statusText = formatTestName(normalizedStatus);
+        if (name === "gps_fix" && normalizedStatus === "running") {
+          const satellites = Number(result.gps_satellites || 0);
+          statusText += `: ${satellites} sats`;
+        }
+        item.textContent = `${formatTestName(name)}: ${statusText}`;
         list.appendChild(item);
       });
       element.appendChild(list);

--- a/src/vario/comms/leaf_log_sync.cpp
+++ b/src/vario/comms/leaf_log_sync.cpp
@@ -43,6 +43,13 @@ void LeafLogSync::beginEligibilityScan() {
 }
 
 void LeafLogSync::update() {
+  if (massStorageSuppressedForChargingSession_) {
+    // Commissioning owns the card for diagnostics and test results. Keep this decision latched for
+    // the charging session so completing commissioning does not expose the drive mid-workflow.
+    sdcard.keepMassStorageEjected();
+    return;
+  }
+
   if (state_ == State::Idle) {
     if (sdcard.takeExplicitEject())
       beginSession(true);
@@ -226,6 +233,7 @@ void LeafLogSync::prepareForCharging() {
   powerOnReady_.store(false, std::memory_order_release);
   centerIntentStartedMs_ = 0;
   resumedAfterEject_ = false;
+  massStorageSuppressedForChargingSession_ = settings.commissioningPending;
   state_ = State::Idle;
 }
 
@@ -236,6 +244,7 @@ void LeafLogSync::prepareForOperating() {
   powerOnRequested_.store(false, std::memory_order_release);
   centerIntentStartedMs_ = 0;
   resumedAfterEject_ = false;
+  massStorageSuppressedForChargingSession_ = false;
   state_ = State::Idle;
 }
 

--- a/src/vario/comms/leaf_log_sync.h
+++ b/src/vario/comms/leaf_log_sync.h
@@ -60,6 +60,7 @@ class LeafLogSync {
   bool wifiAttemptStarted_ = false;
   bool timeStarted_ = false;
   bool resumedAfterEject_ = false;
+  bool massStorageSuppressedForChargingSession_ = false;
   bool sessionTotalKnown_ = false;
   uint16_t completedCount_ = 0;
   uint16_t sessionTotalCount_ = 0;

--- a/src/vario/comms/webserver.cpp
+++ b/src/vario/comms/webserver.cpp
@@ -23,6 +23,7 @@
 #include "diagnostics/memory_report.h"
 #include "diagnostics/self_test/selfTest.h"
 #include "etl/string_stream.h"
+#include "instruments/gps.h"
 #include "logbook/logbook_store.h"
 #include "navigation/gpx.h"
 #include "navigation/route_store.h"
@@ -472,7 +473,9 @@ namespace {
     json += interactive_self_test_pending ? "true" : "false";
     json += ",\"mode\":\"";
     json += selfTestModeName(last_self_test_mode);
-    json += "\",\"status\":\"";
+    json += "\",\"gps_satellites\":";
+    json += static_cast<unsigned int>(gps.fixInfo.numberOfSats);
+    json += ",\"status\":\"";
     json += interactive_self_test_pending ? "pending"
             : running                     ? "running"
                                           : selfTestStatusName(selfTest.results.allTests);
@@ -2449,13 +2452,16 @@ load();
     clearSelfTestDetailsFiles(target);
   }
 
-  String sdCardFormatResultJson(const SDCard::FormatResult& result, bool labelSet) {
+  String sdCardFormatResultJson(const SDCard::FormatResult& result, bool labelSet,
+                                bool restartRequired = false) {
     String json = "{\"formatted\":";
     json += result.formatted ? "true" : "false";
     json += ",\"mounted\":";
     json += result.mounted ? "true" : "false";
     json += ",\"label_set\":";
     json += labelSet ? "true" : "false";
+    json += ",\"restart_required\":";
+    json += restartRequired ? "true" : "false";
     json += ",\"stage\":\"";
     json += result.stage;
     json += "\",\"mount_attempts\":";
@@ -2481,9 +2487,18 @@ load();
       return;
     }
 
-    const SDCard::FormatResult result = sdcard.formatDetailed();
+    // Commissioning verifies the filesystem after a clean restart, avoiding the fragile and slow
+    // in-process remount path.
+    const SDCard::FormatResult result = sdcard.formatDetailed(false);
     const bool labelSet = result.mounted && sdcard.setLabel();
-    target.send(200, "application/json", sdCardFormatResultJson(result, labelSet));
+    const bool restartRequired = result.formatted;
+    target.send(200, "application/json", sdCardFormatResultJson(result, labelSet, restartRequired));
+    if (restartRequired) {
+      // A clean boot is the reliable ownership/mount boundary after formatting. Send the result
+      // first so the factory tool can immediately wait for reconnect and verify the card.
+      delay(250);
+      ESP.restart();
+    }
   }
 
   void remountCommissioningSdCard(WebServer& target) {
@@ -2507,13 +2522,40 @@ load();
     ESP.restart();
   }
 
+  void sendCommissioningStatus(WebServer& target) {
+    if (!connectedToDiagnosticWifi()) {
+      target.send(403, "application/json",
+                  "{\"detail\":\"Commissioning status is only available on the "
+                  "LeafDiagnostics network.\"}");
+      return;
+    }
+
+    String json = "{\"commissioning_complete\":";
+    json += settings.commissioningComplete ? "true" : "false";
+    json += ",\"commissioning_pending\":";
+    json += settings.commissioningPending ? "true" : "false";
+    json += "}";
+    target.send(200, "application/json", json);
+  }
+
   void markCommissioningComplete(WebServer& target) {
-    if (!requireCommissioningHttp(target)) return;
+    if (!connectedToDiagnosticWifi()) {
+      target.send(403, "application/json",
+                  "{\"detail\":\"Commissioning endpoints are only available on the "
+                  "LeafDiagnostics network.\"}");
+      return;
+    }
+
+    // A lost HTTP response must be recoverable after the durable completion flag disables the
+    // other commissioning endpoints.
+    if (settings.commissioningComplete) {
+      sendCommissioningStatus(target);
+      return;
+    }
 
     settings.markCommissioningComplete();
     selfTest.confirmCommissioningComplete();
-    target.send(200, "application/json",
-                "{\"commissioning_complete\":true,\"commissioning_pending\":false}");
+    sendCommissioningStatus(target);
   }
 
   void configureCommissioningRoutes() {
@@ -2537,6 +2579,8 @@ load();
     user_server.on("/sd-card/remount", HTTP_POST,
                    []() { remountCommissioningSdCard(user_server); });
     user_server.on("/restart", HTTP_POST, []() { restartCommissioningDevice(user_server); });
+    user_server.on("/commissioning/status", HTTP_GET,
+                   []() { sendCommissioningStatus(user_server); });
     user_server.on("/commissioning/complete", HTTP_POST,
                    []() { markCommissioningComplete(user_server); });
 
@@ -2562,6 +2606,8 @@ load();
                    []() { clearCommissioningSelfTestResults(user_server); });
     user_server.on("/api/debug/self-test", HTTP_GET,
                    []() { sendCommissioningSelfTest(user_server); });
+    user_server.on("/api/debug/commissioning/status", HTTP_GET,
+                   []() { sendCommissioningStatus(user_server); });
     user_server.on("/api/debug/commissioning/complete", HTTP_POST,
                    []() { markCommissioningComplete(user_server); });
 

--- a/src/vario/diagnostics/self_test/selfTest.cpp
+++ b/src/vario/diagnostics/self_test/selfTest.cpp
@@ -40,6 +40,7 @@ uint32_t gpsFixStartMillis = 0;
 uint32_t gpsFixRemainingSeconds = GPS_FIX_TEST_TIMEOUT_MS / 1000;
 uint32_t gpsFixLastDisplayUpdateMillis = 0;
 bool gpsFixTestCancelled = false;
+bool varioMutedUntilRestart = false;
 SelfTest_PageGPSFix selfTest_pageGPSFix{&gpsFixRemainingSeconds, &gpsFixTestCancelled};
 
 bool waitForVarioStartButton = false;
@@ -332,6 +333,8 @@ SelfTest::Status SelfTest::testGPSfix() {
     gpsFixStartMillis = millisNow;
     gpsFixLastDisplayUpdateMillis = 0;
     gpsFixRemainingSeconds = GPS_FIX_TEST_TIMEOUT_MS / 1000;
+    speaker.setVolume(Speaker::SoundChannel::Vario, SpeakerVolume::Off);
+    varioMutedUntilRestart = true;
     selfTest_pageGPSFix.show();
     display.update();
   }
@@ -645,7 +648,9 @@ SelfTest::Status SpeakerInteractiveTest::update() {
     Serial.println("* SELF TEST * SPEAKER * Test complete");
 
     // return volume to user setting and cancel any sounds playing
-    speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)settings.vario_volume);
+    if (!varioMutedUntilRestart) {
+      speaker.setVolume(Speaker::SoundChannel::Vario, (SpeakerVolume)settings.vario_volume);
+    }
     speaker.setVolume(Speaker::SoundChannel::FX, (SpeakerVolume)settings.system_volume);
     speaker.playSound(fx::silence);
 
@@ -699,6 +704,9 @@ SelfTest_PageCommissioningConfirmation selfTest_pageCommissioningConfirmation;
 bool SelfTest::update() {
   bool updateNeeded = true;  // assume we'll need to call this again
   if (status == Status::Running) {
+    // Keep user-configured Auto-Off from interrupting long commissioning tests. This does not
+    // disable low-battery or other safety shutdown behavior.
+    power.resetAutoOffCounter();
     if (statusAutoTests == Status::Running || statusAutoTests == Status::Unknown) {
       statusAutoTests = runAutoTests(false);  // false = keep file open
     } else if (statusInteractiveTests == Status::Running ||

--- a/src/vario/power.cpp
+++ b/src/vario/power.cpp
@@ -164,7 +164,12 @@ void Power::initPeripherals() {
   // The SD LUN starts absent in every power state. Charging mode runs Leaf Log first and explicitly
   // presents the card; operating mode retains exclusive firmware ownership.
   sdcard.init(true);
-  if (info_.onState == PowerState::On) leaf_usb::disconnect();
+  if (info_.onState == PowerState::On) {
+    leafLogSync.prepareForOperating();
+    leaf_usb::disconnect();
+  } else {
+    leafLogSync.prepareForCharging();
+  }
   heap_monitor::checkpoint("periph-sd");
   Serial.println(" - Finished SDcard");
   lc86g.init();

--- a/src/vario/storage/sd_card.cpp
+++ b/src/vario/storage/sd_card.cpp
@@ -1,5 +1,7 @@
 #include "storage/sd_card.h"
 
+#include <cstring>
+
 #include <Arduino.h>
 #include <FS.h>
 #include <SD_MMC.h>
@@ -450,7 +452,7 @@ bool SDCard::format() {
   return result.formatted && result.mounted;
 }
 
-SDCard::FormatResult SDCard::formatDetailed() {
+SDCard::FormatResult SDCard::formatDetailed(bool remount) {
   FormatResult result;
   if (!isCardPresent()) {
     if (DEBUG_SDCARD) Serial.println("SDcard Format Failed: no card present");
@@ -480,13 +482,23 @@ SDCard::FormatResult SDCard::formatDetailed() {
   if (DEBUG_SDCARD) Serial.println("Formatting SDcard");
 
   if (!formatUnmounted(result.error, result.stage)) {
-    // The format may have failed before changing the card. Attempt to restore normal access.
+    // Formatting is already complete if only the temporary formatter mount failed to unmount.
+    // Preserve that fact so commissioning can reboot and verify instead of formatting twice.
+    result.formatted = strcmp(result.stage, "temporary_unmount") == 0;
+    if (result.formatted && !remount) return result;
+    // Attempt to restore normal access. Commissioning will reboot after a completed format even
+    // when this in-process remount succeeds.
     mounted_ = mountWithRetries(result.mountAttempts);
     result.mounted = mounted_;
     return result;
   }
 
   result.formatted = true;
+  if (!remount) {
+    result.stage = "restart";
+    result.error = ESP_OK;
+    return result;
+  }
   result.stage = "remount";
   mounted_ = mountWithRetries(result.mountAttempts);
   result.mounted = mounted_;

--- a/src/vario/storage/sd_card.h
+++ b/src/vario/storage/sd_card.h
@@ -30,7 +30,7 @@ class SDCard {
   bool mount();
   void unmount();
   bool format();
-  FormatResult formatDetailed();
+  FormatResult formatDetailed(bool remount = true);
   FormatResult remountAfterFormat();
   bool setLabel();
   bool isMounted() { return mounted_; }

--- a/src/vario/ui/settings/settings.h
+++ b/src/vario/ui/settings/settings.h
@@ -59,7 +59,7 @@
 // This allows us to cover all time zones, including the :30 minute and :15 minute ones
 #define DEF_TIME_ZONE -420    // -420 min = UTC -7 hrs (PDT)
 #define DEF_VOLUME_SYSTEM 2   // 0=off, 1=low, 2=med, 3=high
-#define DEF_AUTO_OFF 10       // 0 = DISABLE, or 1, 5 10, 15, 30, 45, 60 minutes
+#define DEF_AUTO_OFF 15       // 0 = DISABLE, or 1, 5, 10, 15, 30, 45, 60 minutes
 #define AUTO_OFF_MAX 60       // max auto-off time in minutes (1 hour)
 #define DEF_WIFI_ON 0         // default wifi off
 #define DEF_BLUETOOTH_ON 0    // default bluetooth off


### PR DESCRIPTION
## Summary

Improves factory commissioning reliability and operator visibility.

- Automatically restarts Leaf after successful SD formatting, reconnects over Wi-Fi, and verifies the card mounted correctly.
- Avoids unreliable in-process remounting and unnecessary repeat formats.
- Keeps USB mass storage hidden while commissioning is pending, preventing host-generated files and drive popups.
- Restores normal mass-storage behavior after successful commissioning and the next USB boot.
- Adds a retry-all option after failed self-tests.
- Prevents Auto-Off during self-tests and changes the default from 10 to 15 minutes.
- Mutes vario audio during the GPS fix test until reboot while preserving system sounds and saved volume settings.
- Reports the live GPS satellite count in the unit and multi-unit commissioning views.
- Shows the current commissioning stage on summary pages.
- Makes final commissioning completion idempotent and verifies saved device state if the HTTP acknowledgment is lost.

## Testing

- Successfully commissioned a physical Leaf.
- Confirmed quick automatic restart and SD mount verification after formatting.
- Confirmed USB mass storage remains hidden during pending/failed commissioning.
- Confirmed mass storage returns after successful commissioning and a subsequent USB boot.
- Confirmed vario audio is muted during the GPS test.
- Confirmed live GPS satellite count appears in the factory interface.
- Confirmed final commissioning completion succeeds.
- Ran factory-interface Python compilation and application import smoke tests.
- Formatted firmware sources.
- Successfully built the `leaf_3_2_6_release` PlatformIO environment.

## Notes

- Failed or incomplete units intentionally remain in commissioning mode, so USB mass storage stays hidden until they pass commissioning.
- The default Auto-Off change affects new/default settings; existing saved user settings remain unchanged.